### PR TITLE
[LCAP 3366] Changes to subject builder search results

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -103,17 +103,23 @@
                           <span v-if="name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
                           <span v-else>{{name.suggestLabel}}</span>
                           <span> [LCNAF]</span>
+                          <span> ({{ this.buildAddtionalInfo(name.collections) }})</span>
                         </div>
                       <hr>
                     </div>
 
                     <div v-if="searchResults.subjectsComplex.length>0">
-                      <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">{{subjectC.suggestLabel}}<span></span></div>
+                      <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
+                        {{subjectC.suggestLabel}}<span></span>
+                      </div>
                       <hr>
                     </div>
 
                     <div v-if="searchResults.subjectsSimple.length>0">
-                      <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">{{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span></div>
+                      <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
+                        {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
+                        <span v-if="!subject.literal"> ({{ this.buildAddtionalInfo(subject.collections) }})</span>
+                      </div>
                     </div>
 
 
@@ -1060,19 +1066,8 @@ methods: {
             }
           }
         }
-
-
-
-
       // },100)
-
-
-
-
     })
-
-
-
   }, 500),
 
   navStringClick: function(event){
@@ -1126,6 +1121,22 @@ methods: {
   clearSelected: function(){
     this.pickLookup[this.pickCurrent].picked = false
     this.pickCurrent = null
+  },
+
+  buildAddtionalInfo: function(collections){
+    console.info(collections)
+    let out = []
+    if (collections.includes("LCSHAuthorizedHeadings") || collections.includes("NamesAuthorizedHeadings")){
+      out.push("Auth Hd")
+    } else if (collections.includes("GenreFormSubdivisions")){
+      out.push("GnFrm")
+    } else if (collections.includes("GeographicSubdivisions") || collections.includes("SubdivideGeographically")){
+      out.push("GeoSubDiv")
+    } else if (collections.includes("Subdivisions")){
+      out.push("SubDiv")
+    }
+
+    return out.join(", ")
   },
 
   loadContext: async function(pickPostion){

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1952,8 +1952,6 @@ const utilsNetwork = {
     */
     subjectSearch: async function(searchVal,complexVal,mode){
 
-
-
       let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")
       let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=ComplexType'
       let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=SimpleType'

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -353,9 +353,10 @@ const utilsNetwork = {
                 // console.log("URL",url)
                 // console.log("r",r)
                 for (let hit of r.hits){
-
+                  let context = await this.returnContext(hit.uri)
 
                   let hitAdd = {
+                    collections: context.nodeMap["MADS Collection"],
                     label: hit.aLabel,
                     vlabel: hit.vLabel,
                     suggestLabel: hit.suggestLabel,
@@ -1792,7 +1793,7 @@ const utilsNetwork = {
             }
           }
 
-          // also we need the MARCKeys 
+          // also we need the MARCKeys
 
           marcKeyPromises.push(this.returnMARCKey(r.uri + '.madsrdf_raw.jsonld'))
         }
@@ -1807,7 +1808,7 @@ const utilsNetwork = {
       }else if (result.hit && result.resultType == 'COMPLEX') {
         // if they are adding a complex value still need to lookup the marc key
         let marcKeyResult = await this.returnMARCKey(result.hit.uri + '.madsrdf_raw.jsonld')
-        result.hit.marcKey = marcKeyResult.marcKey        
+        result.hit.marcKey = marcKeyResult.marcKey
       }
       // console.log("result",result)
       return result

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -225,7 +225,7 @@ export const useConfigStore = defineStore('config', {
 
 
 
-    
+
 
 
   ],
@@ -281,7 +281,10 @@ export const useConfigStore = defineStore('config', {
           'NAF Name/Title':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=NameTitle&count=25&offset=<OFFSET>"},
           'NAF Title':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Title&count=25&offset=<OFFSET>"},
           'NAF Geographic':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Geographic&count=25&offset=<OFFSET>"},
-          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25&offset=<OFFSET>"}
+          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25&offset=<OFFSET>"},
+
+          'NAF Auth Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_NamesAuthorizedHeadings&count=25&offset=<OFFSET>"},
+          'NAF Geo SubDiv':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_GeographicSubdivisions&count=25&offset=<OFFSET>"}
         }
       ]
 
@@ -312,10 +315,11 @@ export const useConfigStore = defineStore('config', {
           'LCSH GenreForm':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=GenreForm&count=25&offset=<OFFSET>"},
           'LCSH Simple Type':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=SimpleType&count=25&offset=<OFFSET>"},
           'LCSH Complex Subject':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=ComplexSubject&count=25&offset=<OFFSET>"},
-          'LCSH Temporal':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Temporal&count=25&offset=<OFFSET>"}
+          'LCSH Temporal':{"url":"https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&rdftype=Temporal&count=25&offset=<OFFSET>"},
 
-
-
+          'LCSH Auth Subjects':{"url":"http://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings&count=25&offset=<OFFSET>"},
+          'LCSH SubDiv Subjects':{"url":"http://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions&count=25&offset=<OFFSET>"},
+          'LCSH GnFrm Subjects':{"url":"http://id.loc.gov/authorities/genreForms/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/genreForms/collection_LCGFT_General&count=25&offset=<OFFSET>"},
         }
       ]
     },


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/LCAP-3366

This makes the following changes to the search results in the subject builder:
* Subjects are followed by a tag indicating what collection it is part of. Only one is added per heading even if it falls into multiple collections. They are applied in the following order.
  * LCSHAuthorizedHeading or NamesAuthorizedHeading -> Auth Hd
  * GenreFormSubdivision                                                  -> GnFrm
  * GeographicSubdivision or SubdivideGeographically       -> GeoSubDiv
  * Subdivisions                                                                 -> SubDiv
* Limits results shown based on position in the search string
  * Authorized headings should only show up when searching in the first position of a compound string
  * Authorized headings should not show up any other time

This filter is happening after the search has gone through. I needed to capture the collection information to add the tags, and that information is being reused to filter the results. 

Another way to do this, would be to add new searches to the config that hit specific collections. I've added some to `config.js` but didn't end up using them. This way of doing things, I think, has many more moving parts and involves more work.

Search for Biography in first position
![image](https://github.com/user-attachments/assets/29a9271f-bf84-418c-94c7-90d25a41b84c)


Search for Biography in second position
![image](https://github.com/user-attachments/assets/68a26ee2-c1f9-4722-9e25-1ba44198a35f)
