### PR TITLE
[LCAP 3758] - Shelflisting Links

### DIFF
--- a/src/components/general/PreferenceModal.vue
+++ b/src/components/general/PreferenceModal.vue
@@ -252,7 +252,7 @@
                       <input type="checkbox" class="checkbox-option" @change="booleanValueChange"  v-model="booleanValue[option.id]">
                     </template>
                     <template v-else-if="option.type==='string'">
-                      <input type="url" @input="stringValueChange" v-model="stringValue[option.id]">
+                      <input type="text" @input="stringValueChange" v-model="stringValue[option.id]">
                     </template>
 
 

--- a/src/components/general/PreferenceModal.vue
+++ b/src/components/general/PreferenceModal.vue
@@ -30,6 +30,7 @@
         rangeValue: {},
         fontValue: {},
         booleanValue: {},
+        stringValue: {},
 
       }
     },
@@ -39,7 +40,7 @@
       // gives access to this.counterStore and this.userStore
       ...mapStores(usePreferenceStore),
       // // gives read access to this.count and this.double
-      ...mapState(usePreferenceStore, ['showPrefModal','showPrefModalGroup','styleDefault', 'showPrefModalGroup', 'fontFamilies']),
+      ...mapState(usePreferenceStore, ['showPrefModal','showPrefModalgroup','styleDefault', 'showPrefModalGroup', 'fontFamilies']),
 
       // array of the pssobile groups from the stlyes
       possilbleGroups() {
@@ -100,6 +101,7 @@
           this.rangeValue = {}
           this.fontValue = {}
           this.booleanValue = {}
+          this.stringValue = {}
 
           if (event){
             this.preferenceStore.setShowPrefModalGroup(event.target.value)
@@ -122,6 +124,8 @@
                 this.fontValue[o.id] = o.value
               }else if (o.type == 'boolean'){
                 this.booleanValue[o.id] = o.value
+              } else if (o.type == 'string'){
+                this.stringValue[o.id] = o.value
               }
               this.renderProperties.push(o)
             }
@@ -156,6 +160,11 @@
           for (let id in this.booleanValue){
             console.log(id,this.booleanValue[id])
             this.preferenceStore.setValue(id,this.booleanValue[id])
+          }
+        },
+        stringValueChange: function(){
+          for (let id in this.stringValue){
+            this.preferenceStore.setValue(id, this.stringValue[id])
           }
         },
 
@@ -240,9 +249,10 @@
                         </select>
                     </template>
                     <template v-else-if="option.type==='boolean'">
-
                       <input type="checkbox" class="checkbox-option" @change="booleanValueChange"  v-model="booleanValue[option.id]">
-
+                    </template>
+                    <template v-else-if="option.type==='string'">
+                      <input type="url" @input="stringValueChange" v-model="stringValue[option.id]">
                     </template>
 
 

--- a/src/components/general/PreferenceModal.vue
+++ b/src/components/general/PreferenceModal.vue
@@ -40,7 +40,7 @@
       // gives access to this.counterStore and this.userStore
       ...mapStores(usePreferenceStore),
       // // gives read access to this.count and this.double
