### PR TITLE
Lcap 3364 remove has item

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -59,7 +59,7 @@
 
 
                     <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false ">
-                      <div class="component-label test" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
+                      <div class="component-label" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                         <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
 
 

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -1,7 +1,7 @@
 <template>
 
-  <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true"> 
-      
+  <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true">
+
       <div style="text-align: right;">
         <button @click="userActiveResourceName = profileName" v-for="profileName in this.activeProfile.rtOrder" :class="{'activeResourceButton': (activeResourceName === profileName)}">
           {{profileName.split(':').slice(-1)[0]}}
@@ -10,8 +10,8 @@
 
   </template>
 
-  <div 
-    v-for="profileName in this.activeProfile.rtOrder" 
+  <div
+    v-for="profileName in this.activeProfile.rtOrder"
     :key="profileName"
     :class="{'edit-panel-work': (profileName.split(':').slice(-1)[0] == 'Work'), 'edit-panel-scroll-x-parent': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x')}">
 
@@ -20,20 +20,20 @@
 
         <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
 
-          <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" 
+          <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
               :key="profileCompoent">
 
 
-            <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false"> 
+            <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
 
               <div class="component-label" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}</div>
-              
-              <Main       
-                :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" 
+
+              <Main
+                :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']"
                 :level="0"
                 :id="activeProfile.rt[profileName].pt[profileCompoent].id"
                 :parentId="activeProfile.rt[profileName].pt[profileCompoent].parentId"
-                :readOnly="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"/>   
+                :readOnly="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"/>
 
             </template>
 
@@ -42,27 +42,27 @@
 
       </template>
       <template v-if="instanceMode == false">
-        
+
         <template v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" :key="profileCompoent">
 
           <template v-if="!hideProps.includes(activeProfile.rt[profileName].pt[profileCompoent].propertyURI)">
-          
-            <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false"> 
+
+            <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
 
               <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
 
                 <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
 
-                 
+
                   <div :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
 
 
 
                     <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false ">
-                      <div class="component-label" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
+                      <div class="component-label test" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                         <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
-                        
-                        
+
+
                       </div>
                     </template>
 
@@ -70,24 +70,24 @@
                       <div v-if="profileName.split(':').slice(-1)[0] == 'Work'" class="inline-mode-resource-color-work">&nbsp;</div>
                       <div v-if="profileName.indexOf(':Instance') > -1" class="inline-mode-resource-color-instance">&nbsp;</div>
                       <button @mouseenter="inlineRowButtonMouseEnter" :class="{'inline-mode-mian-button': true, 'inline-mode-mian-button-has-ref' : profileStore.ptHasRefComponent(activeProfile.rt[profileName].pt[profileCompoent]) }"></button>
-                      
-                      
+
+
                     </template>
 
 
-                    <Main       
-                      :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" 
+                    <Main
+                      :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']"
                       :level="0"
                       :id="activeProfile.rt[profileName].pt[profileCompoent].id"
                       :parentId="activeProfile.rt[profileName].pt[profileCompoent].parentId"
-                      :readOnly="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"/>   
+                      :readOnly="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"/>
 
-                
+
 
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')">
-                          <InlineModeAddField :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />  
+                          <InlineModeAddField :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
                         </template>
-                        
+
                     </div>
                   </template>
                 </template>
@@ -142,9 +142,9 @@
           'http://id.loc.gov/ontologies/bibframe/instanceOf',
           'http://id.loc.gov/ontologies/bibframe/hasItem'
         ]
-        
+
       }
