### PR TITLE
[LCAP-3597] Capture the `GACs` and `marcKey` when possible

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -822,7 +822,7 @@ export default {
 
     navKey: function(event){
 
-      
+
       if (event && event.keyCode == 220 && event.ctrlKey == true){
         let id = `action-button-${event.target.dataset.guid}`
         document.getElementById(id).click()
@@ -856,7 +856,7 @@ export default {
 
     actionButtonCommand: function(cmd){
       this.$refs.lookupInput.focus()
-      
+
     },
 
     focused: function(){
@@ -882,7 +882,7 @@ export default {
     */
     setComplexValue: function(contextValue){
       delete contextValue.typeFull
-      this.profileStore.setValueComplex(this.guid,null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull)
+      this.profileStore.setValueComplex(this.guid,null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap)
       this.searchValue=''
       this.displayModal=false
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -241,7 +241,6 @@
 
         console.log("toLoad: ", toLoad)
 
-        
         this.activeContext = {
             "contextValue": true,
             "source": [],

--- a/src/components/panels/sidebar_preview_marc/Marc.vue
+++ b/src/components/panels/sidebar_preview_marc/Marc.vue
@@ -40,12 +40,9 @@
     methods: {
 
       async refreshMarc() {
-
         this.previewData = await this.profileStore.marcPreview()
-       
-
       }
-      
+
 
 
 
@@ -57,7 +54,7 @@
       // this.profileStore.$subscribe(async (mutation, state)=>{
 
       //   if (mutation && mutation.events && mutation.events.target && mutation.events.target['@guid'] ){
-          
+
       //     window.clearTimeout(this.timeout)
       //     this.timeout = window.setTimeout(()=>{
 
@@ -66,7 +63,7 @@
       //     },500)
 
 
-          
+
       //   }
 
 
@@ -83,9 +80,9 @@
     },
 
     mounted() {
-     
 
-      
+
+
     }
   }
 
@@ -121,21 +118,21 @@
           </pre>
         </div>
       </template>
-    
+
     </template>
     <template v-else>
       <template v-for="ver in previewData.versions">
         <div v-if="selected == ver.version">
           <div class="version-number">{{ ver.version  }}</div>
           <template v-if="ver.error">
-            
+
             <pre>
               <code>
 {{ ver.results }}
               </code>
-            </pre>            
+            </pre>
           </template>
-          <template v-else>            
+          <template v-else>
             <pre>
               <code>
 {{ ver.marcRecord }}
@@ -176,7 +173,7 @@ li{
 }
 
 
-.sidebar-header-text{  
+.sidebar-header-text{
   font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size', true) + 0.25  + 'em'");
   font-family: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-family')");
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -22,7 +22,7 @@ const formatXML = function(xml, tab = '\t', nl = '\n') {
 	return formatted;
 }
 
-// we will use the built in DOMParser() in the browser 
+// we will use the built in DOMParser() in the browser
 const returnDOMParser = function(){
 	let p
 	try{
@@ -32,7 +32,7 @@ const returnDOMParser = function(){
 		// const { JSDOM } = jsdom;
 		// const { window } = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
 		p = new window.DOMParser();
-	}	
+	}
 	return p
 }
 
@@ -56,12 +56,12 @@ const utilsExport = {
 	],
 
   /**
-  * if passed full uri like http://id.loc.gov/ontology/bibframe/xxx will convert to a prefixed bf:xxx 
-  * 
-  * @param {string} uri - the uri to convert 
+  * if passed full uri like http://id.loc.gov/ontology/bibframe/xxx will convert to a prefixed bf:xxx
+  *
+  * @param {string} uri - the uri to convert
   * @return {string}
-  */  
-  namespaceUri: function(uri){	
+  */
+  namespaceUri: function(uri){
 		for (let ns in this.namespace){
 			let nsuri = this.namespace[ns]
 			if (uri.includes(nsuri)){
@@ -72,10 +72,10 @@ const utilsExport = {
 
   /**
   * if passed a prefix like bf:xxx it will expand it to http://id.loc.gov/ontology/bibframe...
-  * 
-  * @param {string} passedNS - the prefixed element/prop 
+  *
+  * @param {string} passedNS - the prefixed element/prop
   * @return {string}
-  */  
+  */
 	UriNamespace: function(passedNS){
 		for (let ns in this.namespace){
 			let nsuri = this.namespace[ns]
@@ -87,16 +87,15 @@ const utilsExport = {
 
   /**
   * creates a element with createElementNS using the correct namespace
-  * 
-  * @param {string} elStr - the element to create 
+  *
+  * @param {string} elStr - the element to create
   * @return {element}
   */
   createElByBestNS: function(elStr){
-
 		// HACK - bad marc2bf conversion
 		if (elStr == 'http://www.loc.gov/mads/rdf/v1#'){
 			elStr = 'http://www.loc.gov/mads/rdf/v1#Authority'
-		} 
+		}
 
 		elStr=elStr.replace('https://','http://')
 		// if the elString is not a expanded URI
@@ -104,32 +103,31 @@ const utilsExport = {
 			elStr = this.UriNamespace(elStr)
 		}
 		for (let ns of Object.keys(this.namespace)){
-			if (elStr.startsWith(this.namespace[ns])){		
+			if (elStr.startsWith(this.namespace[ns])){
 				return document.createElementNS(this.namespace[ns],this.namespaceUri(elStr))
 			}
 		}
 		console.error('could not find namespace for ', elStr)
 		return null
-	}, 
+	},
 
   /**
   * A helper function that will build blank node based on userValue obj
-  * 
+  *
   * @param {obj} userValue - the uservalue to test
   * @param {string} property - the property uri
   * @return {boolean}
   */
 	createBnode: function(userValue,property){
-
 		// some special cases here
 		if (property == 'http://id.loc.gov/ontologies/bibframe/agent'){
 			// if it is an agent create the Agent bnode and just add the type to it as rdf:type
 			let bnode = this.createElByBestNS('bf:Agent')
 			if (userValue['@id']){
-				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])						
+				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
 			}
 			let rdftype = this.createElByBestNS('rdf:type')
-			rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])						
+			rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])
 			bnode.appendChild(rdftype)
 			if (userValue['@parseType']){
 				bnode.setAttribute('rdf:parseType', userValue['@parseType'])
@@ -139,7 +137,7 @@ const utilsExport = {
 			// if it is this specific note vocabulary type then create a bf:Note with a RDF type in it
 			let bnode = this.createElByBestNS('bf:Note')
 			let rdftype = this.createElByBestNS('rdf:type')
-			rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])						
+			rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@type'])
 			bnode.appendChild(rdftype)
 			return bnode
 		}else{
@@ -147,19 +145,19 @@ const utilsExport = {
 			// just normally make it
 			let bnode = this.createElByBestNS(userValue['@type'])
 			if (userValue['@id']){
-				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])						
+				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
 			}
 			if (userValue['@parseType']){
 				bnode.setAttribute('rdf:parseType', userValue['@parseType'])
 			}
 			return bnode
 		}
-	
+
 	},
 
   /**
   * A helper function that will build a literal value element
-  * 
+  *
   * @param {string} property - the property uri
   * @param {obj} userValue - the uservalue to test
   * @return {boolean}
@@ -187,6 +185,9 @@ const utilsExport = {
 		if (userValue['@parseType']){
 			p.setAttribute('rdf:parseType', userValue['@parseType'])
 		}
+		if (userValue['@about']){
+			p.setAttribute('rdf:about', userValue['@about'])
+		}
 
 		// doesnt work :(
 		// p.removeAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns:rdfs')
@@ -196,8 +197,8 @@ const utilsExport = {
 
 
   /**
-  * 
-  * 
+  *
+  *
   * @param {obj} userValue - the uservalue to test
   * @return {boolean}
   */
@@ -217,7 +218,7 @@ const utilsExport = {
 
   /**
   * Some structures share the same predicate
-  * 
+  *
   * @param {string} key - the uri
   * @return {boolean}
   */
@@ -229,8 +230,8 @@ const utilsExport = {
 	},
 
   /**
-  * 
-  * 
+  *
+  *
   * @param {obj} userValue - the uservalue to test
   * @return {boolean}
   */
@@ -247,7 +248,7 @@ const utilsExport = {
 
   /**
   * returns the just the item portion of the profile
-  * 
+  *
   * @param {string} URI - the uri of the instance to look for it's items
   * @param {obj} profile - profile
   * @param {obj} tleLookup - the lookup created out of the export XML process
@@ -272,8 +273,8 @@ const utilsExport = {
 	},
   /**
   * returns the just the work portion of the profile
-  * 
-  * @param {string} instanceURI - the uri of the instance 
+  *
+  * @param {string} instanceURI - the uri of the instance
   * @param {obj} profile - profile
   * @param {obj} tleLookup - the lookup created out of the export XML process
   * @return {obj}
@@ -297,67 +298,62 @@ const utilsExport = {
 			}
 		}
 		return results
-	},	
+	},
 
 
 
 
   /**
-  * 
-  * 
+  *
+  *
   * @param {string} uri - the URI to test
   * @return {boolean}
   */
   buildXML: async function(profile){
-
-	
     // console.log(profile)
 
     // keep track of the proces for later
-		// let debugHistory = []
-		let xmlLog = []
-    
+	// let debugHistory = []
+	let xmlLog = []
 
     let componentXmlLookup = {}
-    
+
     // keep a copy of the org profile around
     let orginalProfile = profile
 	// cut the ref to the orginal
 	profile = JSON.parse(JSON.stringify(profile))
 
-	let xmlParser = returnDOMParser()					
-
+	let xmlParser = returnDOMParser()
 
     // these will store the top level elements
     let tleWork = []
-		let tleInstance = []
-		let tleItem = []
+	let tleInstance = []
+	let tleItem = []
 
     // we are creating the xml in two formats, create the root node for both
     let rdf = document.createElementNS(this.namespace.rdf, "RDF");
-		let rdfBasic = document.createElementNS(this.namespace.rdf, "RDF");
+	let rdfBasic = document.createElementNS(this.namespace.rdf, "RDF");
 
     // just add all the namespaces into the root element
-		for (let ns of Object.keys(this.namespace)){			
-			rdf.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
-			rdfBasic.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
-		}
+	for (let ns of Object.keys(this.namespace)){
+		rdf.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
+		rdfBasic.setAttributeNS("http://www.w3.org/2000/xmlns/", `xmlns:${ns}`, this.namespace[ns])
+	}
 
     // these are elements used to store metadata about the record in the backend
-		let xmlVoidDataRtsUsed = []
-		let xmlVoidDataType = []
-		let xmlVoidExternalID = []
-		let xmlVoidDataTitle = ""
-		let xmlVoidDataContributor = ""
-		let xmlVoidDataLccn = ""
+	let xmlVoidDataRtsUsed = []
+	let xmlVoidDataType = []
+	let xmlVoidExternalID = []
+	let xmlVoidDataTitle = ""
+	let xmlVoidDataContributor = ""
+	let xmlVoidDataLccn = ""
 
     let tleLookup = {
-			Work: {},
-			Instance: {},
-			Item: {},
-			Hub:{}
-		}
-
+		Work: {},
+		Instance: {},
+		Item: {},
+		Hub:{}
+	}
 
 		for (let rt of profile.rtOrder){
 
@@ -366,8 +362,8 @@ const utilsExport = {
 			if (profile.rt[rt].noData){
 				xmlLog.push(` - ${rt} has no data, skipping it.`)
 				continue
-			} 
-			
+			}
+
 			let tleArray // eslint-disable-line
 			let rootEl
 			let rootElName
@@ -399,7 +395,7 @@ const utilsExport = {
 
 			// rdf.appendChild(rootEl,tleArray)
 
-			
+
 			if (profile.rt[rt].URI){
 				rootEl.setAttributeNS(this.namespace.rdf, 'rdf:about', profile.rt[rt].URI)
 				xmlLog.push(`Setting URI for this resource rdf:about to: ${profile.rt[rt].URI}`)
@@ -409,7 +405,7 @@ const utilsExport = {
 				let type = this.createElByBestNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
 				type.setAttributeNS(this.namespace.rdf, 'rdf:resource', profile.rt[rt]['@type'])
 				xmlLog.push(`Setting URI for this resource rdf:resource to: ${profile.rt[rt]['@type']}`)
-				rootEl.appendChild(type)				
+				rootEl.appendChild(type)
 			}
 
 
@@ -423,7 +419,7 @@ const utilsExport = {
 				if (ptObj.deleted){
 					continue
 				}
-				
+
 				if (ptObj.deepHierarchy){
 
 					// just take our existing XML and plop it into the root element
@@ -441,11 +437,11 @@ const utilsExport = {
 
         		// the uservalue could be stored in a few places depending on the nesting
 				if (ptObj.userValue[ptObj.propertyURI] && ptObj.userValue[ptObj.propertyURI][0]){
-					userValue = ptObj.userValue[ptObj.propertyURI][0] 				
+					userValue = ptObj.userValue[ptObj.propertyURI][0]
 				}else if (ptObj.userValue[ptObj.propertyURI]){
 					userValue = ptObj.userValue[ptObj.propertyURI]
 				}else{
-					userValue = ptObj.userValue 	
+					userValue = ptObj.userValue
 				}
 
 				// temp hack to clcean up bad data -- not perm required
@@ -463,7 +459,7 @@ const utilsExport = {
 
 				xmlLog.push(['Set userValue to:', JSON.parse(JSON.stringify(userValue)) ])
 
-				
+
 
 				if (this.ignoreProperties.indexOf(ptObj.propertyURI) > -1){
 					xmlLog.push(`Skpping it because it is in the ignoreProperties list`)
@@ -471,13 +467,13 @@ const utilsExport = {
 				}
 
 
-				// do some updates to the admin metadata 
+				// do some updates to the admin metadata
 				if (pt.includes('http://id.loc.gov/ontologies/bibframe/adminMetadata')){
 					let adminData = ptObj.userValue['http://id.loc.gov/ontologies/bibframe/adminMetadata'][0]
 					// set the profile used
 					adminData['http://id.loc.gov/ontologies/bflc/profile'] = [
 						{
-							'http://id.loc.gov/ontologies/bflc/profile' : rt							
+							'http://id.loc.gov/ontologies/bflc/profile' : rt
 						}
 					]
 					// drop any existing changeDate and add our own
@@ -550,7 +546,7 @@ const utilsExport = {
 								}else if (userValue[key1] && userValue[key1][0] && userValue[key1][0]['http://www.w3.org/2000/01/rdf-schema#label']){
 									let rdftype = this.createElByBestNS(key1)
 									rdftype.innerHTML=userValue[key1][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
-									xmlLog.push(`This bnode just has a rdf:type and label : ${rdftype} setting it an continuing`)									
+									xmlLog.push(`This bnode just has a rdf:type and label : ${rdftype} setting it an continuing`)
 									bnodeLvl1.appendChild(rdftype)
 									continue
 								}
@@ -565,9 +561,9 @@ const utilsExport = {
 									pLvl2 = this.createElByBestNS(key1)
 									xmlLog.push(`Creating lvl 2 property : ${pLvl2.tagName} for ${JSON.stringify(value1)}`)
 								}
-								
 
-								// is it a bnode?
+
+								// is it a bnode?  createElByBestNS
 								if (this.isBnode(value1)){
 									// yes
 									let bnodeLvl2 = this.createBnode(value1,key1)
@@ -588,6 +584,7 @@ const utilsExport = {
 												bnodeLvl2.appendChild(pLvl3)
 												xmlLog.push(`Creating lvl 3 bnode: ${bnodeLvl3.tagName} for ${key2}`)
 
+
 												for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
 													let pLvl4 = this.createElByBestNS(key2)
 													for (let value3 of value2[key3]){
@@ -598,13 +595,13 @@ const utilsExport = {
 															bnodeLvl3.appendChild(pLvl4)
 															xmlLog.push(`Creating lvl 4 bnode: ${bnodeLvl4.tagName} for ${key3}`)
 
-															
+
 															for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
 																for (let value4 of value3[key4]){
 																	if (this.isBnode(value4)){
 																		console.error("Max hierarchy depth reached, but there are more levels left:", key4, 'in', userValue )
 																		xmlLog.push(`Max hierarchy depth reached, but there are more levels left for ${key4}`)
-			
+
 																	}else{
 
 																		for (let key5 of Object.keys(value4).filter(k => (!k.includes('@') ? true : false ) )){
@@ -625,7 +622,7 @@ const utilsExport = {
 
 															}
 
-														
+
 														}else{
 															for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
 																if (typeof value3[key4] == 'string' || typeof value3[key4] == 'number'){
@@ -657,7 +654,6 @@ const utilsExport = {
 										}
 									}
 								}else{
-
 									xmlLog.push(`It's value at lvl is not a bnode, looping through and adding a literal value`)
 									// no it is a literal or something else
 									// loop through its keys and make the values
@@ -670,7 +666,6 @@ const utilsExport = {
 											xmlLog.push(`Setting its rdf:about to ${value1['@id']}`)
 											bnodeLvl1.setAttributeNS(this.namespace.rdf, 'rdf:about', value1['@id'])
 										}
-
 									}
 
 									if (keys.length>0){
@@ -721,18 +716,18 @@ const utilsExport = {
 										let p2 = this.createLiteral(key1, value1)
 										if (p2!==false) bnodeLvl1.appendChild(p2);
 
-										
+
 									}else{
 
 										console.warn('Unhadled literal situtation')
 										console.log("value1", value1, 'key1',key1)
 										// just set it to an empty value
 										value1[key1] = ""
-										
+
 
 									}
 
-									
+
 
 
 								}
@@ -740,12 +735,12 @@ const utilsExport = {
 								value1FirstLoop = false
 
 							}
-						}	
+						}
 						pLvl1.appendChild(bnodeLvl1)
 						rootEl.appendChild(pLvl1)
 
 						componentXmlLookup[`${rt}-${pt}`] = formatXML(pLvl1.outerHTML)
-						
+
 					}else{
 
 						// this.debug(ptObj.propertyURI, 'root level element does not look like a bnode', userValue)
@@ -764,7 +759,7 @@ const utilsExport = {
 								// xmlLog.push(`Found special flag rule for ${ptObj.propertyURI}`)
 								// // an edge case here where we wanted to allow multiple simple lookups in root level fields
 								// // like carrierType, loop through the labels, build the properties, if it doesnt have a @id its because its at te root lvl
-								
+
 								// if (userValue['http://www.w3.org/2000/01/rdf-schema#label']){
 
 								// 	let allXMLFragments = ''
@@ -808,7 +803,7 @@ const utilsExport = {
 								// this.debug(ptObj.propertyURI, 'But has @type, making bnode')
 
 								let p = this.createElByBestNS(ptObj.propertyURI)
-								let bnode = this.createElByBestNS(userValue['@type'])						
+								let bnode = this.createElByBestNS(userValue['@type'])
 								bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
 
 								xmlLog.push(`Created ${p.tagName} property and ${bnode.tagName} bnode`)
@@ -836,15 +831,15 @@ const utilsExport = {
 									// console.log("userValue[key1]",userValue[key1])
 									// are we at the right level?
 									if (typeof userValue[key1] === 'string' || typeof userValue[key1] === 'number'){
-													
+
 										let p1 = this.createLiteral(key1, userValue)
 										// console.log("p1",p1)
 										if (p1!==false) {
 											rootEl.appendChild(p1);
 											xmlLog.push(`Creating literal at root level for ${key1} with value ${p1.innerHTML}`)
-											allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`																								
+											allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
 										}
-									}else{										
+									}else{
 										for (let value1 of userValue[key1]){
 											for (let key2 of Object.keys(value1).filter(k => (!k.includes('@') ? true : false ) )){
 												if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
@@ -852,7 +847,7 @@ const utilsExport = {
 													let p1 = this.createLiteral(key2, value1)
 													if (p1!==false) {
 														rootEl.appendChild(p1);
-														allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`																								
+														allXMLFragments = allXMLFragments + `\n${formatXML(p1.outerHTML)}`
 														xmlLog.push(`Creating literal at root level for ${key2} with value ${value1}`)
 													}
 												}else{
@@ -860,9 +855,9 @@ const utilsExport = {
 													xmlLog.push(`Not a literal at root level ${key2} with value ${value1[key2]}`)
 												}
 											}
-										}									
+										}
 									}
-								}								
+								}
 								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
 							}else if (await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
 
@@ -922,12 +917,12 @@ const utilsExport = {
 					xmlLog.push(`Skpping it because hasUserValue == false`)
 				}
 			}
-				
+
 
 			// add in the admindata
 			// if (orginalProfile.rt[rt].adminMetadataData){
 
-				
+
 			// 	let parser = new DOMParser();
 			// 	let adm = parser.parseFromString(orginalProfile.rt[rt].adminMetadataData, "text/xml");
 
@@ -958,7 +953,7 @@ const utilsExport = {
 			// 	gP.appendChild(GP)
 
 			// 	let GPD = this.createElByBestNS('bf:generationDate')
-			// 	GPD.innerHTML = new Date().toISOString()							
+			// 	GPD.innerHTML = new Date().toISOString()
 			// 	GPD.setAttributeNS(this.namespace.rdf, 'rdf:datatype', 'http://www.w3.org/2001/XMLSchema#dateTime')
 			// 	GP.appendChild(GPD)
 
@@ -972,19 +967,19 @@ const utilsExport = {
 
 
 			// 	adm.getElementsByTagName('bf:AdminMetadata')[0].appendChild(p)
-				
-				
+
+
 
 			// 	rootEl.appendChild(adm)
 			// }
 
-      
 
-			if (orginalProfile.rt[rt].unusedXml){			
+
+			if (orginalProfile.rt[rt].unusedXml){
 
 				let unusedXmlNode = xmlParser.parseFromString(orginalProfile.rt[rt].unusedXml, "text/xml")
 				unusedXmlNode = unusedXmlNode.children[0]
-				for (let el of unusedXmlNode.children){					
+				for (let el of unusedXmlNode.children){
 					// console.log("Looking at",el.tagName)
 					if (el.tagName != 'rdfs:label'){
 						// there is some strange behavior adding the element directly
@@ -1010,7 +1005,7 @@ const utilsExport = {
 		let catCode = profile.user.split(" (")
 		catCode = catCode[catCode.length-1]
 		catCode=catCode.split(")")[0]
-		
+
 		let bf_adminMetadata = this.createElByBestNS("bf:adminMetadata")
 		let bf_AdminMetadtat = this.createElByBestNS("bf:AdminMetadata")
 		let bf_status = this.createElByBestNS("bf:status")
@@ -1027,7 +1022,7 @@ const utilsExport = {
 
 		bf_AdminMetadtat.appendChild(bf_date)
 		bf_AdminMetadtat.appendChild(bf_catalogerId)
-		
+
 		bf_Status.appendChild(bf_StatusLabel)
 		bf_status.appendChild(bf_Status)
 		bf_AdminMetadtat.appendChild(bf_status)
@@ -1038,19 +1033,19 @@ const utilsExport = {
 
 
 
-		
-		
+
+
 		for (let URI in tleLookup['Work']){
-			tleLookup['Work'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])		
+			tleLookup['Work'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])
 		}
 		for (let URI in tleLookup['Instance']){
-			tleLookup['Instance'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])		
+			tleLookup['Instance'][URI].appendChild(xmlParser.parseFromString(adminMetadataText, "text/xml").children[0])
 		}
 
 
 
 
-		// also just build a basic version tosave	
+		// also just build a basic version tosave
 		for (let URI in tleLookup['Work']){
 			let theWork = (new XMLSerializer()).serializeToString(tleLookup['Work'][URI])
 			// theWork = theWork.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
@@ -1078,7 +1073,7 @@ const utilsExport = {
 					uri = item.attributes['rdf:resource'].value
 				}else if(item.attributes['rdf:about']){
 					uri = item.attributes['rdf:about'].value
-				}	
+				}
 				if (uri){
 					let hasItem = this.createElByBestNS('bf:hasItem')
 					hasItem.setAttributeNS(this.namespace.rdf, 'rdf:resource', uri)
@@ -1102,7 +1097,7 @@ const utilsExport = {
 			rdfBasic.appendChild(item)
 		}
 
-		if (orginalProfile.procInfo.includes("update")){	
+		if (orginalProfile.procInfo.includes("update")){
 			//build it cenered around the instance
 			if (Object.keys(tleLookup['Instance']).length>0){
 				for (let URI in tleLookup['Instance']){
@@ -1117,7 +1112,7 @@ const utilsExport = {
 							instance.appendChild(p)
 						}
 					}
-					
+
 					let work = this.returnWorkFromInstance(URI,orginalProfile,tleLookup)
 					if (work){
 						let p = this.createElByBestNS('bf:instanceOf')
@@ -1133,10 +1128,10 @@ const utilsExport = {
 				// use the first work key TODO: multiple works....?
 				let workKey = Object.keys(tleLookup['Work'])[0]
 				let work = tleLookup['Work'][workKey]
-				if (work){			
+				if (work){
 				  rdf.appendChild(work)
 				}
-			}			
+			}
 		}else{
 			// FIX CHANGE NOT RIGHT ECT!!
 			for (let URI in tleLookup['Instance']){
@@ -1144,7 +1139,7 @@ const utilsExport = {
 				let instance = (new XMLSerializer()).serializeToString(tleLookup['Instance'][URI])
 				instance = xmlParser.parseFromString(instance, "text/xml").children[0];
 				let items = this.returnHasItem(URI,orginalProfile,tleLookup)
-				if (items.length > 0){			
+				if (items.length > 0){
 					for (let item of items){
 						let p = this.createElByBestNS('bf:hasItem')
 						p.appendChild(item)
@@ -1152,7 +1147,7 @@ const utilsExport = {
 					}
 				}
 				let work = this.returnWorkFromInstance(URI,orginalProfile,tleLookup)
-				
+
 				if (work){
 					let p = this.createElByBestNS('bf:instanceOf')
 					p.appendChild(work)
@@ -1166,7 +1161,7 @@ const utilsExport = {
 
 		// are we just editing a single HUB?
 		if (Object.keys(tleLookup['Work']).length==0 && Object.keys(tleLookup['Hub']).length == 1){
-			
+
 
 			let theHub = (new XMLSerializer()).serializeToString(rdfBasic)
 			theHub = parser.parseFromString(theHub, "text/xml").children[0];
@@ -1190,7 +1185,7 @@ const utilsExport = {
 			if (rdfBasic.getElementsByTagName("bflc:PrimaryContribution")[0].getElementsByTagName("rdfs:label").length>0){
 				xmlVoidDataContributor = rdfBasic.getElementsByTagName("bflc:PrimaryContribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
 			}
-			
+
 		}else{
 
 			if (rdfBasic.getElementsByTagName("bf:Contribution").length>0){
@@ -1245,7 +1240,7 @@ const utilsExport = {
 						}
 					}
 				}
-				
+
 			}
 
 		}
@@ -1291,7 +1286,7 @@ const utilsExport = {
 		el = document.createElementNS(this.namespace.lclocal, 'lclocal:lccn')
 		el.innerHTML = xmlVoidDataLccn
 		datasetDescriptionEl.appendChild(el)
-    	
+
 		el = document.createElementNS(this.namespace.lclocal, 'lclocal:user')
 		el.innerHTML = profile.user
 		datasetDescriptionEl.appendChild(el)
@@ -1348,7 +1343,7 @@ const utilsExport = {
       let almaItemsEl =  rdfBasic.getElementsByTagName("bf:Item")
 
       const doc = document.implementation.createDocument("", "", null);
-      // make a new root element 
+      // make a new root element
       let almaXmlElBib = doc.createElement("bib");
       // <bib>
 
@@ -1356,19 +1351,19 @@ const utilsExport = {
       almaXmlElRecordFormat.innerHTML = "BIBFRAME"
       almaXmlElBib.appendChild(almaXmlElRecordFormat)
       // make a child element record of bib
-      let almaXmlElRecord = doc.createElement("record");			
-      //rdf tag should be open 
+      let almaXmlElRecord = doc.createElement("record");
+      //rdf tag should be open
       let almaXmlElRdf = doc.createElement("rdf:RDF");
-      almaXmlElRdf.setAttribute("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");					
+      almaXmlElRdf.setAttribute("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
       almaXmlElRecord.appendChild(almaXmlElRdf)
-      almaXmlElBib.appendChild(almaXmlElRecord)	
-    
+      almaXmlElBib.appendChild(almaXmlElRecord)
+
       for (let el of almaWorksEl){ almaXmlElRdf.appendChild(el) }
       for (let el of almaInstancesEl){ almaXmlElRdf.appendChild(el) }
       for (let el of almaItemsEl){ almaXmlElRdf.appendChild(el) }
-          
 
-      let strAlmaXmlElBib = (new XMLSerializer()).serializeToString(almaXmlElBib)	
+
+      let strAlmaXmlElBib = (new XMLSerializer()).serializeToString(almaXmlElBib)
 
       // overwrite the existing string with with one
       // strXml is the one sent to the server
@@ -1378,22 +1373,21 @@ const utilsExport = {
 
 
         // build the BF2MARC package
-		
+
 		let bf2MarcXmlElRdf = this.createElByBestNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#RDF')
-		// bf2MarcXmlElRdf.setAttribute("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");					
-	
+		// bf2MarcXmlElRdf.setAttribute("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+
 		for (let el of rdfBasic.getElementsByTagName("bf:Work")){ bf2MarcXmlElRdf.appendChild(el) }
 		for (let el of rdfBasic.getElementsByTagName("bf:Instance")){ bf2MarcXmlElRdf.appendChild(el) }
 		for (let el of rdfBasic.getElementsByTagName("bf:Item")){ bf2MarcXmlElRdf.appendChild(el) }
-		let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)	
+		let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)
 
 		// console.log(strBf2MarcXmlElBib, strXmlFormatted, strXmlBasic, strXml)
-			
+
 		// console.log("-------componentXmlLookup",componentXmlLookup)
     // console.log(strXmlFormatted)
     // console.log("------")
     // console.log(strXmlBasic)
-		
 		return {
 			xmlDom: rdf,
 			xmlStringFormatted: strXmlFormatted,

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1388,6 +1388,8 @@ const utilsExport = {
     // console.log(strXmlFormatted)
     // console.log("------")
     // console.log(strXmlBasic)
+		console.info("strBf2MarcXmlElBib: ", strBf2MarcXmlElBib)
+
 		return {
 			xmlDom: rdf,
 			xmlStringFormatted: strXmlFormatted,

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -185,8 +185,8 @@ const utilsExport = {
 		if (userValue['@parseType']){
 			p.setAttribute('rdf:parseType', userValue['@parseType'])
 		}
-		if (userValue['@about']){
-			p.setAttribute('rdf:about', userValue['@about'])
+		if (userValue['@gacs']){
+			p.setAttribute('rdf:datatype', userValue['@gacs'])
 		}
 
 		// doesnt work :(
@@ -1388,7 +1388,6 @@ const utilsExport = {
     // console.log(strXmlFormatted)
     // console.log("------")
     // console.log(strXmlBasic)
-		console.info("strBf2MarcXmlElBib: ", strBf2MarcXmlElBib)
 
 		return {
 			xmlDom: rdf,

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -9,7 +9,7 @@ import utilsRDF from './utils_rdf';
 
 const utilsParse = {
 
-  data: {   
+  data: {
     work: [],
     instance: [],
     item:[]
@@ -24,12 +24,12 @@ const utilsParse = {
 
   /**
   * Tests if a URI string is likely an RDF Class
-  * 
+  *
   * @param {string} uri - the URI to test
   * @return {boolean}
   */
   isClass: function(uri){
-    
+
     // just testing a few name spaces here
     if (uri.match(/bf:[A-Z]/)){
       return true
@@ -67,11 +67,11 @@ const utilsParse = {
 
   /**
   * Takes a URI and turns it into the shortened namespaced version bf:whatever
-  * 
+  *
   * @param {string} uri - the URI to convert
   * @return {string} - the namespaced version
   */
-  namespaceUri: function(uri){  
+  namespaceUri: function(uri){
     for (let ns in this.namespace){
       let nsuri = this.namespace[ns]
       if (uri.includes(nsuri)){
@@ -83,7 +83,7 @@ const utilsParse = {
 
   /**
   * Takes a shortened namespaced version bf:whatever and turns it into the full URI
-  * 
+  *
   * @param {string} uri - the URI to convert
   * @return {string} - the full version
   */
@@ -98,7 +98,7 @@ const utilsParse = {
 
   /**
   * Small helper to add a modifer to URIs being pulled from the data
-  * 
+  *
   * @param {string} uri - the URI to extract
   * @return {string} - the modified URI
   */
@@ -109,21 +109,21 @@ const utilsParse = {
 
   /**
   * Returns the first child of where the parent is a spefific XML node
-  * 
+  *
   * @param {dom} selection - XML dom tree to parse
   * @param {string} requiredParent - the tagName of parent that is requreid
   * @return {dom} - the dom xml of the result
   */
-  returnOneWhereParentIs: function(selection, requiredParent){  
+  returnOneWhereParentIs: function(selection, requiredParent){
     if (selection.length == 1){
       if (selection[0].parentNode.tagName === requiredParent){
         return selection[0]
       }else{
         return false
-      }     
+      }
     }
     for (let el of selection){
-      
+
       if (el.parentNode.tagName === requiredParent){
         return el
       }
@@ -132,20 +132,20 @@ const utilsParse = {
   },
 
   /**
-  * For ID uris, return the code from the uri 
-  * 
+  * For ID uris, return the code from the uri
+  *
   * @param {string} uri - the URI to test
   * @return {string} - the trailing part of the uri
   */
   returnLookupListFromURI: function(uri){
 
-    // its an ID vocab, just split off the end and use that 
+    // its an ID vocab, just split off the end and use that
     if (uri.includes('http://id.loc.gov/vocabulary/') || uri.includes('https://id.loc.gov/vocabulary/')){
       uri = uri.split('/')
       uri.splice(-1,1)
       uri = uri.join('/')
       return uri
-    }    
+    }
     return false
   },
 
@@ -154,7 +154,7 @@ const utilsParse = {
   testSeperateRdfTypeProperty: function(pt){
     if (pt.valueConstraint && pt.valueConstraint.valueTemplateRefs){
       for (let id of pt.valueConstraint.valueTemplateRefs){
-        if (useProfileStore().rtLookup[id]){          
+        if (useProfileStore().rtLookup[id]){
           for (let p of useProfileStore().rtLookup[id].propertyTemplates){
             if (p.propertyURI === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
               return true
@@ -162,7 +162,7 @@ const utilsParse = {
           }
         }
       }
-    }   
+    }
     return false
   },
 
@@ -170,7 +170,7 @@ const utilsParse = {
 
   /**
   * Takes the XML and parses it
-  * 
+  *
   * @param {string} xml - the XML payload
   * @return {void}
   */
@@ -178,7 +178,7 @@ const utilsParse = {
 
     // if (!xml){
     //   xml = this.testXml
-    // } 
+    // }
 
     this.xmlSource = xml
     // use the browser if we can, should be faster, fall back to the library if not running in the browser
@@ -192,9 +192,9 @@ const utilsParse = {
       if (root.length > 0){ root = root[0]}
 
 
-      
+
       this.hasInstance = 0
-      for (let rdfChild of root.children){        
+      for (let rdfChild of root.children){
         if (rdfChild.tagName == 'bf:Instance'){
           this.hasInstance++
         }
@@ -202,7 +202,7 @@ const utilsParse = {
 
       // test to see if there are any Items,
       this.hasItem = this.activeDom.getElementsByTagName('bf:Item').length
-      
+
 
     // the library very much doesn't work on anything but chrome
     // }else{
@@ -216,28 +216,28 @@ const utilsParse = {
 
   /**
   * Takes the XML marks any bf:relation properties with hints to use in the parsing of it
-  * 
+  *
   * @param {Node} xml - the XML payload
   * @return {Node}
   */
   sniffWorkRelationType(xml){
-    for (let child of xml.children){ 
+    for (let child of xml.children){
       if (child.tagName == 'bf:relation'){
        if (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
        } else if (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bibframe/Uncontrolled")>-1){
-        child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')        
+        child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
        } else if ( (child.innerHTML.indexOf("bf:Hub")>-1 || child.innerHTML.indexOf("bf:Work")>-1) &&  child.innerHTML.indexOf("hasSeries")>-1   ){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHubLookup')
        } else if (child.innerHTML.indexOf("bf:Work")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:RelWorkLookup')
        }else{
-          // leave blank? 
+          // leave blank?
         }
       }
     }
     return xml
-  },  
+  },
 
 
   specialTransforms: {
@@ -246,9 +246,8 @@ const utilsParse = {
 
 
   transformRts: async function(profile){
-
     let toDeleteNoData = []
-  
+
     // before we start processing make sure we have enough instance rts for the number needed
     let totalInstanceRts = 0
     let useInstanceRt = null
@@ -261,7 +260,7 @@ const utilsParse = {
       }
     }
 
-    
+
     [...Array(this.hasInstance - totalInstanceRts)].forEach((_, i) => {
       profile.rt[useInstanceRtName + '_'+(i+1)] = JSON.parse(JSON.stringify(useInstanceRt))
       profile.rtOrder.push(useInstanceRtName + '_'+(i+1))
@@ -270,7 +269,7 @@ const utilsParse = {
 
     for (const pkey in profile.rt) {
 
-      let tle = ""      
+      let tle = ""
       if (pkey.includes(':Work')){
         tle = "bf:Work"
       }else if (pkey.includes(':Instance')){
@@ -287,14 +286,14 @@ const utilsParse = {
       // select the right part of the profile
       let pt = profile.rt[pkey].pt
       let xml = this.activeDom.getElementsByTagName(tle)
-      
+
       // store this here for easy access to the error report
       profile.xmlSource = this.xmlSource
-      
-      
+
+
       // only return the top level, no nested related things
       xml = this.returnOneWhereParentIs(xml, "rdf:RDF")
-      
+
 
       if (xml === false && tle == 'bf:Hub'){
         tle = "bf:Work"
@@ -305,7 +304,7 @@ const utilsParse = {
           xml = this.activeDom.getElementsByTagName(tle)
         }
         xml = this.returnOneWhereParentIs(xml, "rdf:RDF")
-        
+
       }
       if (xml===false){
         console.warn(tle,'was not processed because it failed the top level test, must be a nested resource?')
@@ -331,7 +330,7 @@ const utilsParse = {
 
 
       //let rdftype = xml.getElementsByTagName('rdf:type')
-      for (let child of xml.children){ 
+      for (let child of xml.children){
         if (child.tagName == 'rdf:type'){
           if (child.attributes['rdf:resource']){
             profile.rt[pkey]['@type'] = child.attributes['rdf:resource'].value
@@ -350,11 +349,11 @@ const utilsParse = {
             profile.rt[pkey].instanceOf = instanceOf.attributes['rdf:resource'].value
           }else if(instanceOf.attributes['rdf:about']){
             profile.rt[pkey].instanceOf = instanceOf.attributes['rdf:about'].value
-          }         
+          }
 
 
         }
-        
+
       }
 
       // find itemOf
@@ -365,14 +364,14 @@ const utilsParse = {
             profile.rt[pkey].itemOf = itemOf.attributes['rdf:resource'].value
           }else if(itemOf.attributes['rdf:about']){
             profile.rt[pkey].itemOf = itemOf.attributes['rdf:about'].value
-          }     
+          }
           // delete it
           itemOf.remove()
         }
       }
 
       // is there admin metdata in the data? If so we need to insert that profile template into the pt
-      
+
       let adminMetadataCount = xml.getElementsByTagName('bf:adminMetadata').length
 
       if (adminMetadataCount>0){
@@ -387,8 +386,8 @@ const utilsParse = {
             break
           }
         }
-          
-        
+
+
         // adminMetadataCount
         pt['id_loc_gov_ontologies_bibframe_adminmetadata'] = {
           "mandatory": false,
@@ -420,7 +419,7 @@ const utilsParse = {
       if (tle == "bf:Work"){
         xml = this.sniffWorkRelationType(xml)
       }
-      
+
 
 
 
@@ -430,8 +429,8 @@ const utilsParse = {
       // at this point we have the main piece of the xml tree that has all our data
       // loop through properties we are looking for and build out the the profile
       for (let k in pt){
-        
-        
+
+
         let ptk = JSON.parse(JSON.stringify(pt[k]))
         // make sure each new one has a unique guid
         ptk['@guid'] = short.generate()
@@ -443,12 +442,12 @@ const utilsParse = {
         let propertyURI = ptk.propertyURI
         let prefixURI = this.namespaceUri(propertyURI)
 
-        // we only want top level elements, not nested things like dupe notes etc.                
+        // we only want top level elements, not nested things like dupe notes etc.
         let el = []
         for (let e of xml.children){
           if (this.UriNamespace(e.tagName) == propertyURI){
             // if it has a hint then we need to check if we can find the right pt for it
-            if (e.attributes['local:pthint'] && e.attributes['local:pthint'].value){              
+            if (e.attributes['local:pthint'] && e.attributes['local:pthint'].value){
               // check to see if this pt has that hint value in the valueConstraint  valueTemplateRefs
               if (ptk.valueConstraint.valueTemplateRefs.indexOf(e.attributes['local:pthint'].value) > -1){
                 // it matches, so use this one for sure
@@ -457,7 +456,7 @@ const utilsParse = {
                 // if it doesn't match that might mean there is a better match further in the pts or it could mean it will never match
                 // so look ahead and see, if there is a better match don't add it now and leave this el for that future pt
                 let foundPtToUse = false
-                for (let kCheck in pt){                  
+                for (let kCheck in pt){
                   if (pt[kCheck].valueConstraint.valueTemplateRefs.indexOf(e.attributes['local:pthint'].value) > -1){
                     // console.log("found a place for you in the future :)")
                     // console.log("here",pt[kCheck])
@@ -468,8 +467,8 @@ const utilsParse = {
                   // jump to the next el this one will get grabbed by the one it is suppose to use
                   continue
                 }else{
-                  // we did not find a place to put this el, so we need to add it here 
-                  el.push(e)                                    
+                  // we did not find a place to put this el, so we need to add it here
+                  el.push(e)
                 }
               }
             }else{
@@ -478,7 +477,7 @@ const utilsParse = {
             }
           }
         }
-        
+
 
         // Some structural things here to hardcode
         if (propertyURI==='http://id.loc.gov/ontologies/bibframe/Work'){
@@ -488,15 +487,15 @@ const utilsParse = {
               '@root': 'http://id.loc.gov/ontologies/bibframe/Work',
               '@guid': short.generate() ,
               '@id': profile.rt[pkey].URI,
-            }            
-          }          
+            }
+          }
           pt[k] = ptk
           continue
         }
 
 
 
-        // sometimes the profile has a rdf:type selectable in the profile itself, we probably 
+        // sometimes the profile has a rdf:type selectable in the profile itself, we probably
         // took that piece of data out eariler and set it at the RT level, so fake that userValue for this piece of
         // data in the properties because el will be empty
         if (profile.rt[pkey]['@type'] && propertyURI == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
@@ -522,7 +521,7 @@ const utilsParse = {
           ptk.hasData = true
           ptk.canBeHidden = false
           ptk.deepHierarchy = false
-          
+
           // loop through all of them
           let counter = 0
           for (let e of el){
@@ -548,7 +547,7 @@ const utilsParse = {
               }
 
 
-              // does it have a rdf type of that 
+              // does it have a rdf type of that
               for (let typeEl of e.getElementsByTagName('rdf:type')){
                 if (typeEl.attributes['rdf:resource']){
                 }
@@ -557,7 +556,7 @@ const utilsParse = {
                 }
                 if (typeEl.attributes['rdf:resource'] && typeEl.attributes['rdf:resource'].value == 'http://id.loc.gov/ontologies/bibframe/PrimaryContribution'){
                   isPrimaryContribXML = true
-                }                
+                }
               }
 
               // or is using the <bflc:PrimaryContribution> element
@@ -591,28 +590,28 @@ const utilsParse = {
             populateData.xmlSource = e.outerHTML
 
             populateData['@guid'] = short.generate()
-          
+
             // if (this.tempTemplates[hashCode(populateData.propertyURI + populateData.xmlSource)]){
-            //   populateData.valueConstraint.valueTemplateRefs.push(this.tempTemplates[hashCode(populateData.propertyURI + populateData.xmlSource)])              
+            //   populateData.valueConstraint.valueTemplateRefs.push(this.tempTemplates[hashCode(populateData.propertyURI + populateData.xmlSource)])
             // }
 
 
             // we want all userValues to includ the root predicate property
             // we will map that to the base level to make things cleaner below
-            // so populateData.userValue['http://id.loc.gov/bibframe/title'] becomes userValue              
+            // so populateData.userValue['http://id.loc.gov/bibframe/title'] becomes userValue
             populateData.userValue[populateData.propertyURI] = [{}]
             let userValue = populateData.userValue[populateData.propertyURI][0]
 
-            
+
             // we have some special functions to deal with tricky elements
             if (this.specialTransforms[prefixURI]){
               // make sure to pass the current 'this' context to the functions that use helper functions at this level like this.UriNamespace
-              populateData = this.specialTransforms[prefixURI].call(this,e,populateData)  
-              
+              populateData = this.specialTransforms[prefixURI].call(this,e,populateData)
 
-            }else if (e.children.length == 0){          
 
-              
+            }else if (e.children.length == 0){
+
+
               // if (!populateData.userValue){
                 userValue['@guid'] = short.generate()
               // }
@@ -620,9 +619,9 @@ const utilsParse = {
               let eProperty = this.UriNamespace(e.tagName)
 
               // could be a first level bnode with no children
-              
+
               if (this.isClass(e.tagName)){
-                
+
                 userValue['@type'] = this.UriNamespace(e.tagName)
 
                 // check for URI
@@ -635,7 +634,7 @@ const utilsParse = {
                 }
 
               }else if (this.UriNamespace(e.tagName) == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
-                
+
                 if (this.testSeperateRdfTypeProperty(populateData)){
                   console.warn("Need to account for rdf:type at this level.")
                 }
@@ -655,7 +654,7 @@ const utilsParse = {
 
 
               }else if (e.attributes['rdf:resource'] && e.innerHTML.trim() == ''){
-                
+
                 // it is a property pointing to another resource with no label or anything
                 userValue['@guid'] = short.generate()
                 userValue['@id'] = this.extractURI(e.attributes['rdf:resource'].value)
@@ -665,11 +664,11 @@ const utilsParse = {
                 //  {
                 //  "http://www.w3.org/2000/01/rdf-schema#label": userValue['@id'].split('/').slice(-1)[0],
                 //  "@guid": short.generate()
-                //  }               
+                //  }
                 // ]
 
               }else{
-                
+
 
 
                 if (!userValue[eProperty]){
@@ -690,7 +689,7 @@ const utilsParse = {
                 if (e.innerHTML != null && e.innerHTML.trim() != ''){
                   userValue[eProperty] = e.innerHTML
 
-                  // does it have a data type or lang                 
+                  // does it have a data type or lang
                   if (e.attributes && e.attributes['rdf:datatype']){
                     userValue['@datatype'] = e.attributes['rdf:datatype'].value
                   }
@@ -702,12 +701,12 @@ const utilsParse = {
                   }
                   if (e.attributes && e.attributes['rdf:parseType']){
                     userValue['@parseType'] = e.attributes['rdf:parseType'].value
-                  }                 
+                  }
 
 
                 }
 
-                
+
                 // console.log(userValue)
 
 
@@ -717,7 +716,7 @@ const utilsParse = {
 
 
 
-                    
+
             }else{
 
 
@@ -730,8 +729,8 @@ const utilsParse = {
               }
 
 
-              // loop through.... though don't really need to loop, 
-              // this is the main bnode <bf:title><bf:Title> 
+              // loop through.... though don't really need to loop,
+              // this is the main bnode <bf:title><bf:Title>
               for (let child of e.children){
 
                 // the inital bnode
@@ -741,7 +740,7 @@ const utilsParse = {
                 userValue['@type'] = this.UriNamespace(child.tagName)
 
                 // does this thing have a URI?
-                // <bf:title><bf:Title rdf:about="http://...."> 
+                // <bf:title><bf:Title rdf:about="http://....">
 
                 if (child.attributes && child.attributes['rdf:about']){
                   userValue['@id'] = this.extractURI(child.attributes['rdf:about'].value)
@@ -754,15 +753,15 @@ const utilsParse = {
                   // this is okay, it mostly won't
                 }
 
-                // now loop through all the children 
+                // now loop through all the children
                 for (let gChild of child.children){
 
 
                   if (this.UriNamespace(gChild.tagName) == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
-                    
+
                     if (this.testSeperateRdfTypeProperty(populateData)){
 
-                      // we have a patern, in notes for example, where we are storing the type in a single rdftype 
+                      // we have a patern, in notes for example, where we are storing the type in a single rdftype
                       // predicate and the don't want to change the orginal type. so look through the templates and see
                       // if that pt has a standalone rdf:type predicate defined, if so populate just that and don't overwrite
                       let rdfTypeUri = null
@@ -816,7 +815,7 @@ const utilsParse = {
                     let gChildProperty = this.UriNamespace(gChild.tagName)
 
 
-                    // if it a one liner Class w/ no children add it in as its own obj otherwise it is a 
+                    // if it a one liner Class w/ no children add it in as its own obj otherwise it is a
                     // literal or something
                     if (this.isClass(gChild.tagName)){
                       let gChildData = {'@guid': short.generate()}
@@ -842,8 +841,8 @@ const utilsParse = {
 
                       if (gChild.innerHTML != null && gChild.innerHTML.trim() != ''){
                         gChildData[gChildProperty] = gChild.innerHTML
-                        
-                        // does it have a data type or lang                 
+
+                        // does it have a data type or lang
                         if (gChild.attributes && gChild.attributes['rdf:datatype']){
                           gChildData['@datatype'] = gChild.attributes['rdf:datatype'].value
                         }
@@ -855,7 +854,7 @@ const utilsParse = {
                         }
                         if (gChild.attributes && gChild.attributes['rdf:parseType']){
                           gChildData['@parseType'] = gChild.attributes['rdf:parseType'].value
-                        } 
+                        }
 
                       }
 
@@ -865,7 +864,7 @@ const utilsParse = {
                     }
 
 
-                  
+
 
                   }else{
 
@@ -887,7 +886,7 @@ const utilsParse = {
 
 
 
-                      // if its a bnode then loop through the children, 
+                      // if its a bnode then loop through the children,
                       if (this.isClass(ggChild.tagName)){
 
                         // mint a new one for this iteration, since there could be multiple classes nested
@@ -907,7 +906,7 @@ const utilsParse = {
                         //       <bf:Identifier> ~~~~~~~~~~~~~YOU ARE HERE ~~~~~~~~~~~~
                         //         <rdf:value>fst01920007</rdf:value>
                         //         <bf:source>
-                        //           <bf:Source> 
+                        //           <bf:Source>
                         //             <bf:code>OCoLC</bf:code>
                         //           </bf:Source>
                         //         </bf:source>
@@ -934,7 +933,7 @@ const utilsParse = {
                         // now loop through these ggchildren, they are properties of this bnode
                         for (let gggChild of ggChild.children){
 
-                          // not a bnode, just a one liner property of the bnode      
+                          // not a bnode, just a one liner property of the bnode
                           if (this.UriNamespace(gggChild.tagName) == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
 
 
@@ -971,7 +970,7 @@ const utilsParse = {
 
                               if (gggChild.innerHTML != null && gggChild.innerHTML.trim() != ''){
                                 gggChildData[gggChildProperty] = gggChild.innerHTML
-                                // does it have a data type or lang                 
+                                // does it have a data type or lang
                                 if (gggChild.attributes && gggChild.attributes['rdf:datatype']){
                                   gggChildData['@datatype'] = gggChild.attributes['rdf:datatype'].value
                                 }
@@ -983,7 +982,7 @@ const utilsParse = {
                                 }
                                 if (gggChild.attributes && gggChild.attributes['rdf:parseType']){
                                   gggChildData['@parseType'] = gggChild.attributes['rdf:parseType'].value
-                                } 
+                                }
 
 
                               }
@@ -1055,7 +1054,7 @@ const utilsParse = {
                                 // now loop through this bnodes descendants
                                 for (let gggggChild of ggggChild.children){
 
-                                  
+
 
                                   if (this.UriNamespace(gggggChild.tagName) == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
 
@@ -1093,8 +1092,8 @@ const utilsParse = {
 
                                       if (gggggChild.innerHTML != null && gggggChild.innerHTML.trim() != ''){
                                         ggggChildData[gggggChildProperty] = gggggChild.innerHTML
-                                        
-                                        // does it have a data type or lang                 
+
+                                        // does it have a data type or lang
                                         if (gggggChild.attributes && gggggChild.attributes['rdf:datatype']){
                                           ggggChildData['@datatype'] = gggggChild.attributes['rdf:datatype'].value
                                         }
@@ -1106,7 +1105,7 @@ const utilsParse = {
                                         }
                                         if (gggggChild.attributes && gggggChild.attributes['rdf:parseType']){
                                           ggggChildData['@parseType'] = gggggChild.attributes['rdf:parseType'].value
-                                        } 
+                                        }
 
 
                                       }
@@ -1130,7 +1129,7 @@ const utilsParse = {
 
                                     for (let g6Child of gggggChild.children){
                                       // console.log("Doing",g6Child.tagName)
-                                      
+
 
                                       if (this.isClass(g6Child.tagName)){
 
@@ -1176,10 +1175,10 @@ const utilsParse = {
                                             if (!g5ChildData[g7ChildProperty]){
                                               g5ChildData[g7ChildProperty] = []
                                             }
-      
+
                                             // it doesn't have any children, so it will be a literal or something like that
                                             let g6ChildData = {'@guid': short.generate()}
-      
+
                                             if (g7Child.attributes && g7Child.attributes['rdf:about']){
                                               g6ChildData['@id'] = this.extractURI(g7Child.attributes['rdf:about'].value)
                                             }else if (g6ChildData.attributes && g7Child.attributes['rdf:resource']){
@@ -1187,11 +1186,11 @@ const utilsParse = {
                                             }else{
                                               // console.log('No URI for this child property')
                                             }
-      
+
                                             if (g7Child.innerHTML != null && g7Child.innerHTML.trim() != ''){
                                               g6ChildData[g7ChildProperty] = g7Child.innerHTML
-                                              
-                                              // does it have a data type or lang                 
+
+                                              // does it have a data type or lang
                                               if (g7Child.attributes && g7Child.attributes['rdf:datatype']){
                                                 g6ChildData['@datatype'] = g7Child.attributes['rdf:datatype'].value
                                               }
@@ -1203,11 +1202,11 @@ const utilsParse = {
                                               }
                                               if (g7Child.attributes && g7Child.attributes['rdf:parseType']){
                                                 g6ChildData['@parseType'] = g7Child.attributes['rdf:parseType'].value
-                                              } 
-      
-      
+                                              }
+
+
                                             }
-      
+
                                             g5ChildData[g7ChildProperty].push(g6ChildData)
 
 
@@ -1226,7 +1225,7 @@ const utilsParse = {
                                             if (!g5ChildData[g7ChildProperty]){
                                               g5ChildData[g7ChildProperty] = []
                                             }
-                                            
+
                                             if (g7Child.children.length>0){
 
                                               // now loop through this bnodes descendants
@@ -1235,13 +1234,13 @@ const utilsParse = {
                                                 // console.log("Looking at",g8Child)
 
                                                 if (this.isClass(g8Child.tagName)){
-                                                  // its a class build a blank node                                             
+                                                  // its a class build a blank node
                                                 }else{
 
                                                 }
 
 
-                                              }                                              
+                                              }
 
                                             }else{
 
@@ -1249,10 +1248,10 @@ const utilsParse = {
 
 
                                             }
-                                            
 
 
-                                            
+
+
 
 
 
@@ -1265,7 +1264,7 @@ const utilsParse = {
 
 
                                             // for (let ggggChild of gggChild.children){
-                                            
+
 
 
                                           }
@@ -1288,14 +1287,14 @@ const utilsParse = {
 
                                     }
 
-                                    
+
                                     gggData[g5ChildProperty].push(g5ChildData)
 
 
                                   }
 
-                                }                              
-                                
+                                }
+
 
                               }else{
 
@@ -1315,13 +1314,13 @@ const utilsParse = {
                                 }else{
                                   // console.log('No URI for this child property')
                                 }
-                                
+
                                 let ggggChildData = {'@guid': short.generate()}
 
                                 if (ggggChild.innerHTML != null && ggggChild.innerHTML.trim() != ''){
                                   ggggChildData[ggggChildProperty] = ggggChild.innerHTML
 
-                                  // does it have a data type or lang                 
+                                  // does it have a data type or lang
                                   if (ggggChild.attributes && ggggChild.attributes['rdf:datatype']){
                                     ggggChildData['@datatype'] = ggggChild.attributes['rdf:datatype'].value
                                   }
@@ -1333,7 +1332,7 @@ const utilsParse = {
                                   }
                                   if (ggggChild.attributes && ggggChild.attributes['rdf:parseType']){
                                     ggggChildData['@parseType'] = ggggChild.attributes['rdf:parseType'].value
-                                  } 
+                                  }
 
 
                                 }
@@ -1391,7 +1390,7 @@ const utilsParse = {
 
                             if (ggChild.innerHTML != null && ggChild.innerHTML.trim() != ''){
                               ggChildData[ggChildProperty] = ggChild.innerHTML
-                              // does it have a data type or lang                 
+                              // does it have a data type or lang
                               if (ggChild.attributes && ggChild.attributes['rdf:datatype']){
                                 ggChildData['@datatype'] = ggChild.attributes['rdf:datatype'].value
                               }
@@ -1403,7 +1402,7 @@ const utilsParse = {
                               }
                               if (ggChild.attributes && ggChild.attributes['rdf:parseType']){
                                 ggChildData['@parseType'] = ggChild.attributes['rdf:parseType'].value
-                              } 
+                              }
 
 
                             }
@@ -1426,14 +1425,14 @@ const utilsParse = {
                       }
 
                     }
-                    // when there are multiple nested bnodes we take 
+                    // when there are multiple nested bnodes we take
                     // care of adding them to the structure above
                     // and then set the last one to false
-                    // so dont add 
+                    // so dont add
                     if (gChildData !== false){
-                      userValue[gChildProperty].push(gChildData)  
+                      userValue[gChildProperty].push(gChildData)
                     }
-                    
+
 
                   }
                 }
@@ -1441,15 +1440,15 @@ const utilsParse = {
               }
             }
 
-            sucessfulElements.push(e.outerHTML)          
+            sucessfulElements.push(e.outerHTML)
 
-            // since we created a brand new populateData we either need to 
-            // replace the orginal in the profile or if there is more than one we 
+            // since we created a brand new populateData we either need to
+            // replace the orginal in the profile or if there is more than one we
             // need to make a new one and add it to the resource template list
             // since each piece of data in the property is its own resource template
 
-            if (counter === 0){              
-              pt[k] = populateData              
+            if (counter === 0){
+              pt[k] = populateData
             }else{
 
               let newKey = `${k}_${counter}`
@@ -1461,26 +1460,26 @@ const utilsParse = {
             }
 
 
-            
-            // do a little sanity check here, loop through and 
+
+            // do a little sanity check here, loop through and
             userValue = this.removeEmptyBnodes(userValue)
-            
+
 
 
             counter++
 
           }
 
-        }        
-        
+        }
+
         // we did something with it, so remove it from the xml
         // doing this inside the loop because some PT use the same element (like primary contribuitor vs contributor)
 
         for (let p of sucessfulProperties){
           let els = xml.getElementsByTagName(p)
           // this is a strange loop here because we need to remvoe elements without changing the parent order which will mess up the dom tree and the loop
-          for (let step = els.length-1; step >= 0; step=step-1) {            
-            
+          for (let step = els.length-1; step >= 0; step=step-1) {
+
             if (sucessfulElements.indexOf(els[step].outerHTML)> -1){
               els[step].remove()
             }
@@ -1491,7 +1490,7 @@ const utilsParse = {
 
       }
 
-      // store the unused xml     
+      // store the unused xml
       profile.rt[pkey].unusedXml = xml.outerHTML;
       if (xml.children.length == 0){
         profile.rt[pkey].unusedXml = false
@@ -1506,7 +1505,7 @@ const utilsParse = {
 
           if (!profile.rt[pkey].pt[key].userValue['http://id.loc.gov/ontologies/bibframe/adminMetadata']){
             profile.rt[pkey].pt[key].userValue['http://id.loc.gov/ontologies/bibframe/adminMetadata'] = [{}]
-          }         
+          }
           let userValue = profile.rt[pkey].pt[key].userValue['http://id.loc.gov/ontologies/bibframe/adminMetadata'][0]
 
           // // if it doesnt already have a cataloger id use ours
@@ -1529,14 +1528,14 @@ const utilsParse = {
 
           // using MARC2BF rules 2.6+ we need to find the admin metadata that does not have a status
           // that will be our primary adminMetadat that they edit
-          
+
           if (userValue){
             if (!userValue['http://id.loc.gov/ontologies/bibframe/status']){
               profile.rt[pkey].pt[key].adminMetadataType = 'primary'
               adminMedtataPrimary = key
             }else{
               profile.rt[pkey].pt[key].adminMetadataType = 'secondary'
-              
+
               let useDate = "00000000"
               if (userValue['http://id.loc.gov/ontologies/bibframe/date'] && userValue['http://id.loc.gov/ontologies/bibframe/date'][0]){
                 if (userValue['http://id.loc.gov/ontologies/bibframe/date'][0]['http://id.loc.gov/ontologies/bibframe/date']){
@@ -1556,19 +1555,19 @@ const utilsParse = {
                 console.warn('Cant parse date',useDate)
                 useDate = 0
               }
-              
-              adminMedtataSecondary.push({key:key,date:useDate})
-              
-              
-              
-              
-              
 
-              
+              adminMedtataSecondary.push({key:key,date:useDate})
+
+
+
+
+
+
+
             }
           }
         }
-        
+
         // if we have multiple types of adminMetadata we want to reorder them
         if (adminMedtataPrimary && adminMedtataSecondary.length>0){
           // first remove all of them from the order
@@ -1585,7 +1584,7 @@ const utilsParse = {
 
         }
 
-        
+
 
 
         // we can potentailly prevent some xml errors from propagating further here
@@ -1599,7 +1598,7 @@ const utilsParse = {
         //    // delete profile.rt[pkey].pt[key].userValue['@type']
         //    console.log('----------x_x-----------')
         //    console.log(profile.rt[pkey].pt[key].userValue)
-        //    console.log('---------------------')            
+        //    console.log('---------------------')
 
 
         //  }
@@ -1617,13 +1616,13 @@ const utilsParse = {
 
 
       }
-      
+
 
       let uniquePropertyURIs  = {}
       // we are now going to do some ananlyis on profile, see how many properties are acutally used, what is not used, etc
       // also do some post-load data cleanup (like &amp; -> &)
       for (let key in profile.rt[pkey].pt){
-        
+
         if (Object.keys(uniquePropertyURIs).indexOf(profile.rt[pkey].pt[key].propertyURI)===-1){
           uniquePropertyURIs[profile.rt[pkey].pt[key].propertyURI] = {status:false,data:[],resourceTemplates:{},unAssingedProperties:[]}
         }
@@ -1658,9 +1657,9 @@ const utilsParse = {
             if (Array.isArray(profile.rt[pkey].pt[key].userValue[k])){
               for (let kItem of profile.rt[pkey].pt[key].userValue[k]){
 
-                
+
                 for (let kItemKey in kItem){
-                  
+
 
                   if (kItemKey == 'http://www.w3.org/2000/01/rdf-schema#label'){
 
@@ -1676,7 +1675,7 @@ const utilsParse = {
                       }
                     }
 
-                    
+
                   }
 
 
@@ -1708,16 +1707,16 @@ const utilsParse = {
                 allUris.push(ptObj.propertyURI)
               }
 
-            })  
+            })
           })
 
-          
+
           profile.rt[pkey].pt[key].missingProfile = []
           // loop though the URIs we have
           Object.keys(profile.rt[pkey].pt[key].userValue).forEach((userURI)=>{
             if (!userURI.includes('@')){
               if (allUris.indexOf(userURI)===-1){
-                
+
                 profile.rt[pkey].pt[key].missingProfile.push(userURI)
 
                 uniquePropertyURIs[profile.rt[pkey].pt[key].propertyURI].unAssingedProperties.push(userURI)
@@ -1740,7 +1739,7 @@ const utilsParse = {
         }
       }
 
-      
+
 
 
 
@@ -1748,8 +1747,8 @@ const utilsParse = {
 
       profile.rt[pkey].propertyLoadRatio = parseInt(Object.keys(uniquePropertyURIs).filter((k)=>uniquePropertyURIs[k].status).length /Object.keys(uniquePropertyURIs).length * 100)
 
-      
-      
+
+
       // remove it for the next item if there is one
       if (tle == 'bf:Item' || tle == 'bf:Instance'){
         console.log('Done processing XML fragment, removing',xml)
@@ -1762,7 +1761,7 @@ const utilsParse = {
 
     // these RTs did not have any data parsed into them, because they were not present
     for (let x of toDeleteNoData){
-      profile.rt[x].noData=true     
+      profile.rt[x].noData=true
     }
     console.log("profileprofileprofileprofile",JSON.parse(JSON.stringify(profile)))
 
@@ -1777,8 +1776,8 @@ const utilsParse = {
 
 
   /**
-  * Will take a profile obj and make sure the Works have a hasInstance and the Instances have instanceOf 
-  * 
+  * Will take a profile obj and make sure the Works have a hasInstance and the Instances have instanceOf
+  *
   * @param {object} profile - profile object
   * @return {object} - the updated profile
   */
@@ -1816,19 +1815,19 @@ const utilsParse = {
       if (k.indexOf(':Instance')>-1){
 
         for (let pk in useProfile.rt[k].pt){
-          
+
           if (useProfile.rt[k].pt[pk].propertyURI == 'http://id.loc.gov/ontologies/bibframe/instanceOf'){
             if (!useProfile.rt[k].pt[pk].userValue['http://id.loc.gov/ontologies/bibframe/instanceOf']){
               useProfile.rt[k].pt[pk].userValue['http://id.loc.gov/ontologies/bibframe/instanceOf'] = []
-            }            
+            }
             useProfile.rt[k].pt[pk].userValue['http://id.loc.gov/ontologies/bibframe/instanceOf'].push(
               {
                 "@guid": short.generate(),
                 "@id": workUri
-              })           
+              })
           }
-        }     
-      
+        }
+
       }else if (k.indexOf(':Work')>-1){
 
         for (let pk in useProfile.rt[k].pt){
@@ -1836,20 +1835,20 @@ const utilsParse = {
           if (useProfile.rt[k].pt[pk].propertyURI == 'http://id.loc.gov/ontologies/bibframe/hasInstance'){
             if (!useProfile.rt[k].pt[pk].userValue['http://id.loc.gov/ontologies/bibframe/hasInstance']){
               useProfile.rt[k].pt[pk].userValue['http://id.loc.gov/ontologies/bibframe/hasInstance'] = []
-            }       
+            }
             for (let i of instanceUris){
 
-            
+
             useProfile.rt[k].pt[pk].userValue['http://id.loc.gov/ontologies/bibframe/hasInstance'].push(
               {
                 "@guid": short.generate(),
                 "@id": i
-              })           
+              })
             }
           }
         }
 
-      
+
       }
     }
 
@@ -1866,7 +1865,7 @@ const utilsParse = {
       if (Array.isArray(userValue[key])){
         let newArray = []
         for (let arrayObj of userValue[key]){
-          if (typeof arrayObj === 'object' && !Array.isArray(arrayObj) && arrayObj !== null){            
+          if (typeof arrayObj === 'object' && !Array.isArray(arrayObj) && arrayObj !== null){
             if (Object.keys(arrayObj).length==1){
               console.log("Bad obj->",arrayObj)
             }else{
@@ -1874,8 +1873,8 @@ const utilsParse = {
             }
             // console.log("Is arrayObj object ===>",arrayObj)
           }
-        }      
-        userValue[key] = newArray  
+        }
+        userValue[key] = newArray
       }
     }
 
@@ -1900,7 +1899,7 @@ const utilsParse = {
 
 
 
-  
+
 
 }
 

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -12,11 +12,11 @@ const utilsProfile = {
 
   /**
   * Returns the piece of the the userValue passed that contains the given @guid
-  * 
+  *
   * @param {object} obj - the object, most likely the userValue
   * @param {string} guid - the guid to search for
   * @return {object|boolean} - will return the obj or false if not found
-  */    
+  */
   returnGuidLocation: function(obj,guid){
     // use a pattern that looks at many possible levels down for a @guid
     let foundPos = objectScan(['*.**.@guid,*.**.@guid.**.@guid,*.**.@guid.**.@guid.**.@guid,*.**.@guid.**.@guid.**.@guid.**.@guid'])(obj);
@@ -27,7 +27,7 @@ const utilsProfile = {
       // and pointerParent will be the object containing that @guid
       let pointerParent = null
       for (let pos of fp){
-        
+
         pointerParent = pointer
         // if the guid was not in the hiearchy at some point this pointer will be undefined and we can kick back a false
         if (typeof pointer ==='undefined'){
@@ -48,11 +48,11 @@ const utilsProfile = {
 
   /**
   * Returns the parent of the node with that guid
-  * 
+  *
   * @param {object} obj - the object, most likely the userValue
   * @param {string} guid - the guid to search for
   * @return {object|boolean} - will return the obj or false if not found
-  */    
+  */
   returnGuidParent: function(obj,guid){
     // use a pattern that looks at many possible levels down for a @guid
     let foundPos = objectScan(['*.**.@guid,*.**.@guid.**.@guid,*.**.@guid.**.@guid.**.@guid,*.**.@guid.**.@guid.**.@guid.**.@guid'])(obj);
@@ -66,7 +66,7 @@ const utilsProfile = {
       // let pointerGrandParent = null
       let pointerHistory = []
       for (let pos of fp){
-        
+
         // pointerGrandParent = pointerParent
         // pointerParent = pointer
         // if the guid was not in the hiearchy at some point this pointer will be undefined and we can kick back a false
@@ -91,14 +91,14 @@ const utilsProfile = {
           // else if (pointerHistory[pointerHistory.length-1]){
           //   // if (Array.isArray(pointerHistory[pointerHistory.length-2]) == true){
           //   //   pointerHistory[pointerHistory.length-2] = pointerHistory[pointerHistory.length-2][0]
-          //   // } 
+          //   // }
           //   return pointerHistory[pointerHistory.length-1]
           // }
 
-          
+
         }else{
           // add it to the history if we didn't just find it
-          pointerHistory.push(pointer[pos])          
+          pointerHistory.push(pointer[pos])
           pointer = pointer[pos]
         }
 
@@ -117,13 +117,13 @@ const utilsProfile = {
 
   /**
   * Returns the piece profile passed to find the sepcific PT requested regardless of RT
-  * 
+  *
   * @param {object} prfoile - the object, most likely the activeProfile
   * @param {string} guid - the guid to search for
   * @return {object|boolean} - will return the obj or false if not found
-  */    
+  */
   returnPt: function(profile,guid){
-      
+
       for (let rt in profile.rt){
         for (let pt in profile.rt[rt].pt){
           if (profile.rt[rt].pt[pt]['@guid'] === guid){
@@ -143,7 +143,7 @@ const utilsProfile = {
   * @param {object} pt - the pt field for that component
   * @param {array} propertyPath - the array of URI strings that points to the place to build the blank node obj
   * @return {number} - will return the count
-  */    
+  */
   countValues: function(pt,propertyPath){
       // link to the base userValue
       let pointer = pt.userValue
@@ -154,10 +154,10 @@ const utilsProfile = {
           return counter
         }else{
           // if this is the last property in the list then take the count at the end of it
-          if (p === propertyPath[propertyPath.length-1].propertyURI){            
+          if (p === propertyPath[propertyPath.length-1].propertyURI){
             counter = pointer[p].length
           }else{
-            if (pointer[p][0]){            
+            if (pointer[p][0]){
               pointer = pointer[p][0]
             }else{
               return counter
@@ -179,7 +179,7 @@ const utilsProfile = {
   * @param {object} pt - the pt field for that component
   * @param {array} propertyPath - the array of URI strings that points to the place to build the blank node obj
   * @return {object|boolean} - the position in the pt hiearchy or false
-  */    
+  */
   returnPropertyPathParent: function(pt,propertyPath){
       // link to the base userValue
       let pointer = pt.userValue
@@ -190,10 +190,10 @@ const utilsProfile = {
           return false
         }else{
           // if this is the last property in the list then take the count at the end of it
-          if (p === propertyPath[propertyPath.length-1].propertyURI){            
+          if (p === propertyPath[propertyPath.length-1].propertyURI){
             return pointer
           }else{
-            if (pointer[p][0]){            
+            if (pointer[p][0]){
               pointer = pointer[p][0]
             }else{
               return false
@@ -214,15 +214,15 @@ const utilsProfile = {
   * @param {object} pt - the pt field for that component
   * @param {array} propertyPath - the array of URI strings that points to the place to build the blank node obj
   * @return {array} - will return an array with the pt as 0 and the new @guid of the blanknode as 1
-  */    
+  */
   buildBlanknode: function(pt,propertyPath){
-      
+
       // link to the base userValue
       let pointer = pt.userValue
 
       for (let p of propertyPath){
 
-        // the property path has two parts 
+        // the property path has two parts
         // {level: 0, propertyURI: 'http://id.loc.gov/ontologies/bibframe/title'}
         // we don't care about the level number so just overwrite it
         p = p.propertyURI
@@ -248,7 +248,7 @@ const utilsProfile = {
             // console.log("Linink to",pointer[p][0])
             pointer = pointer[p][0]
           }else{
-            console.error("Trying to link to a level in userValue and unable to find it", p, 'of', propertyPath, 'in', pt)  
+            console.error("Trying to link to a level in userValue and unable to find it", p, 'of', propertyPath, 'in', pt)
           }
         }
 
@@ -257,7 +257,7 @@ const utilsProfile = {
       if (!pointer || !pointer['@guid']){
         console.error("There was an unknown error trying to create a blank node in", propertyPath, ' in ', pt)
       }
-      
+
       this.setTypesForBlankNode(pt,propertyPath)
       console.log("Return pointer to blank node now")
       return [pt, pointer['@guid']]
@@ -265,13 +265,13 @@ const utilsProfile = {
 
 
   /**
-  * Called from buildBlanknode to build the @types for a userValue it is a seperate function to allow it to run 
+  * Called from buildBlanknode to build the @types for a userValue it is a seperate function to allow it to run
   * without blocking the creation of the blanknode which lags data input if we had to wait around why deciding the @types for the node
   * @async
   * @param {object} pt - the pt field for that component
   * @param {array} propertyPath - the array of URI strings that points to the place to build the blank node obj
   * @return {void} - doesn't return anything it works on the reference to the pt.userValue updating the orginal
-  */    
+  */
   setTypesForBlankNode: async function(pt, propertyPath){
     let pointer = pt.userValue
     for (let p of propertyPath){
@@ -287,24 +287,24 @@ const utilsProfile = {
         if (type === false){
           // did not find it in the profile, look to the network
           type = await utilsRDF.suggestTypeNetwork(p)
-        } 
+        }
         if (type !== false){
-          // first we test to see if the type is a literal, if so then we 
+          // first we test to see if the type is a literal, if so then we
           // don't need to set the type, as its not a blank node, just a nested property
           if (utilsRDF.isUriALiteral(type) === false){
             // if it doesn't yet have a type then go ahead and set it
             if (!pointer[p][0]['@type']){
-              pointer[p][0]['@type'] = type  
+              pointer[p][0]['@type'] = type
             }
           }else{
             // nothing to do, its a literal
           }
         }else{
-          console.error("Could not find type for this property", p, 'of', propertyPath, 'in', pt)  
+          console.error("Could not find type for this property", p, 'of', propertyPath, 'in', pt)
         }
         pointer = pointer[p][0]
       }else{
-        console.error("Trying to link to a level in userValue and unable to find it", p, 'of', propertyPath, 'in', pt)  
+        console.error("Trying to link to a level in userValue and unable to find it", p, 'of', propertyPath, 'in', pt)
       }
     }
   },
@@ -315,7 +315,7 @@ const utilsProfile = {
   * @param {object} pt - the pt field for that component
   * @param {array} propertyPath - the array of URI strings that points to the place to build the blank node obj
   * @return {array} - will return the value array at the end of the property path if it exists
-  */    
+  */
   returnValueFromPropertyPath: function(pt,propertyPath){
 
       let deepestLevel = propertyPath[propertyPath.length-1].level
@@ -323,9 +323,9 @@ const utilsProfile = {
       let pointer = pt.userValue
       for (let p of propertyPath){
 
-        // the property path has two parts 
+        // the property path has two parts
         // {level: 0, propertyURI: 'http://id.loc.gov/ontologies/bibframe/title'}
-        
+
         // navigates the property
         if (pointer[p.propertyURI]){
 
@@ -335,7 +335,7 @@ const utilsProfile = {
               console.warn("Expecting there to be at least one value here: ", pt, p, propertyPath)
             }
 
-            // if this is the last level then return the whole array, if we are continuing 
+            // if this is the last level then return the whole array, if we are continuing
             // down the hiearchy then just select the first element, as we don't support multiple values at the early levels
             if (p.level !== deepestLevel){
               pointer = pointer[p.propertyURI][0]
@@ -367,13 +367,13 @@ const utilsProfile = {
 
 
   /**
-  * Loops through a uservalue and looks for properties that have children that 
+  * Loops through a uservalue and looks for properties that have children that
   * only have a @guid and/or a @type but no other data, an empty blank node
   * @param {object} userValue - the userValue
   * @return {object} - will return the userValue pruned
-  */    
+  */
   pruneUserValue: function(userValue){
-      
+
     for (let key in userValue){
 
       if (Array.isArray(userValue[key])){
@@ -408,7 +408,7 @@ const utilsProfile = {
         if (!hasData){
           console.log(key,'does not have data')
           delete userValue[key]
-        }      
+        }
       }
     }
       return userValue
@@ -417,10 +417,10 @@ const utilsProfile = {
 
   /**
   * Loads a record from the marva backend store and parses the XML into the profile
-  * 
+  *
   * @param {string} recordId - the userValue
   * @return {object} - the profile
-  */ 
+  */
   loadRecordFromBackend: async function(recordId){
     console.log(recordId)
     let xml = await utilsNetwork.loadSavedRecord(recordId)
@@ -428,8 +428,8 @@ const utilsProfile = {
     let meta = this.returnMetaFromSavedXML(xml)
     console.log(meta.xml)
 
-    
-    
+
+
     utilsParse.parseXml(meta.xml)
 
     // alert(parseBfdb.hasItem)
@@ -444,17 +444,17 @@ const utilsProfile = {
     }
 
     // we might need to load in a item
-    if (utilsParse.hasItem>0){       
+    if (utilsParse.hasItem>0){
       let useItemRtLabel
       // look for the RT for this item
       let instanceId = meta.rts.filter((id)=>{ return id.includes(':Instance')  })
       if (instanceId.length>0){
-        useItemRtLabel = instanceId[0].replace(':Instance',':Item')          
+        useItemRtLabel = instanceId[0].replace(':Instance',':Item')
       }
       if (!useItemRtLabel){
         let instanceId = meta.rts.filter((id)=>{ return id.includes(':Work')  })
         if (instanceId.length>0){
-          useItemRtLabel = instanceId[0].replace(':Work',':Item')          
+          useItemRtLabel = instanceId[0].replace(':Work',':Item')
         }
 
       }
@@ -464,32 +464,32 @@ const utilsProfile = {
               if (rtkey == useItemRtLabel){
                 let useItem = JSON.parse(JSON.stringify(useProfileStore().profiles[pkey].rt[rtkey]))
                 useProfile.rtOrder.push(useItemRtLabel+'-'+step)
-                useProfile.rt[useItemRtLabel+'-'+step] = useItem                
+                useProfile.rt[useItemRtLabel+'-'+step] = useItem
               }
             }
           }
 
 
 
-      }         
+      }
 
-      
+
 
 
     }
 
-    
-    
+
+
     if (!useProfile.log){
       useProfile.log = []
-    
+
     }
     useProfile.log.push({action:'loadInstanceFromSave',from:meta.eid})
     // useProfile.procInfo= "update instance"
 
 
     useProfile.procInfo = meta.procInfo
-    
+
     // console.log('meta',meta)
 
     // also give it an ID for storage
@@ -497,7 +497,7 @@ const utilsProfile = {
     useProfile.user = meta.user
     useProfile.status = meta.status
 
-    
+
     let transformResults  = await utilsParse.transformRts(useProfile)
 
     transformResults = this.reorderRTOrder(transformResults)
@@ -513,10 +513,10 @@ const utilsProfile = {
   /**
   * Pass it a profile and it will reorder the rtOrder array abased on how it should flow
   * Work->Instance1->Item1,Item2->Instance2-Item2-1,etc..
-  * 
+  *
   * @param {object} profile - the profile
   * @return {object} - the profile
-  */ 
+  */
   reorderRTOrder: function(profile){
       //build an item lookup
       let itemLookup = {}
@@ -528,7 +528,7 @@ const utilsProfile = {
                   itemLookup[rt] = profile.rt[rt].itemOf
               }else{
                   console.warn('Cannot find the itemOf of this item',rt)
-              }                
+              }
           }
       }
 
@@ -542,16 +542,16 @@ const utilsProfile = {
 
           if (rt.includes(':Instance')){
 
-              
-              // add itself in 
+
+              // add itself in
               newOrder.push(rt)
               let thisInstanceURI = profile.rt[rt].URI
 
               // then look for its items
               for (let k in itemLookup){
                   if (itemLookup[k] == thisInstanceURI){
-                      
-                      newOrder.push(k)                        
+
+                      newOrder.push(k)
                   }
               }
           }
@@ -589,7 +589,7 @@ const utilsProfile = {
 
 
 
-  returnMetaFromSavedXML: function(xml){      
+  returnMetaFromSavedXML: function(xml){
 
       let parser = new DOMParser();
       xml = parser.parseFromString(xml, "text/xml");

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -324,7 +324,7 @@ export const useConfigStore = defineStore('config', {
 				{
 					'LCNAF Geographic':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&count=25&offset=<OFFSET>"},
 					'LCSH Geographic':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings&count=25&offset=<OFFSET>"},
-					'GACS':{"url":"https://id.loc.gov/vocabulary/geographicAreas/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
+					//'GACS':{"url":"https://id.loc.gov/vocabulary/geographicAreas/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
 				}
 			]
 		},

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -13,11 +13,12 @@ export const useConfigStore = defineStore('config', {
       dev:{
 
         ldpjs : 'http://localhost:9401/api-staging/',
-        util  : 'http://localhost:9401/util/',
+        //util  : 'http://localhost:9401/util/',
+        util  : 'http://localhost:5200/',
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',
         publish : 'http://localhost:9401/util/publish/staging',
-        validate: 'http://localhost:5200/util/validate',
+        validate: 'http://localhost:5200/validate',
         bfdb : 'https://preprod-8230.id.loc.gov/',
         shelfListing: 'https://preprod-8230.id.loc.gov/',
         profiles : 'http://localhost:9401/util/profiles/profile/prod',

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1847,12 +1847,18 @@ export const useProfileStore = defineStore('profile', {
             blankNode["http://www.loc.gov/mads/rdf/v1#code"] = [
               {
                 '@guid': short.generate(),
-                'http://www.loc.gov/mads/rdf/v1#code':
-                  [{
-                    '@type': 'http://www.loc.gov/mads/rdf/v1#code',
-                    "@about": "https://id.loc.gov/vocabulary/geographicAreas/" + nodeMap["GAC(s)"][0].replace(/---/g, ""),
-                    "http://www.loc.gov/mads/rdf/v1#code": nodeMap["GAC(s)"][0]
-                  }]
+                "@id": "https://id.loc.gov/vocabulary/geographicAreas/" + nodeMap["GAC(s)"][0].replace(/---/g, ""),
+                'http://www.loc.gov/mads/rdf/v1#code': nodeMap["GAC(s)"][0]
+
+
+
+                // [
+                //   {
+                //     '@type': 'http://www.loc.gov/mads/rdf/v1#code',
+                //     "@about": "https://id.loc.gov/vocabulary/geographicAreas/" + nodeMap["GAC(s)"][0].replace(/---/g, ""),
+                //     "http://www.loc.gov/mads/rdf/v1#code": nodeMap["GAC(s)"][0]
+                //   }
+                // ]
               }
             ]
           }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1847,7 +1847,7 @@ export const useProfileStore = defineStore('profile', {
             blankNode["http://www.loc.gov/mads/rdf/v1#code"] = [
               {
                 '@guid': short.generate(),
-                "@id": "https://id.loc.gov/vocabulary/geographicAreas/" + nodeMap["GAC(s)"][0].replace(/---/g, ""),
+                "@gacs": "http://id.loc.gov/datatypes/codes/gac",
                 'http://www.loc.gov/mads/rdf/v1#code': nodeMap["GAC(s)"][0]
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1849,16 +1849,6 @@ export const useProfileStore = defineStore('profile', {
                 '@guid': short.generate(),
                 "@gacs": "http://id.loc.gov/datatypes/codes/gac",
                 'http://www.loc.gov/mads/rdf/v1#code': nodeMap["GAC(s)"][0]
-
-
-
-                // [
-                //   {
-                //     '@type': 'http://www.loc.gov/mads/rdf/v1#code',
-                //     "@about": "https://id.loc.gov/vocabulary/geographicAreas/" + nodeMap["GAC(s)"][0].replace(/---/g, ""),
-                //     "http://www.loc.gov/mads/rdf/v1#code": nodeMap["GAC(s)"][0]
-                //   }
-                // ]
               }
             ]
           }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -117,7 +117,6 @@ export const useProfileStore = defineStore('profile', {
     */
     async buildProfiles() {
 
-
       const config = useConfigStore()
 
       let profileData;
@@ -1728,7 +1727,7 @@ export const useProfileStore = defineStore('profile', {
           let source = null
           if (URI && URI.indexOf('/fast/') >1){
             source = 'FAST'
-          } 
+          }
 
 
 
@@ -1790,9 +1789,7 @@ export const useProfileStore = defineStore('profile', {
 
     * @return {void}
     */
-    setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type){
-
-
+    setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null){
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -1802,8 +1799,6 @@ export const useProfileStore = defineStore('profile', {
       // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
-
-      
       if (!type && URI){
         // I regretfully inform you we will need to look this up
         let context = await utilsNetwork.returnContext(URI)
@@ -1846,6 +1841,29 @@ export const useProfileStore = defineStore('profile', {
               'http://www.w3.org/2000/01/rdf-schema#label' : label
             }
           ]
+
+          //Add gacs code to user data
+          if (nodeMap["GAC(s)"]){
+            blankNode["http://www.loc.gov/mads/rdf/v1#code"] = [
+              {
+                '@guid': short.generate(),
+                'http://www.loc.gov/mads/rdf/v1#code':
+                  [{
+                    '@type': 'http://www.loc.gov/mads/rdf/v1#code',
+                    "@about": "https://id.loc.gov/vocabulary/geographicAreas/" + nodeMap["GAC(s)"][0].replace(/---/g, ""),
+                    "http://www.loc.gov/mads/rdf/v1#code": nodeMap["GAC(s)"][0]
+                  }]
+              }
+            ]
+          }
+          if (nodeMap["marcKey"]){
+            blankNode["http://id.loc.gov/ontologies/bflc/marcKey"] = [
+              {
+                '@guid': short.generate(),
+                'http://id.loc.gov/ontologies/bflc/marcKey': nodeMap["marcKey"][0]
+              }
+            ]
+          }
         }else{
 
           let parent = utilsProfile.returnGuidParent(pt.userValue,fieldGuid)
@@ -2759,7 +2777,7 @@ export const useProfileStore = defineStore('profile', {
 
     },
 
-    
+
     /**
     * Moves the passed heading the first of the subjects in the PT order
     *
@@ -2800,7 +2818,7 @@ export const useProfileStore = defineStore('profile', {
           this.activeProfile.rt[workRtId].ptOrder.splice(currentHeadingPos, 1);
           // insert where the first heading is
           this.activeProfile.rt[workRtId].ptOrder.splice(firstHeadingPos, 0, pt.id);
-          
+
           this.dataChanged()
         }
 
@@ -2885,7 +2903,7 @@ export const useProfileStore = defineStore('profile', {
                 }
             }
 
-            
+
 
 
           }else{
@@ -2897,7 +2915,7 @@ export const useProfileStore = defineStore('profile', {
 
         }else{
 
-          
+
           alert("Error: no structure found")
 
         }
@@ -2975,7 +2993,7 @@ export const useProfileStore = defineStore('profile', {
         //     let userValue = newPt.userValue[baseURI][0]
 
 
-            
+
         //     // it doesn't exist at the top level, see if it has at least one reference template, if so use the first one and look up if that one has defualt values
         //     // the first one since it is the default for the referencetemplace componment
         //     let useRef = defaultsProperty.valueConstraint.valueTemplateRefs[0]
@@ -3051,7 +3069,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     duplicateComponent: async function(componentGuid, createEmpty){
-
       console.log(componentGuid)
 
       createEmpty = true
@@ -3270,11 +3287,6 @@ export const useProfileStore = defineStore('profile', {
           this.activeProfile.rt[pt.parentId].pt[pt.id].deleted = true
 
         }else{
-          console.info("this.activeProfile: ", this.activeProfile)
-          console.info("this.activeProfile.rt: ", this.activeProfile.rt)
-          console.info("this.activeProfile.rt[pt.parentId]: ", this.activeProfile.rt[pt.parentId])
-          console.info("pt.id: ", pt.id)
-          console.info("Trying to delete: ", this.activeProfile.rt[pt.parentId].pt[pt.id].userValue)
           for (let key in this.activeProfile.rt[pt.parentId].pt[pt.id].userValue){
             if (!key.startsWith('@')){
                delete this.activeProfile.rt[pt.parentId].pt[pt.id].userValue[key]
@@ -3451,7 +3463,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     dataChanged:  function(){
-
       this.activeProfileSaved = false
 
       window.clearTimeout(dataChangedTimeout)
@@ -3469,7 +3480,7 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     prepareForNewRecord:  function(){
-      
+
       this.activeProfile = {}
 
     }

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -384,8 +384,6 @@
       loadSearch: function(){
         this.lccnLoadSelected = null
 
-        console.info("Load: ", this.urlToLoad)
-
         if (this.urlToLoad.startsWith("http://") || this.urlToLoad.startsWith("https://")){
           this.urlToLoadIsHttp = true
           return false


### PR DESCRIPTION
Ticket: https://staff.loc.gov/tasks/browse/LCAP-3597

This updates `extractContextData` in `utils_network.js` to capture the marcKey.
And updates `setValueComplex` in `profile.js` to load the values GACs and marcKey into the `userValue` of the profile.

Not sure if there are other `madsrdf:code` fields thatneed to be included in this.

There's a small update to `createLiteral` in `utils_export.js` to be able to handle the incoming uri for the GACs code. The bf2marc conversion wants `rdf:about`, but `createLiteral` was only able to create `rdf:resource`.

@thisismattmiller I can't check that this actually does anything to the MARC preview. But in the XML preview everything looks like it is in place

![image](https://github.com/user-attachments/assets/f727ce4c-44fb-4c7d-9007-df9a166997d6)
