### PR TITLE
[LCAP-3362] Additional Title Bug

### DIFF
--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1955,7 +1955,7 @@ export const useProfileStore = defineStore('profile', {
                     currentUserValuePos[p.propertyURI] = []
                 }
 
-                let thisLevelType = utilsRDF.suggestTypeProfile(p.propertyURI,pt)   
+                let thisLevelType = utilsRDF.suggestTypeProfile(p.propertyURI,pt)
                 if (thisLevelType === false){
                   // did not find it in the profile, look to the network
                   thisLevelType = await utilsRDF.suggestTypeNetwork(p.propertyURI)
@@ -2967,20 +2967,27 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     duplicateComponent: async function(componentGuid, structure){
-
       let createEmpty = true
 
       // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
+      //Ensure that the component is going to the right place by checking the structure.parentID
+      let actionTarget = null
+      if (structure.parentId.includes("Instance")) {
+        actionTarget = "Instance"
+      } else if (structure.parentId.includes("Work")) {
+        actionTarget = "Work"
+      } else {
+        console.error("Don't know how to handle: ", structure.parentId)
+      }
+
       if (pt !== false){
-
-
         let profile
         let propertyPosition
         for (let r of this.activeProfile.rtOrder){
           propertyPosition = this.activeProfile.rt[r].ptOrder.indexOf(pt.id)
-          if (propertyPosition != -1){
+          if (propertyPosition != -1 && r.includes(actionTarget)){
             profile = r
             break
           }
@@ -3024,15 +3031,10 @@ export const useProfileStore = defineStore('profile', {
 
 
           // we also want to add any default values in if it is just a empty new property and not duping
-
           let idPropertyId = newPt.propertyURI
-
           let baseURI = newPt.propertyURI
-
-
           // let defaults = null
           let defaultsProperty
-
 
           let useProfile = profile
           // if the profile is a multiple, like lc:RT:bf2:Monograph:Item-0 split off the -0 for it to find it in the RT lookup
@@ -3049,14 +3051,8 @@ export const useProfileStore = defineStore('profile', {
 
               }
           }
-
-
-
-
         }else{
-
           // doesn't support duplicating components yet
-
         }
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2978,8 +2978,6 @@ export const useProfileStore = defineStore('profile', {
         actionTarget = "Instance"
       } else if (structure.parentId.includes("Work")) {
         actionTarget = "Work"
-      } else {
-        console.error("Don't know how to handle: ", structure.parentId)
       }
 
       if (pt !== false){
@@ -2987,7 +2985,8 @@ export const useProfileStore = defineStore('profile', {
         let propertyPosition
         for (let r of this.activeProfile.rtOrder){
           propertyPosition = this.activeProfile.rt[r].ptOrder.indexOf(pt.id)
-          if (propertyPosition != -1 && r.includes(actionTarget)){
+
+          if (propertyPosition != -1 && (r.includes(actionTarget) || actionTarget == null)){
             profile = r
             break
           }


### PR DESCRIPTION
This fixes additional titles for instances being added under work.

I think this was happening because "title" is in both the work and instance form, but there was no check for which form the addition should have been part of, so it was adding it to the first form it matched in which was Work.