-    },    
+    },
     computed: {
       // other computed properties
       // ...
@@ -153,7 +153,7 @@
 
 
       ...mapState(usePreferenceStore, ['styleDefault']),
-      
+
       // gives read access to this.count and this.double
       // ...mapState(usePreferenceStore, ['profilesLoaded']),
       ...mapState(useProfileStore, ['profilesLoaded','activeProfile','activeComponent']),
@@ -179,8 +179,8 @@
 
         showDebug: function(event,data){
 
-          
-          this.debugModalData= this.profileStore.returnStructureByComponentGuid(data['@guid']); 
+
+          this.debugModalData= this.profileStore.returnStructureByComponentGuid(data['@guid']);
           this.showDebugModal=true
 
           event.preventDefault()
@@ -220,7 +220,7 @@
 
       activeComponent(newVal){
 
-        
+
 
             this.$nextTick(() => {
               window.setTimeout(()=> {
@@ -240,7 +240,7 @@
                 },500);
 
 
-              },10);             
+              },10);
             });
 
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -12,8 +12,8 @@
     data() {
       return {
         hideProps:[
-          'http://id.loc.gov/ontologies/bibframe/hasInstance',
-          'http://id.loc.gov/ontologies/bibframe/instanceOf',
+          //'http://id.loc.gov/ontologies/bibframe/hasInstance',
+          //'http://id.loc.gov/ontologies/bibframe/instanceOf',
           'http://id.loc.gov/ontologies/bibframe/hasItem'
         ]
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -127,7 +127,7 @@
                             <template #item="{element}">
                               <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI)">
                                 <li @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-li sidebar-property-li-empty">
-                                  <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-ul-alink test">
+                                  <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
                                       {{activeProfile.rt[profileName].pt[element].propertyLabel}}
                                   </a>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -11,7 +11,12 @@
   export default {
     data() {
       return {
-        
+        hideProps:[
+          'http://id.loc.gov/ontologies/bibframe/hasInstance',
+          'http://id.loc.gov/ontologies/bibframe/instanceOf',
+          'http://id.loc.gov/ontologies/bibframe/hasItem'
+        ]
+
       }
     },
     components: {
@@ -47,7 +52,7 @@
                   titles.push(this.rtLookup[t].resourceLabel)
               }
           }
-          
+
           return titles
 
 
@@ -58,7 +63,7 @@
     },
 
     mounted() {
-     
+
 
 
     }
@@ -71,7 +76,7 @@
 <template>
 
   <template  v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-accordion') == true">
-    
+
 
     <AccordionList  :open-multiple-items="false">
 
@@ -82,7 +87,7 @@
         <template v-if="activeProfile.rt[profileName].noData != true">
                 <AccordionItem style="color: white;" :id="'accordion_'+profileName" default-closed>
                   <template #summary>
-                            
+
                     <div :class="{'container-type-icon': true }">
                             <svg v-if="profileName.split(':').slice(-1)[0] == 'Work'" width="1.5em" height="1.1em" version="1.1" xmlns="http://www.w3.org/2000/svg">
                               <circle :fill="preferenceStore.returnValue('--c-general-icon-work-color')" cx="0.55em" cy="0.6em" r="0.45em"/>
@@ -95,7 +100,7 @@
                             </svg>
                             <svg  v-if="profileName.endsWith(':Hub')" version="1.1" viewBox="0 -20 100 100" xmlns="http://www.w3.org/2000/svg">
                               <path fill="royalblue" d="m62.113 24.66 1.9023-15.238 18.875 32.691-7.5469 20.004 15.238 1.9023-32.691 18.875-20.004-7.5469-1.9023 15.238-18.875-32.691 7.5469-20.004-15.238-1.9023 32.691-18.875zm-17.684 15.695-4.0781 15.215 15.215 4.0781 4.0781-15.215z" fill-rule="evenodd"/>
-                            </svg>                        
+                            </svg>
                             <span class="sidebar-header-text" v-if="profileName.split(':').slice(-1)[0] == 'Work'">{{$t("message.wordWork")}}</span>
                             <span class="sidebar-header-text" v-if="profileName.split(':').slice(-1)[0].indexOf('Instance') > -1">
                               <template v-if="activeProfile.rt[profileName]['@type'] && activeProfile.rt[profileName]['@type'] == 'http://id.loc.gov/ontologies/bflc/SecondaryInstance'">Secondary</template>
@@ -113,16 +118,16 @@
 
 
 
-                          <draggable 
-                            v-model="activeProfile.rt[profileName].ptOrder" 
-                            group="people" 
-                            @start="drag=true" 
-                            @end="drag=false" 
+                          <draggable
+                            v-model="activeProfile.rt[profileName].ptOrder"
+                            group="people"
+                            @start="drag=true"
+                            @end="drag=false"
                             item-key="id">
                             <template #item="{element}">
-                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted">
+                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI)">
                                 <li @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-li sidebar-property-li-empty">
-                                  <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-ul-alink">
+                                  <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-ul-alink test">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
                                       {{activeProfile.rt[profileName].pt[element].propertyLabel}}
                                   </a>
@@ -133,8 +138,8 @@
                                               <a tabindex="-1" href="#" class="sidebar-property-ul-alink sidebar-property-ul-alink-sublink" >{{t}}</a>
                                             </li>
                                         </ul>
