### PR TITLE
[LCAP-3720] Subject builder working more as expected with GEO

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -861,6 +861,7 @@ methods: {
      */
 
     if (mode == "GEO"){
+      this.typeLookup[this.activeComponentIndex] = 'madsrdf:Geographic'
       /**
        * When dealing with a switch to GEO, we need to combine the "loose" components
        * into 1 so the search will work.
@@ -956,6 +957,7 @@ methods: {
       }
 
     } else {
+      this.typeLookup[this.activeComponentIndex] = 'madsrdf:Topic'
       // Above we took loose components and combined them,
       // here we undo that incase someone made a mistake and the geo
       // term has a subject in it that needs to be split out.
@@ -1704,6 +1706,9 @@ methods: {
       if (this.typeLookup[id]){
         type = this.typeLookup[id]
       }
+
+      console.info("id: ", id)
+      console.info("typelookup: ", this.typeLookup)
 
       this.components.push({
         label: ss,

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -924,15 +924,6 @@ methods: {
       // get the boxes lined up correctly
       this.renderHintBoxes()
 
-      // for (let i in this.components){
-      //   for (let j in this.componetLookup){
-      //     if (this.components[i].label == this.componetLookup[j].label && i != j){
-      //       this.componetLookup[i] = this.componetLookup[j]
-      //       delete this.componetLookup[j]
-      //     }
-      //   }
-      // }
-
     } else {
       // Above we took loose components and combined them,
       // here we undo that incase someone made a mistake and the geo

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -863,7 +863,7 @@ methods: {
        *  !! the `not` hyphes are very important !!
        *  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
        */
-      // Update the id of the active component to indx[0]
+      // Update the id of the active component to indx[0] so we're working with the first component of the looseComponents
       this.activeComponentIndex = Number(indx[0])
       this.activeComponent = looseComponents[this.activeComponentIndex]
       this.activeComponent.id = this.activeComponentIndex
@@ -884,7 +884,7 @@ methods: {
       }
       this.activeComponent.posStart = looseComponents[0].posStart
 
-      // if the approved pieces aren't all at the front, we need to make sure the order is maintained
+      // we need to make sure the order is maintained
       // use the component map to determine maintain order
       let final = []
       for (let el in componentMap){
@@ -923,6 +923,17 @@ methods: {
 
       // get the boxes lined up correctly
       this.renderHintBoxes()
+
+      // hacky, but without this the componentLooks won't match in `subjectStringChanged`
+      for (let i in this.components){
+        for (let j in this.componetLookup){
+          const key = Object.keys(this.componetLookup[j])[0]
+          if (this.components[i].label == key){
+            this.componetLookup[i] = this.componetLookup[j]
+
+          }
+        }
+      }
 
     } else {
       // Above we took loose components and combined them,

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -945,7 +945,7 @@ methods: {
       // get the boxes lined up correctly
       this.renderHintBoxes()
 
-      // hacky, but without this the componentLooks won't match in `subjectStringChanged`
+      // hacky, but without this `this.componentLooks` won't match in `subjectStringChanged`
       for (let i in this.components){
         for (let j in this.componetLookup){
           const key = Object.keys(this.componetLookup[j])[0]
@@ -962,7 +962,6 @@ methods: {
       let unApproved = []
       let unApprovedIdx = []
       let approved = []
-      let componentMap = []
       for (let c in this.components){
         if (this.components[c].uri == null && this.components[c].literal != true){
           unApproved.push(this.components[c])
@@ -974,7 +973,9 @@ methods: {
 
       //remove the terms that have been exploded
       for (let i in unApprovedIdx){
-        this.components.splice(unApprovedIdx[i], 1)
+        if (this.components[unApprovedIdx[i]].label.includes("‑‑")){
+          this.components.splice(unApprovedIdx[i], 1)
+        }
       }
 
       for (let c in unApproved){
@@ -1013,17 +1014,8 @@ methods: {
 
         }
 
-        //build the map to maintain order
-        for (let c in this.components){
-          if (this.components[c].uri == null && this.components[c].literal != true){
-            componentMap.push("-")
-          } else {
-            componentMap.push(c)
-          }
-        }
-
-
         let final = this.components.map((component) => component.label)
+
         this.adjustStartEndPos(this.components)
         this.subjectString = final.join("--")
       }


### PR DESCRIPTION
Ticket: https://staff.loc.gov/tasks/browse/LCAP-3720

Update to the subject builder so that GEO selection work better.

If a cataloger entered a string such as "families--portugal--porto" all while LCSH is selected in the top options, it can be difficult get Marva to recognize the desired term for the GEO search. This was because when you select the GEO option, Marva understands the hyphens to mean that this is one term ("portugal--porto", not "portual","porto"). But if you switch to GEO after writing the entire string, it will take each piece as separate and it needs to be rewritten to get it to recognize the full string. This should only be an issue with this compound GEOs and is the reason "portugal--porto" was showing results "portugal--a..."

This update will combine all of the currently unapproved (terms that are highlighted red) into one term so that Marva will search on a compound subject. This has the downside of capturing all unapproved terms, so if there is a term after the geo term Marva will think it is part of the geo term. For example, with the string "portugal--porto--history", "history" will be included in the geo search if it is all written out before selecting GEO or before validating "history." There's no way around this.

Additionally, if the user selects another search option, any combined but unapproved term will be separated into the individual components. This is in case someone writes out something like "families--portugal--porto" and then selects GEO before validating "families." So instead of rewriting the whole string, they can go back to LCSH and Marva will treat everything as separate.

It should be possible to switch back and forth between the search options as you build a string.