### PR TITLE
Better subject deduping

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -113,7 +113,7 @@
 
 
       </div>
-      
+
 
       <div v-if="structure.propertyURI=='http://id.loc.gov/ontologies/bibframe/itemPortion'">
         <!-- { "title": "knitter's handy book of patterns", "classNumber": "TT820", "cutterNumber": ".B877 2002", "titleNonSort": 4, "contributors": [ { "type": "PrimaryContribution", "label": "Budd, Ann, 1956-" } ], "firstSubject": "Knitting--Patterns" } -->
@@ -182,9 +182,9 @@
           <div>
             <ul>
               <template v-for="(item, idx) in preferences">
-                <li v-if="preferenceStore.returnValue(item[1]).trim() != ''">
+                <li v-if="preferenceStore.returnValue(item[1]) != ''">
                   <a :href="preferenceStore.returnValue(item[1])" target="_blank">
-                    {{ preferenceStore.returnValue(item[0]).trim() != "" ? preferenceStore.returnValue(item[0]) : preferenceStore.returnValue(item[1])}}
+                    {{ preferenceStore.returnValue(item[0]) != "" ? preferenceStore.returnValue(item[0]) : preferenceStore.returnValue(item[1])}}
                     <span class="material-icons" style="font-size: 14px;">open_in_new</span>
                   </a>
                 </li>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -100,7 +100,7 @@
                     <div v-if="searchResults && searchResults.names.length>0 && !this.searching">
 
                       <div v-for="(name,idx) in searchResults.names" @click="selectContext((searchResults.names.length - idx)*-1)" @mouseover="loadContext((searchResults.names.length - idx)*-1)" :data-id="(searchResults.names.length - idx)*-1" :key="name.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1 ),'picked': (pickLookup[(searchResults.names.length - idx)*-1] && pickLookup[(searchResults.names.length - idx)*-1].picked)}]">
-                          <span v-if="name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
+                          <span v-if="name.suggestLabel && name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
                           <span v-else>{{name.suggestLabel}}</span>
                           <span> [LCNAF]</span>
                           <span v-if="name.collections"> ({{ this.buildAddtionalInfo(name.collections) }})</span>
@@ -1182,40 +1182,6 @@ methods: {
     searchStringFull=searchStringFull.replaceAll('‑','-')
 
     that.searchResults = await utilsNetwork.subjectSearch(searchString,searchStringFull,that.searchMode)
-
-    /**
-     * The following lines will remove search results based on
-     * the position of the term in the string and whether or not
-     * the term is an authorized heading.
-     *
-     * Authorized headings should only show in position 0.
-     */
-    let pos = 0
-    if (searchStringFull.includes("--")){
-      let pieces = searchStringFull.split("--")
-      pos = pieces.indexOf(searchString)
-    }
-
-    // limiting output so that authorized headings won't appear when search for a subdivsion
-    // But it is possible for someone to build a heading that exists in full and they could end up with
-    // an uncontrolled heading that really should be
-    for (let element in that.searchResults){
-      if (element != "subjectsComplex"){  // keep showing complext subjects so the most full version shows if available
-        for (let i = that.searchResults[element].length-1; i >= 0; i--){
-          if (that.searchResults[element][i].collections){
-            let isAuth = that.searchResults[element][i].collections.findIndex(coll => coll.includes("AuthorizedHeadings")) >= 0
-            // the heading is not authorized, and we're looking at position 0, remove it
-            if (!isAuth && pos == 0){
-              that.searchResults[element].splice(i, 1)
-            } else if (isAuth && pos != 0) { // the heading is authorized, but we're not looking at position 0, remove it
-              that.searchResults[element].splice(i, 1)
-            }
-
-          }
-        }
-      }
-    }
-
     // if they clicked around while it was doing this lookup bail out
     // if (that.activeSearchInterrupted){
 
@@ -1855,7 +1821,6 @@ methods: {
         this.updateAvctiveTypeSelected()
         this.validateOkayToAdd()
       },100)
-
     })
 
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1949,14 +1949,14 @@ const utilsNetwork = {
     */
     subjectSearch: async function(searchVal,complexVal,mode){
 
-      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")
+      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_NamesAuthorizedHeadings'
       let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
-      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=ComplexType'
-      let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=SimpleType'
+      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+      let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
       let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
-        let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
+      let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
 
       let worksUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
       let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
@@ -2156,7 +2156,7 @@ const utilsNetwork = {
         'subjectsSimple': pos == 0 ? resultsSubjectsSimple : resultsPayloadSubjectsSimpleSubdivision,
         'subjectsComplex': resultsSubjectsComplex,
         'names': pos == 0 ? resultsNames : resultsNamesSubdivision,
-        'hierarchicalGeographic': resultsHierarchicalGeographic
+        'hierarchicalGeographic':  pos == 0 ? [] : resultsHierarchicalGeographic
       }
 
       return results


### PR DESCRIPTION
This should improve the search results in the subject builder.

It was pointed out that a search "something--`interview`" did not return a result for "interviews." The previous efforts to dedupe the search results and prevent Authorized Headings from appearing when typing a subdivision was preventing the expected results.