### PR TITLE
Add styling for `info` in validation.

### DIFF
--- a/src/components/panels/nav/ValidateModal.vue
+++ b/src/components/panels/nav/ValidateModal.vue
@@ -194,6 +194,7 @@
     font-size: 1.5em;
   }
 
+  .level-INFO,
   .level-SUCCESS,
   .level-WARNING,
   .level-ERROR{
@@ -217,5 +218,11 @@
     color: #155724;
     background-color: #d4edda;
     border-color: #c3e6cb;
+  }
+
+  .level-INFO {
+    color: #0c5460;
+    background-color: #d1ecf1;
+    border-color: #bee5eb;
   }
 </style>

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -212,7 +212,7 @@ export const useConfigStore = defineStore('config', {
   testData:[
     {lccn:'2001059208',label:"The knitter's handy book of patterns: basic designs in multiple sizes & gauges", idUrl:'https://id.loc.gov/resources/instances/12618072.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
     {lccn:'2021375840',label:"Schooling under control", idUrl:'https://id.loc.gov/resources/instances/21910923.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
-    
+
     {lccn:'2024591512',label:"The Berkshires, Massachusetts discovery map 2022-2023", idUrl:'https://id.loc.gov/resources/instances/23486403.html', profile:'Cartographic',profileId:'lc:RT:bf2:Cartographic:Instance'},
     {lccn:'2016627557',label:"Wallflower", idUrl:'https://id.loc.gov/resources/instances/2016627557.html', profile:'Audio CD',profileId:'lc:RT:bf2:SoundRecording:Instance'},
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc7bf603-17c8-414c-b22f-a200a726c5c8)
