### PR TITLE
Fix arrows & expand geo search

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1235,7 +1235,10 @@ export default {
         if (parseInt(this.pickPostion) <= this.searchResults.names.length*-1){
           return false
         }
+
+        this.pickCurrent = null //allows keyboard selection
         this.loadContext(parseInt(this.pickPostion) - 1 )
+        this.pickCurrent = parseInt(this.pickPostion)
         event.preventDefault()
         return false
       }else if (event.key == 'ArrowDown'){
@@ -1244,8 +1247,9 @@ export default {
           return false
         }
 
-
+        this.pickCurrent = null //allows keyboard selection
         this.loadContext(parseInt(this.pickPostion) + 1 )
+        this.pickCurrent = parseInt(this.pickPostion)
         event.preventDefault()
         return false
       }else if (event.key == 'Enter'){

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1930,7 +1930,6 @@ const utilsNetwork = {
 
       let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>',searchValHierarchicalGeographic).replace('&count=25','&count=4').replace("<OFFSET>", "1")
 
-
       if (mode == 'GEO'){
         subjectUrlHierarchicalGeographic = subjectUrlHierarchicalGeographic.replace('&count=4','&count=12').replace("<OFFSET>", "1")
       }
@@ -1961,7 +1960,6 @@ const utilsNetwork = {
         url: [subjectUrlHierarchicalGeographic],
         searchValue: searchValHierarchicalGeographic
       }
-
 
       let searchPayloadWorksAnchored = {
         processor: 'lcAuthorities',

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -323,7 +323,7 @@ export const useConfigStore = defineStore('config', {
 
       "modes":[
         {
-          'All':{"url":"https://preprod-8288.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic", "all":true},
+          'All':{"url":"https://preprod-8288.id.loc.gov/suggest2/?q=<QUERY>&count=25&rdftype=HierarchicalGeographic", "all":true},
         }
       ]
     },


### PR DESCRIPTION
This reverts the subject builder back to having a separate section for looking up geo subdivisions. Including them with the topical subject headings kept surfacing issues where it wouldn't work or wouldn't work as intended with the fixes for those not being easy, or maybe even possible without a massive re-work.

This also expands the geo subdivision search to use the more generic `...id.loc.gov/suggest2...` endpoint rather than only searching on subjects. This allows the search to find both subjects and names when building.

This also includes a fix for the arrows not working.

~~# TODO: fix merge conflicts~~