-      ...mapState(usePreferenceStore, ['showPrefModal','showPrefModalgroup','styleDefault', 'showPrefModalGroup', 'fontFamilies']),
+      ...mapState(usePreferenceStore, ['showPrefModal','showPrefModalGroup','styleDefault', 'showPrefModalGroup', 'fontFamilies']),
 
       // array of the pssobile groups from the stlyes
       possilbleGroups() {

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -179,12 +179,14 @@
           </div>
           <div>
             <ul>
-              <li v-for="(item, idx) in preferences" >
-                <a :href="preferenceStore.returnValue(item[1])" target="_blank">
-                  {{ preferenceStore.returnValue(item[0]) }}
-                  <span class="material-icons" style="font-size: 14px;">open_in_new</span>
-                </a>
-              </li>
+              <template v-for="(item, idx) in preferences">
+                <li v-if="preferenceStore.returnValue(item[1]).trim() != ''">
+                  <a :href="preferenceStore.returnValue(item[1])" target="_blank">
+                    {{ preferenceStore.returnValue(item[0]).trim() != "" ? preferenceStore.returnValue(item[0]) : preferenceStore.returnValue(item[1])}}
+                    <span class="material-icons" style="font-size: 14px;">open_in_new</span>
+                  </a>
+                </li>
+              </template>
             </ul>
           </div>
           <div style="flex:1;     display: flex;justify-content: center;align-items: center;">

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -79,8 +79,8 @@
                 autocomplete="off"
                 @focusin="focused"
                 @blur="blured"
-                @input="valueChanged" 
-                @keyup="navKey"    
+                @input="valueChanged"
+                @keyup="navKey"
                 @keydown="keyDown"
                 :ref="'input_' + lValue['@guid']"
                 :data-guid="lValue['@guid']"
@@ -177,15 +177,21 @@
 
           </fieldset>
           </div>
+          <div>
+            <ul>
+              <li v-for="(item, idx) in preferences" >
+                <a :href="preferenceStore.returnValue(item[1])" target="_blank">
+                  {{ preferenceStore.returnValue(item[0]) }}
+                  <span class="material-icons" style="font-size: 14px;">open_in_new</span>
+                </a>
+              </li>
+            </ul>
+          </div>
           <div style="flex:1;     display: flex;justify-content: center;align-items: center;">
               <button @click="openShelfListSearch">Shelf List Search</button>
           </div>
-
         </div>
-
       </div>
-
-
     </div>
 
 
@@ -288,7 +294,7 @@ export default {
 
     navKey: function(event){
 
-      
+
 
       if (event && event.code === 'ArrowUp'){
         utilsMisc.globalNav('up',event.target)
@@ -304,7 +310,7 @@ export default {
         document.getElementById(id).click()
       }
 
-      
+
 
     },
 
@@ -352,13 +358,13 @@ export default {
       for (let macro of this.diacriticUseValues){
             if (event.code == macro.code && event.ctrlKey == macro.ctrlKey && event.altKey == macro.altKey && event.shiftKey == macro.shiftKey){
               // console.log("run this macro", macro)
-              
+
               let insertAt = event.target.value.length
-          
+
               if (event.target && event.target.selectionStart){
                 insertAt=event.target.selectionStart
-              }       
-              let inputV    
+              }
+              let inputV
               if (event.target){
                 inputV = event.target
               }else{
@@ -376,7 +382,7 @@ export default {
                   // if it is in fact a digit char then remove it
                   if (inputV.value.charAt(insertAt) == event.code.replace('Digit','')){
                     // remove the last char
-                    // inputV.value = inputV.value.slice(0, -1); 
+                    // inputV.value = inputV.value.slice(0, -1);
                     inputV.value = inputV.value.slice(0,insertAt) + inputV.value.slice(insertAt)
 
                   }
@@ -398,7 +404,7 @@ export default {
                   if (inputV.value.charAt(inputV.value.length-1) == '`'){
                     // remove the last char
                     // inputV.value = inputV.value.slice(0, -1);
-                    inputV.value = inputV.value.slice(0,insertAt) + inputV.value.slice(insertAt) 
+                    inputV.value = inputV.value.slice(0,insertAt) + inputV.value.slice(insertAt)
                   }
 
                 }
@@ -425,7 +431,7 @@ export default {
                       this.$nextTick(()=>{
                         inputV.focus()
                       })
-                    
+
                   }
 
 
@@ -444,13 +450,13 @@ export default {
 
                     if (inputV.value.charAt(inputV.value.length-1) == '`'){
                       // remove the last char
-                      inputV.value = inputV.value.slice(0, -1); 
+                      inputV.value = inputV.value.slice(0, -1);
                     }
 
                     }
 
 
-                    // little cheap hack here, on macos the Alt+9 makes ª digits 1-0 do this with Alt+## but we only 
+                    // little cheap hack here, on macos the Alt+9 makes ª digits 1-0 do this with Alt+## but we only
                     // have one short cut that uses Alt+9 so just remove that char for now
                     inputV.value=inputV.value.replace('ª','')
 
@@ -481,7 +487,7 @@ export default {
 
                 event.preventDefault()
                 event.stopPropagation()
-                return false                
+                return false
             }
           }
 
@@ -495,18 +501,18 @@ export default {
 
       if (this.nextInputIsVoyagerModeDiacritics){
 
-        
 
-        // they are pressing shift in about to press antoher macro shrotcut 
+
+        // they are pressing shift in about to press antoher macro shrotcut
         if (event.key == 'Shift'){
           return false
         }
-        
+
         if (this.diacriticPacks.voyager[event.code]){
 
 
           let useMacro
-          for (let macro of this.diacriticPacks.voyager[event.code]){          
+          for (let macro of this.diacriticPacks.voyager[event.code]){
             if (macro.shiftKey == event.shiftKey){
               useMacro = macro
               break
@@ -514,13 +520,13 @@ export default {
           }
 
           let inputV = event.target
-          let insertAt = event.target.value.length          
+          let insertAt = event.target.value.length
           if (event.target && event.target.selectionStart){
             insertAt=event.target.selectionStart
-          }       
+          }
 
           if (!useMacro.combining){
-          // it is not a combining unicode char so just insert it into the value            
+          // it is not a combining unicode char so just insert it into the value
             if (inputV.value){
               // inputV.value=inputV.value+useMacro.codeEscape
               inputV.value = inputV.value.substring(0, insertAt) + useMacro.codeEscape + inputV.value.substring(insertAt);
@@ -574,7 +580,7 @@ export default {
                 this.runMacroExpressMacro(event)
                 this.valueChanged(event)
                 return false
-                
+
               }
             }
           }
@@ -587,10 +593,10 @@ export default {
               event.preventDefault()
               return false
             }
-            
+
           }
 
-          // 
+          //
 
         }
     },
@@ -721,7 +727,7 @@ export default {
     ...mapState(useConfigStore, ['scriptShifterLangCodes', 'lccFeatureProperties']),
     ...mapState(usePreferenceStore, ['diacriticUseValues', 'diacriticUse','diacriticPacks']),
     ...mapWritableState(useProfileStore, ['showShelfListingModal','activeField','activeProfile', 'literalLangShow', 'literalLangInfo','dataChangedTimestamp','activeShelfListData']),
-
+    ...mapState(usePreferenceStore, ['showPrefModal','showPrefModalgroup','styleDefault', 'showPrefModalGroup', 'fontFamilies']),
 
     myGuid(){
       return `${this.structure['@guid']}--${this.guid}`
@@ -831,7 +837,7 @@ export default {
       cutterCalcLength: 2,
       nextInputIsVoyagerModeDiacritics: false,
 
-
+      preferences: {},
 
     }
   },
@@ -841,19 +847,24 @@ export default {
       this.expandHeightToContent()
     })
 
-
-
+    //get the preferences to load into the page
+    for (let k in this.styleDefault){
+      if (k.includes("shelflist")){
+        let o = Object.assign({}, this.styleDefault[k])
+        if (o.index in this.preferences){
+          //save `k` so the information in the page will match the preferences in real time
+          this.preferences[o.index].push(k)
+        } else {
+          this.preferences[o.index] = [k]
+        }
+      }
+    }
   },
   created: function(){
 
     this.$nextTick().then(() => {
       this.expandHeightToContent()
     })
-
-
-
-
-
   },
 };
 </script>

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -55,7 +55,7 @@
       ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay']),
       ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal']),
       ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal']),
-      
+
 
 
 
@@ -181,9 +181,9 @@
               { text: 'Diacritic Macros', click: () => this.showDiacriticConfigModal = true, icon: 'keyboard' },
               { text: 'Text Macros', click: () => this.showTextMacroModal = true, icon: 'abc' },
 
-              
 
-              
+
+
 
               { is: 'separator'},
 
@@ -196,6 +196,7 @@
               { text: 'Nav Bar', click: () => this.preferenceStore.togglePrefModal('Nav Bar')},
               { text: 'Sidebars - Previews', click: () => this.preferenceStore.togglePrefModal('Sidebars - Previews')},
               { text: 'Sidebars - Property', click: () => this.preferenceStore.togglePrefModal('Sidebars - Property')},
+              { text: 'Sheflisting', click: () => this.preferenceStore.togglePrefModal('Sheflisting')},
 
 
               { is: 'separator'},

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -196,7 +196,7 @@
               { text: 'Nav Bar', click: () => this.preferenceStore.togglePrefModal('Nav Bar')},
               { text: 'Sidebars - Previews', click: () => this.preferenceStore.togglePrefModal('Sidebars - Previews')},
               { text: 'Sidebars - Property', click: () => this.preferenceStore.togglePrefModal('Sidebars - Property')},
-              { text: 'Sheflisting', click: () => this.preferenceStore.togglePrefModal('Sheflisting')},
+              { text: 'Shelflisting', click: () => this.preferenceStore.togglePrefModal('Shelflisting')},
 
 
               { is: 'separator'},

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -6,7 +6,7 @@ import diacrticsVoyagerNative from "@/lib/diacritics/diacritic_pack_voyager_nati
 
 export const usePreferenceStore = defineStore('preference', {
   state: () => ({
-    
+
 
     // controls showing the modal that is parked in the App.vue
     showPrefModal: false,
@@ -40,7 +40,7 @@ export const usePreferenceStore = defineStore('preference', {
 
     diacriticUse:[],
     diacriticUseValues:[],
-    
+
     showTextMacroModal: false,
 
 
@@ -645,7 +645,7 @@ export const usePreferenceStore = defineStore('preference', {
         unit: null,
         group: 'Diacritics',
         range: [true,false]
-      },      
+      },
 
       '--c-diacritics-enabled-macros' : {
         value:[],
@@ -662,6 +662,75 @@ export const usePreferenceStore = defineStore('preference', {
         type: 'other',
         group: 'Diacritics',
         range: null
+      },
+
+      //Shelflisting
+      '--b-shelflist-link-1-label' : {
+        desc: 'Label for link 1.',
+        descShort: 'Link 1 Label',
+        value: "Cutter Table",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 0
+      },
+      '--b-shelflist-link-1' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 1 URL',
+        value: "http://www.loc.gov/aba/pcc/053/table",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 0
+      },
+
+      '--b-shelflist-link-2-label' : {
+        desc: 'Label for link 2.',
+        descShort: 'Link 2 Label',
+        value: "Biography Table",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 1
+      },
+      '--b-shelflist-link-2' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 2 URL',
+        value: "https://www.loc.gov/aba/publications/FreeCSM/G320.pdf",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 1
+      },
+
+      '--b-shelflist-link-3-label' : {
+        desc: 'Label for link 3.',
+        descShort: 'Link 3 Label',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 2
+      },
+      '--b-shelflist-link-3' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 3 URL',
+        value: "https://www.loc.gov/aba/publications/FreeCSM/G150.pdf",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 2
+      },
+
+      '--b-shelflist-link-4-label' : {
+        desc: 'Label for link 4.',
+        descShort: 'Link 4 Label',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
+      '--b-shelflist-link-4' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 4 URL',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
       },
 
 
@@ -715,7 +784,7 @@ export const usePreferenceStore = defineStore('preference', {
       if (window.localStorage.getItem('marva-diacriticUse')){
         this.diacriticUse = JSON.parse(window.localStorage.getItem('marva-diacriticUse'))
       }
-      
+
 
 
       this.styleDefaultOrginal = JSON.parse(JSON.stringify(this.styleDefault))
@@ -920,7 +989,7 @@ export const usePreferenceStore = defineStore('preference', {
 
 
       this.diacriticUse = [...new Set(this.diacriticUse)];
-      
+
       console.log(this.diacriticUse)
 
 
@@ -933,12 +1002,12 @@ export const usePreferenceStore = defineStore('preference', {
             this.diacriticUseValues.push(macro)
           }
         }
-        
+
 
       }
       console.log(this.diacriticUseValues)
 
-      
+
     },
 
     /**

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -702,7 +702,7 @@ export const usePreferenceStore = defineStore('preference', {
       '--b-shelflist-link-3-label' : {
         desc: 'Label for link 3.',
         descShort: 'Link 3 Label',
-        value: "",
+        value: "Translation Table",
         type: 'string',
         group: 'Shelflisting',
         index: 2
@@ -722,7 +722,7 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
-        index: 4
+        index: 3
       },
       '--b-shelflist-link-4' : {
         desc: 'Link to an outside resource to help with shelf listing.',
@@ -730,18 +730,27 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
+        index: 3
+      },
+
+      '--b-shelflist-link-5-label' : {
+        desc: 'Label for link 5.',
+        descShort: 'Link 5 Label',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
+      '--b-shelflist-link-5' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 5 URL',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
         index: 4
       },
 
-
-
-
-
-
     }
-
-
-
   }),
 
   // catInitals: null,
@@ -853,6 +862,9 @@ export const usePreferenceStore = defineStore('preference', {
         for (let k in prefs.styleDefault){
           if (prefs.styleDefault[k].group == "Sidebars - OPAC"){
             prefs.styleDefault[k].group = "Sidebars - Previews"
+          }
+          if (prefs.styleDefault[k].group == "Shelflisting"){
+            prefs.styleDefault[k].group = "Shelflisting"
           }
         }
 


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/LCAP-3758

Adds a preference section for shelflisting. The preferences allow the user to define up to 5 links and labels that will appear in the shelflisting tool between the Cuttering tool and the search button.

![image](https://github.com/user-attachments/assets/66152424-cd27-4a6c-a2ae-ed377e809b12)

![image](https://github.com/user-attachments/assets/0b511c67-1c00-43c9-b1c3-f962c22c39b1)

If a URL isn't provided, no link will be shown. If a label is missing, the URL will be used.

The first 3 links are pre-populated with links to the LC cutter table, the Biography Table, and the Translation Table. Changes to the preferences should show on the page as they happen.

It's only expecting the data for URLs and labels. If different types of data gets added here, there will need to be updates in `Literal.vue` to make sure it parses data correctly in `mounted()` or the links will break.

`TODO`: make this dynamic? so the user can click a button to add more links as they want. Maybe with a limit to avoid issues in how the page gets formatted.