### PR TITLE
[LCAP-3436] Fix issue not being able to retrieve LCCNs starting with letters

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2300,11 +2300,20 @@ const utilsNetwork = {
     * @return {array} - An array of {@link lccnSearchResult} results
     */
     searchInstanceByLCCN: async function(lccn){
-
       lccn = lccn.replaceAll(' ','')
+
+      // ID needs the lccn to have a space between letters and the numbers
+      // If there isn't one, make the adjustment
+      const re = /^[a-z]{2}/g          // not sure if it's only every 2 characters
+      const found = lccn.match(re)
+      if (found != null){
+        lccn = lccn.slice(0,2) + " " + lccn.slice(2)
+      }
+
       try{
         let req = await fetch(useConfigStore().returnUrls.id + `resources/instances/suggest2?q=${lccn}&searchtype=keyword` )
         let results = await req.json()
+
         let returnVal = []
 
         for (let r of results.hits){

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -6,12 +6,12 @@
       <Nav/>
     </pane>
 
-    <pane> 
+    <pane>
 
       <splitpanes>
 
 
-        
+
         <pane class="load" v-if="displayAllRecords">
           <button @click="displayAllRecords=false;displayDashboard=true">Close</button>
           <div id="all-records-table">
@@ -21,7 +21,7 @@
 
               <template #tbody="{row}">
 
-                
+
                 <td>
                   <router-link :to="{ name: 'Edit', params: { recordId: row.Id }}">
                     {{ row.Id }}
@@ -33,9 +33,9 @@
                 <td v-text="row.Status"/>
                 <td>
                   <div v-for="u in row.Urls">
-                    <a v-if="u.indexOf('/works/') >-1" :href="u" target="_blank">Work</a> 
-                    <a v-else-if="u.indexOf('/instances/') >-1" :href="u" target="_blank">Instance</a> 
-                    <a v-else :href="u" target="_blank">{{ u }}</a> 
+                    <a v-if="u.indexOf('/works/') >-1" :href="u" target="_blank">Work</a>
+                    <a v-else-if="u.indexOf('/instances/') >-1" :href="u" target="_blank">Instance</a>
+                    <a v-else :href="u" target="_blank">{{ u }}</a>
 
                   </div>
 
@@ -46,19 +46,19 @@
               </template>
 
             </DataTable>
-            
+
           </div>
 
-          
+
 
         </pane>
 
         <pane class="load" v-if="displayDashboard">
-          
-          
+
+
 
           <div class="load-columns">
-            
+
             <div class="load-test-data-column">
               <h1>
                 <span style="font-size: 1.15em; vertical-align: bottom; margin-right: 5px;" class="material-icons">cloud_download</span>
@@ -82,22 +82,22 @@
 
                     <li v-for="(r,idx) in searchByLccnResults" :key="r.idURL">
                         <div style="display:flex">
-                          
+
                             <div style="flex:2;">{{++idx}}. <span style="font-weight:bold">{{r.label}}</span></div>
                             <div style="flex:1">
                               <a :href="r.bfdbURL" style="padding-right: 10px;" target="_blank">View on BFDB</a>
                               <label :for="'lccnsearch'+idx">Select</label><input type="radio" v-model="lccnLoadSelected" :value="r" name="lccnToLoad" :id="'lccnsearch'+idx" :name="'lccnsearch'+idx"/>
                             </div>
-                            
+
                           <!-- <div style="flex:1"><a href="#" target="_blank" @click.prevent="instanceEditorLink = r.bfdbPackageURL; testInstance()">Retrieve</a></div> -->
 
                         </div>
-                      </li>   
+                      </li>
 
-        
-                      
-                    
-                    
+
+
+
+
                   </template>
 
 
@@ -108,15 +108,15 @@
 
               <h3>Load with profile:</h3>
 
-              <div class="load-buttons"> 
+              <div class="load-buttons">
                 <button class="load-button" @click="loadUrl(s.instance)" :disabled="(urlToLoadIsHttp || lccnLoadSelected ) ? false : true"  v-for="s in startingPointsFiltered">{{s.name}}</button>
 
-                
+
               </div>
               <hr>
 
 
-              
+
               <h2>Test Data:</h2>
               <table id="test-data-table">
                   <tr class="test-data" v-for="t in testData">
@@ -133,11 +133,11 @@
             </div>
 
             <div>
-              
+
               <h1>
                 <span style="font-size: 1.25em; vertical-align: bottom; margin-right: 3px;"  class="material-icons">edit_note</span>
-                <span>Your Records</span></h1>     
-                <a href="#" @click="loadAllRecords" style="color: inherit;">Show All Records</a>                         
+                <span>Your Records</span></h1>
+                <a href="#" @click="loadAllRecords" style="color: inherit;">Show All Records</a>
                 <div>
 
                   <div class="saved-records-empty" v-if="continueRecords.length==0">
@@ -171,12 +171,12 @@
 
               <h1 style="margin-bottom: 10px;">
                 <span style="font-size: 1.25em; vertical-align: bottom; margin-right: 3px;"  class="material-icons">edit_document</span>
-                <span>Create Blank Record</span></h1>                
+                <span>Create Blank Record</span></h1>
                 <div>
-                  <div class="load-buttons"> 
+                  <div class="load-buttons">
                     <button class="load-button" @click="loadUrl(s.instance)" v-for="s in startingPointsFiltered">{{s.name}}</button>
 
-                    
+
                   </div>
                 </div>
 
@@ -184,12 +184,12 @@
 
             </div>
 
-          </div> 
-          
+          </div>
+
 
 
         </pane>
-     
+
 
 
       </splitpanes>
@@ -242,7 +242,7 @@
         continueRecords: [],
 
         urlToLoadIsHttp: false,
-        
+
         searchByLccnResults: null,
         lccnToSearchTimeout: null,
 
@@ -257,7 +257,7 @@
 
 
       }
-    },    
+    },
     computed: {
       // other computed properties
       // ...
@@ -298,7 +298,7 @@
 
         console.log(row)
 
-      },  
+      },
 
       loadAllRecords: async function(event){
         event.preventDefault()
@@ -333,13 +333,13 @@
 
 
         this.isLoadingAllRecords=false
-      },  
+      },
 
       returnTimeAgo: function(timestamp){
         console.log(timestamp, timestamp*1000,Date.now())
         return timeAgo.format(timestamp*1000)
       },
