### PR TITLE
Some quick fixes

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -58,7 +58,7 @@
 
 
 
-                    <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
+                    <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false && profileName.indexOf(':Instance') == -1">
                       <div class="component-label" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                         <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
                       </div>

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -57,12 +57,20 @@
                   <div :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
 
 
-
-                    <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false && profileName.indexOf(':Instance') == -1">
-                      <div class="component-label" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
-                        <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
-                      </div>
-                    </template>
+                    <template v-if="this.dualEdit == false">
+                      <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
+                        <div class="component-label" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
+                          <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
+                        </div>
+                      </template>
+                  </template>
+                  <template v-if="this.dualEdit == true">
+                      <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false && profileName.indexOf(':Instance') == -1">
+                        <div class="component-label" >{{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
+                          <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
+                        </div>
+                      </template>
+                  </template>
 
                     <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')">
                       <div v-if="profileName.split(':').slice(-1)[0] == 'Work'" class="inline-mode-resource-color-work">&nbsp;</div>

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -315,6 +315,19 @@ export const useConfigStore = defineStore('config', {
       ]
     },
 
+    "http://id.loc.gov/authorities/geographics" : {
+			"name":"geographics",
+			"type":"complex",
+			"processor" : 'lcAuthorities',
+			"modes":[
+				{
+					'LCNAF Geographic':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&count=25"},
+					'LCSH Geographic':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings&count=25"},
+					'GACS':{"url":"https://id.loc.gov/vocabulary/geographicAreas/suggest2/?q=<QUERY>&rdftype=Geographic&count=25"},
+				}
+			]
+		},
+
 
     "HierarchicalGeographic": {
       "name":"names",
@@ -324,6 +337,18 @@ export const useConfigStore = defineStore('config', {
       "modes":[
         {
           'All':{"url":"https://preprod-8288.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic", "all":true},
+        }
+      ]
+    },
+
+    // this will search across names and subjects, the above only searches names
+    "HierarchicalGeographicAll": {
+      "name":"names",
+      "type":"simple",
+      "processor" : 'lcAuthorities',
+      "modes":[
+        {
+          'All':{"url":"https://preprod-8288.id.loc.gov/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic", "all":true},
         }
       ]
     },


### PR DESCRIPTION
This does 2 things:

1) Enable the geo lookup. This was copied over from `marva-frontend`. I thought this was added before, not sure what happened.
2) Fix instance component titles. When I got the instance to not display under the work in dual edit mode, it made the instance component labels disappear in `single edit` mode. They were re-added, but that also added them below the work. Just the titles. This should have them appearing when and where they should.