-                                    </template>              
-                                  </template>                               
+                                    </template>
+                                  </template>
                                 </li>
                               </template>
                              </template>
@@ -144,7 +149,7 @@
 
 
 
-<!-- 
+<!--
 
                           <li v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" @click.stop="activeComponent = activeProfile.rt[profileName].pt[profileCompoent]" :key="profileCompoent" class="sidebar-property-li sidebar-property-li-empty" >
                                 <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[profileCompoent]" class="sidebar-property-ul-alink">
@@ -158,7 +163,7 @@
                                             <a tabindex="-1" href="#" class="sidebar-property-ul-alink sidebar-property-ul-alink-sublink" >{{t}}</a>
                                           </li>
                                       </ul>
-                                  </template>              
+                                  </template>
                                 </template>
                         </li> -->
 
@@ -167,7 +172,7 @@
                     </ul>
 
 
-                  
+
                 </AccordionItem>
 
 
@@ -184,7 +189,7 @@
 
   </template>
   <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-accordion') == false">
-      
+
     <div v-for="profileName in activeProfile.rtOrder" class="sidebar" :key="profileName">
 
       <div v-if="activeProfile.rt[profileName].noData != true">
@@ -200,7 +205,7 @@
                   </svg>
                   <svg  v-if="profileName.endsWith(':Hub')" version="1.1" viewBox="0 -20 100 100" xmlns="http://www.w3.org/2000/svg">
                     <path fill="royalblue" d="m62.113 24.66 1.9023-15.238 18.875 32.691-7.5469 20.004 15.238 1.9023-32.691 18.875-20.004-7.5469-1.9023 15.238-18.875-32.691 7.5469-20.004-15.238-1.9023 32.691-18.875zm-17.684 15.695-4.0781 15.215 15.215 4.0781 4.0781-15.215z" fill-rule="evenodd"/>
-                  </svg>                        
+                  </svg>
                   <span class="sidebar-header-text" v-if="profileName.split(':').slice(-1)[0] == 'Work'">{{$t("message.wordWork")}}</span>
                   <span class="sidebar-header-text" v-if="profileName.split(':').slice(-1)[0] == 'Instance'">{{$t("message.wordInstance")}}</span>
                   <span class="sidebar-header-text" v-if="profileName.split(':').slice(-1)[0] == 'Item'">{{$t("message.wordItem")}}</span>
@@ -209,14 +214,14 @@
 
           <ul class="sidebar-property-ul" role="list">
 
-                          <draggable 
-                            v-model="activeProfile.rt[profileName].ptOrder" 
-                            group="people" 
-                            @start="drag=true" 
-                            @end="drag=false" 
+                          <draggable
+                            v-model="activeProfile.rt[profileName].ptOrder"
+                            group="people"
+                            @start="drag=true"
+                            @end="drag=false"
                             item-key="id">
                             <template #item="{element}">
-                              
+
                               <li @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-li sidebar-property-li-empty">
 
                                 <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-ul-alink">
@@ -230,8 +235,8 @@
                                             <a tabindex="-1" href="#" class="sidebar-property-ul-alink sidebar-property-ul-alink-sublink" >{{t}}</a>
                                           </li>
                                       </ul>
-                                  </template>              
-                                </template>                               
+                                  </template>
+                                </template>
                               </li>
                              </template>
                           </draggable>
@@ -252,7 +257,7 @@
                                 <a tabindex="-1" href="#" class="sidebar-property-ul-alink sidebar-property-ul-alink-sublink" >{{t}}</a>
                               </li>
                           </ul>
-                      </template>              
+                      </template>
                     </template>
             </li>
  -->
@@ -304,7 +309,7 @@
     justify-content: space-between;
     align-items: center;
 
-    
+
     line-height: 24px;
     transition: color 300ms ease-in-out;
 
@@ -356,14 +361,14 @@
 
 
 .container-type-icon{
-  color: #ffffff; 
-  width: inherit; 
-  text-align: left;  
+  color: #ffffff;
+  width: inherit;
+  text-align: left;
   display: flex;
 }
 
 
-.sidebar-header-text{  
+.sidebar-header-text{
   font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-properties-font-size', true) + 0.25  + 'em'");
   font-family: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-font-family')");
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-font-color')") !important;


### PR DESCRIPTION
@thisismattmiller, you might want to make sure this makes sense. It just duplicates the check in the edit panel that prevents this field from showing up in the form. It adds a `hideProps` array that gets checked when the properties are built. This one only hides `hasItem` not the `instance` properties.