-      
+
 
       returnPixleAsPercent: function(pixles){
         return pixles/window.innerHeight*100
@@ -361,7 +361,6 @@
       },
 
       loadSearch: function(){
-
         this.lccnLoadSelected = null
 
         if (this.urlToLoad.startsWith("http://") || this.urlToLoad.startsWith("https://")){
@@ -421,8 +420,8 @@
           if (this.profiles[key].rtOrder.indexOf(useInstanceProfile)>-1){
             useProfile = JSON.parse(JSON.stringify(this.profiles[key]))
           }
-        }       
-        
+        }
+
         if (useProfile===null){
           alert('Cannot find profile.')
           return false
@@ -431,9 +430,9 @@
         if (this.urlToLoad.trim() !== ''){
 
 
-          
+
           // we might need to load in a item
-          if (utilsParse.hasItem>0){ 
+          if (utilsParse.hasItem>0){
             // loop the number of ITEMS there are in the XML
             Array.from(Array(utilsParse.hasItem)).map((_,i) => {
               let useItemRtLabel
@@ -444,7 +443,7 @@
               for (let pkey in this.profiles){
                 for (let rtkey in this.profiles[pkey].rt){
                   if (rtkey == useItemRtLabel){
-                    let useRtLabel =  useItemRtLabel + '-' + (i+1) 
+                    let useRtLabel =  useItemRtLabel + '-' + (i+1)
                     let useItem = JSON.parse(JSON.stringify(this.profiles[pkey].rt[rtkey]))
 
                     // make the guids for all the properties unique
@@ -456,8 +455,8 @@
                     // console.log('using',this.profiles[pkey].rt[rtkey])
                     foundCorrectItemProfile = true
                     useProfile.rtOrder.push(useRtLabel)
-                    useProfile.rt[useRtLabel] = useItem     
-                    // console.log(JSON.parse(JSON.stringify(useProfile)))           
+                    useProfile.rt[useRtLabel] = useItem
+                    // console.log(JSON.parse(JSON.stringify(useProfile)))
                   }
                 }
               }
@@ -482,7 +481,7 @@
         // also give it an ID for storage
         if (!useProfile.eId){
           let uuid = 'e' + decimalTranslator.new()
-          uuid = uuid.substring(0,8)        
+          uuid = uuid.substring(0,8)
           useProfile.eId= uuid
         }
 
@@ -495,7 +494,7 @@
           useProfile.status = 'unposted'
         }
 
-        
+
 
 
         if (this.urlToLoad.trim() !== ''){
@@ -508,18 +507,18 @@
 
           this.activeProfile = useProfile
         }
-        
+
         console.log("this.activeProfile",this.activeProfile)
 
         if (multiTestFlag){
-          this.$router.push(`/multiedit/`)          
+          this.$router.push(`/multiedit/`)
           return true
         }
 
         this.$router.push(`/edit/${useProfile.eId}`)
 
 
-        
+
       },
 
 
@@ -532,8 +531,8 @@
 
     },
     created: async function(){
-      
-      
+
+
 
       let records = await utilsNetwork.searchSavedRecords(this.preferenceStore.returnUserNameForSaving)
       console.log(records)
@@ -565,7 +564,7 @@
           }
 
 
-          
+
           // if (this.$router.currentRoute && this.$router.currentRoute.query && this.$router.currentRoute.query.url){
           //   let url = this.$router.currentRoute.query.url
           //   if (this.$router.currentRoute && this.$router.currentRoute.query && this.$router.currentRoute.query.action && this.$router.currentRoute.query.action == 'loadwork'){
@@ -580,13 +579,13 @@
           // }
         },500)
 
-      
+
     }
   }
 
 </script>
 
-<style scoped>  
+<style scoped>
 #test-data-table{
   width:100%;
 }
@@ -605,7 +604,7 @@
 .test-data a{
   color:inherit!important;
   text-decoration: none;
-  
+
 }
 .test-data a:hover{
   text-decoration: underline;
@@ -658,7 +657,7 @@ label{
 
   .continue-record-list li:nth-of-type(1n+100) {
     display: none;
-  } 
+  }
 
   .continue-record-title{
     font-style: italic;
@@ -728,9 +727,9 @@ label{
   }
   .header{
     background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-nav-background-color')") !important;
-    
+
   }
-  
+
 
 
 


### PR DESCRIPTION
Jira ticket: https://staff.loc.gov/tasks/browse/LCAP-3436

Cause: ID requires that the LCCN matches what is in the `index:lccn` value. These are given as `sn 85066387`. If you take out the space, there's no longer anything to match on. The letters aren't needed because it will still match on the numbers.

This update checks if the lccn begins with 2 letters. if it does, it will make sure that there is a space between the letters and the numbers.