### PR TITLE
Name lookup pages

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -345,13 +345,8 @@ const utilsNetwork = {
             let overflow = 0
             if (r.hits.length < r.count){
               // It looks like the count is 1 more than the number of hits, why?
-              overflow = (r.count - r.hits.length) - 1
+              overflow = (r.count - r.hits.length)
             }
-
-            console.log("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-            console.log(overflow)
-            console.log("Count: ", r.count)
-            console.log("Hits: ", r.hits.length)
 
             if (searchPayload.processor == 'lcAuthorities'){
                 // process the results as a LC suggest service

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -294,6 +294,10 @@ const utilsNetwork = {
         let returnUrls = useConfigStore().returnUrls
 
         let urlTemplate = searchPayload.url
+
+        console.log("######################################")
+        console.log("url ", urlTemplate)
+
         if (!Array.isArray(urlTemplate)){
             urlTemplate=[urlTemplate]
         }
@@ -335,6 +339,20 @@ const utilsNetwork = {
 
 
             let r = await this.fetchSimpleLookup(url)
+
+            //Config only allows 25 results, this will add something to the results
+            // to let the user know there are more names.
+            let overflow = 0
+            if (r.hits.length < r.count){
+              // It looks like the count is 1 more than the number of hits, why?
+              overflow = (r.count - r.hits.length) - 1
+            }
+
+            console.log("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+            console.log(overflow)
+            console.log("Count: ", r.count)
+            console.log("Hits: ", r.hits.length)
+
             if (searchPayload.processor == 'lcAuthorities'){
                 // process the results as a LC suggest service
                 // console.log("URL",url)
@@ -349,7 +367,8 @@ const utilsNetwork = {
                     uri: hit.uri,
                     literal:false,
                     depreciated: false,
-                    extra: ''
+                    extra: '',
+                    total: r.count
                   }
 
                   if (hitAdd.label=='' && hitAdd.suggestLabel.includes('DEPRECATED')){

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -226,13 +226,13 @@ export const useConfigStore = defineStore('config', {
       "processor" : 'lcAuthorities',
       "modes":[
         {
-          'NAF All':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25", "all":true},
-          'NAF Personal Names':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=25"},
-          'NAF Corporate Name':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25"},
-          'NAF Name/Title':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=NameTitle&count=25"},
-          'NAF Title':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Title&count=25"},
-          'NAF Geographic':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&count=25"},
-          'NAF Conference Name':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25"}
+          'NAF All':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
+          'NAF Personal Names':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=25&offset=<OFFSET>"},
+          'NAF Corporate Name':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25&offset=<OFFSET>"},
+          'NAF Name/Title':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=NameTitle&count=25&offset=<OFFSET>"},
+          'NAF Title':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Title&count=25&offset=<OFFSET>"},
+          'NAF Geographic':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
+          'NAF Conference Name':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25&offset=<OFFSET>"}
         }
       ]
     },
@@ -243,13 +243,13 @@ export const useConfigStore = defineStore('config', {
       "processor" : 'lcAuthorities',
       "modes":[
         {
-          'NAF All':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25", "all":true},
-          'NAF Personal Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=25"},
-          'NAF Corporate Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25"},
-          'NAF Name/Title':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=NameTitle&count=25"},
-          'NAF Title':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Title&count=25"},
-          'NAF Geographic':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&count=25"},
-          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25"}
+          'NAF All':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
+          'NAF Personal Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=25&offset=<OFFSET>"},
+          'NAF Corporate Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25&offset=<OFFSET>"},
+          'NAF Name/Title':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=NameTitle&count=25&offset=<OFFSET>"},
+          'NAF Title':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Title&count=25&offset=<OFFSET>"},
+          'NAF Geographic':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
+          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25&offset=<OFFSET>"}
         }
       ]
 


### PR DESCRIPTION
Adds pagination to complex lookups.

![image](https://github.com/user-attachments/assets/58a026bc-75f6-4102-8a79-20173b558925)

The image is for names, but it should work for everything. The buttons are first, previous, next, last.

There's some strangeness to it, but this is down to how the suggest service counts the number of results. It doesn't really count the number of results that can be sent to the user, but the number of results from a previous search. Also one page might have 17 entries and the next will have 22. The page buttons will appear on on search results when there aren't really other pages. This too is because of the numbering ID is doing, but not doing well, or at least well for this kind of functionality. The buttons get added when the `total number of results / 25 > 0` but some times/often the that number is higher than the number of possible results. I don't have a good solution for this in Marva or ID. You can see this if you search "act" under genre. There are only 13 results but the count is 28 -- https://id.loc.gov/authorities/genreForms/suggest2/?q=act&count=50.