### PR TITLE
Lcap 3721 building complex subjects

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1923,14 +1923,33 @@ methods: {
         c.type = this.localContextCache[c.uri].typeFull.replace('http://www.loc.gov/mads/rdf/v1#','madsrdf:')
       }
     }
-    console.log(this.localContextCache)
-    console.log(this.components)
-    console.info("this.localContextCache: ", this.localContextCache)
-    console.info("this.components: ", this.components)
-    // the the components that are being added exist as a single term in the localContextCache, swap them
-    let componentCheck = this.components.map((component) => component.label).join("--") ? this.components.length > 0 : false
-    console.info("check: ", componentCheck)
-    console.info(this.components.map((component) => component.label).join("--"))
+
+    // If the individual components together, match a complex subject, switch'em so the user ends up with a controlled term
+    let match = false
+    const componentCount = this.components.length
+    const componentCheck = this.components.length > 0 ? this.components.map((component) => component.label).join("--") : false
+
+    for (let el in this.searchResults["subjectsComplex"]){
+      let target = this.searchResults["subjectsComplex"][el]
+      if (target.label.replaceAll("‑", "-") == componentCheck && target.depreciated == false){
+        match = true
+        this.components.push({
+          "complex": target.complex,
+          "id": 0,
+          "label": target.label,
+          "literal": false,
+          "posEnd": target.label.length,
+          "posStart": 0,
+          "type": "madsrdf:Topic",
+          "uri": target.uri,
+        })
+      }
+    }
+    //remove unused components
+    if (match){
+      Array(componentCount).fill(0).map((i) => this.components.shift())
+    }
+
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1035,9 +1035,6 @@ methods: {
 
   // some context messing here, pass the debounce func a ref to the vue "this" as that to ref in the function callback
   searchApis: debounce(async (searchString, searchStringFull, that) => {
-    console.info("searchApis")
-    console.info("searchString: ", searchString)
-    console.info("searchStringFull: ", searchStringFull)
     that.pickCurrent = null //reset the current selection when the search changes
 
     that.searchResults=null
@@ -1063,7 +1060,6 @@ methods: {
     searchStringFull=searchStringFull.replaceAll('‑','-')
 
     that.searchResults = await utilsNetwork.subjectSearch(searchString,searchStringFull,that.searchMode)
-    console.info("searchResults: ", that.searchResults)
 
     /**
      * The following lines will remove search results based on
@@ -1907,7 +1903,6 @@ methods: {
 
 
   add: function(){
-    console.info("adding")
     //remove any existing thesaurus label, so it has the most current
     //this.profileStore.removeValueSimple(componentGuid, fieldGuid)
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1035,6 +1035,9 @@ methods: {
 
   // some context messing here, pass the debounce func a ref to the vue "this" as that to ref in the function callback
   searchApis: debounce(async (searchString, searchStringFull, that) => {
+    console.info("searchApis")
+    console.info("searchString: ", searchString)
+    console.info("searchStringFull: ", searchStringFull)
     that.pickCurrent = null //reset the current selection when the search changes
 
     that.searchResults=null
@@ -1060,6 +1063,7 @@ methods: {
     searchStringFull=searchStringFull.replaceAll('‑','-')
 
     that.searchResults = await utilsNetwork.subjectSearch(searchString,searchStringFull,that.searchMode)
+    console.info("searchResults: ", that.searchResults)
 
     /**
      * The following lines will remove search results based on
@@ -1074,17 +1078,22 @@ methods: {
       pos = pieces.indexOf(searchString)
     }
 
+    // limiting output so that authorized headings won't appear when search for a subdivsion
+    // But it is possible for someone to build a heading that exists in full and they could end up with
+    // an uncontrolled heading that really should be
     for (let element in that.searchResults){
-      for (let i = that.searchResults[element].length-1; i >= 0; i--){
-        if (that.searchResults[element][i].collections){
-          let isAuth = that.searchResults[element][i].collections.findIndex(coll => coll.includes("AuthorizedHeadings")) >= 0
-          // the heading is not authorized, and we're looking at position 0, remove it
-          if (!isAuth && pos == 0){
-            that.searchResults[element].splice(i, 1)
-          } else if (isAuth && pos != 0) { // the heading is authorized, but we're not looking at position 0, remove it
-            that.searchResults[element].splice(i, 1)
-          }
+      if (element != "subjectsComplex"){  // keep showing complext subjects so the most full version shows if available
+        for (let i = that.searchResults[element].length-1; i >= 0; i--){
+          if (that.searchResults[element][i].collections){
+            let isAuth = that.searchResults[element][i].collections.findIndex(coll => coll.includes("AuthorizedHeadings")) >= 0
+            // the heading is not authorized, and we're looking at position 0, remove it
+            if (!isAuth && pos == 0){
+              that.searchResults[element].splice(i, 1)
+            } else if (isAuth && pos != 0) { // the heading is authorized, but we're not looking at position 0, remove it
+              that.searchResults[element].splice(i, 1)
+            }
 
+          }
         }
       }
     }
@@ -1121,17 +1130,10 @@ methods: {
     }
 
     for (let s of that.searchResults.subjectsSimple){
-
-
       if (s.suggestLabel && s.suggestLabel.includes('(DEPRECATED')){
-
         s.suggestLabel = s.suggestLabel.split('(DEPRECATED')[0] + "(DEPRECATED)"
       }
-
-
     }
-
-
 
     for (let s of that.searchResults.hierarchicalGeographic){
       if (s.suggestLabel && s.suggestLabel.includes(' (USE ')){
@@ -1149,11 +1151,7 @@ methods: {
           s.suggestLabel = s.label
         }
       }
-
     }
-
-
-
 
     for (let s of that.searchResults.hierarchicalGeographic){
       s.labelOrginal = s.label
@@ -1161,12 +1159,9 @@ methods: {
       s.label = s.label.replaceAll('-','‑')
     }
 
-
     if (that.searchResults.hierarchicalGeographic.length>0 && that.searchResults.subjectsComplex.length==0){
       that.searchResults.subjectsComplex = that.searchResults.hierarchicalGeographic
     }
-
-
 
     that.pickLookup = {}
 
@@ -1183,19 +1178,12 @@ methods: {
       that.pickLookup[parseInt(x)+parseInt(that.searchResults.subjectsComplex.length)] = that.searchResults.subjectsSimple[x]
     }
 
-
-
-
-
-
     for (let x in that.searchResults.names){
       that.pickLookup[(that.searchResults.names.length - x)*-1] = that.searchResults.names[x]
     }
 
     for (let k in that.pickLookup){
-
       that.pickLookup[k].picked = false
-
       if (searchString.toLowerCase() == that.pickLookup[k].label.toLowerCase() && !that.pickLookup[k].literal ){
         // if the labels are the same for the current one selected don't overide it
         if (that.pickLookup[k].label.replaceAll('‑','-') == that.activeComponent.label.replaceAll('‑','-') && that.activeComponent.uri){
@@ -1204,53 +1192,32 @@ methods: {
             that.pickLookup[k].picked=true
             that.selectContext()
           }
-
         }else{
-
-
           // if they started typing the next word already then stop this
           if (that.subjectString.replaceAll('‑','-')!=searchStringFull.replaceAll('‑','-')){
             break
-
           }
-
           // do they even have the same label currently, they might be clicking around in the interface
           // so at this point with the async lookup this is not even the right componen
           if (that.pickLookup[k].label !=  that.activeComponent.label){
             break
-
           }
-
-
           that.pickPostion=k
           that.pickLookup[k].picked=true
           that.selectContext()
-
         }
-
-
-
-
-
       }
     }
 
     // that.contextData.dispatch("clearContext", { self: that})
-
     if (that.pickLookup[that.pickPostion] && !that.pickLookup[that.pickPostion].literal){
       that.contextRequestInProgress = true
-
       that.contextData = await utilsNetwork.returnContext(that.pickLookup[that.pickPostion].uri)
-
       // keep a local copy of it for looking up subject type
       if (that.contextData){
         that.localContextCache[that.contextData.uri] = JSON.parse(JSON.stringify(that.contextData))
       }
-
     }
-
-
-
 
     window.clearInterval(ti)
     window.clearTimeout(tiBackup)
@@ -1940,6 +1907,7 @@ methods: {
 
 
   add: function(){
+    console.info("adding")
     //remove any existing thesaurus label, so it has the most current
     //this.profileStore.removeValueSimple(componentGuid, fieldGuid)
 
@@ -1957,6 +1925,12 @@ methods: {
     }
     console.log(this.localContextCache)
     console.log(this.components)
+    console.info("this.localContextCache: ", this.localContextCache)
+    console.info("this.components: ", this.components)
+    // the the components that are being added exist as a single term in the localContextCache, swap them
+    let componentCheck = this.components.map((component) => component.label).join("--") ? this.components.length > 0 : false
+    console.info("check: ", componentCheck)
+    console.info(this.components.map((component) => component.label).join("--"))
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -8,7 +8,7 @@ import utilsMisc from './utils_misc';
 import utilsNetwork from './utils_network';
 
 
-const escapeHTML = str => str.replace(/[&<>'"]/g, 
+const escapeHTML = str => str.replace(/[&<>'"]/g,
   tag => ({
       '&': '&amp;',
       '<': '&lt;',
@@ -347,7 +347,7 @@ const utilsExport = {
 			return xmlObj
 		} catch (error) {
 			console.warn("XML Parsing Error:")
-			console.warn(error)			
+			console.warn(error)
 
 			useProfileStore().triggerBadXMLBuildRecovery(this.lastGoodXMLBuildProfile, this.lastGoodXMLBuildProfileTimestamp)
 
@@ -368,7 +368,7 @@ const utilsExport = {
 			----------------
 			XML Creation Log
 			----------------
-			
+
 			----End Creation Log----
 
 
@@ -377,7 +377,7 @@ const utilsExport = {
 			****************
 			${(profile.xmlSource) ? profile.xmlSource : 'No Source Found'}
 			***End Source***
-			`			
+			`
 
 			utilsNetwork.sendErrorReportLog(errorReport,filename,profileAsJson)
 
@@ -1469,6 +1469,8 @@ const utilsExport = {
     // console.log(strXmlFormatted)
     // console.log("------")
     // console.log(strXmlBasic)
+
+		console.info("xml: ", strXmlBasic)
 
 		return {
 			xmlDom: rdf,

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1470,8 +1470,6 @@ const utilsExport = {
     // console.log("------")
     // console.log(strXmlBasic)
 
-		console.info("xml: ", strXmlBasic)
-
 		return {
 			xmlDom: rdf,
 			xmlStringFormatted: strXmlFormatted,

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -571,7 +571,6 @@ const utilsNetwork = {
 
       let instances = []
 
-
       // grab the title
       for (let val of data){
 
@@ -2123,7 +2122,6 @@ const utilsNetwork = {
         'names':resultsNames,
         'hierarchicalGeographic': resultsHierarchicalGeographic
       }
-
 
       return results
 


### PR DESCRIPTION
Ticket: https://staff.loc.gov/tasks/browse/LCAP-3721

This addresses some of this ticket. 

It does two things:
1. Adjusts the subject deduping to always include the complex subjects. So if someone types and selects "Korean poetry," then goes one to write "1894-1919", there will be options that include "Korean poetry--1894-1919...". The current system of removing all authorized headings when working on a subdivision meant that a cataloger could easily miss the full heading they really want.
2. If someone builds a heading that matches an controlled, authorized heading, but doesn't select that controlled heading, when they "Add" the item their built subject will be replaced with the controlled form. Building "`Korean poetry`--`1894-1919`--`History and criticism`" with the components being separated and not selecting the matching complex option will still result in the controlled form being selected "`Korean poetry--1894-1919--History and criticism`"

>  There could be other situtations where they use a complex authorized heading for the start of the subject and then use another History or Fiction or whatever as another subfield that would be the same problem.

This portion isn't address at all.