### PR TITLE
[LCAP-3721] Building Complex Subjects II

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1994,7 +1994,6 @@ methods: {
 
 
   add: async function(){
-    console.info("Adding Subject")
     //remove any existing thesaurus label, so it has the most current
     //this.profileStore.removeValueSimple(componentGuid, fieldGuid)
 
@@ -2039,14 +2038,9 @@ methods: {
     } else {
         // need to break up the complex heading into it's pieces so their URIs are availble
         for (let component in this.components){
-          console.info("Type: ", this.components[component].type)
-          console.info("includes", ['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(this.components[component].type))
           if (this.components[component].complex && !['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(this.components[component].type)){
-            console.info("!!!!!!!!!! BREAKING IT UP !!!!!!!!!!")
-            console.info(this.components[component])
             let uri = this.components[component].uri
             let data = await this.parseComplexSubject(uri)
-            console.info("data: ", data)
 
             const complexLabel = this.components[component].label
             //remove the complex component
@@ -2095,7 +2089,6 @@ methods: {
         }
       }
 
-    console.info("final components: ", this.components)
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2039,8 +2039,10 @@ methods: {
         // need to break up the complex heading into it's pieces so their URIs are availble
         for (let component in this.components){
           if (this.components[component].complex){
+            console.info("!!!!!!!!!! BREAKING IT UP !!!!!!!!!!")
             let uri = this.components[component].uri
             let data = await this.parseComplexSubject(uri)
+            console.info("data: ", data)
 
             const complexLabel = this.components[component].label
             //remove the complex component
@@ -2079,7 +2081,7 @@ methods: {
                 "posEnd": label.length,
                 "posStart": 0,
                 "type": subfield,
-                "uri": data["components"][0][id],
+                "uri": data["components"][0]["@list"][id]["@id"],
               }))
 
               id++
@@ -2089,6 +2091,7 @@ methods: {
         }
       }
 
+    console.info("final components: ", this.components)
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1994,6 +1994,7 @@ methods: {
 
 
   add: async function(){
+    console.info("Adding Subject")
     //remove any existing thesaurus label, so it has the most current
     //this.profileStore.removeValueSimple(componentGuid, fieldGuid)
 
@@ -2038,8 +2039,11 @@ methods: {
     } else {
         // need to break up the complex heading into it's pieces so their URIs are availble
         for (let component in this.components){
-          if (this.components[component].complex){
+          console.info("Type: ", this.components[component].type)
+          console.info("includes", ['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(this.components[component].type))
+          if (this.components[component].complex && !['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(this.components[component].type)){
             console.info("!!!!!!!!!! BREAKING IT UP !!!!!!!!!!")
+            console.info(this.components[component])
             let uri = this.components[component].uri
             let data = await this.parseComplexSubject(uri)
             console.info("data: ", data)

--- a/src/components/panels/sidebar_preview_xml/Xml.vue
+++ b/src/components/panels/sidebar_preview_xml/Xml.vue
@@ -45,20 +45,21 @@
         let exportResult = await this.profileStore.buildExportXML()
 
         this.xml = exportResult.xlmStringBasic
+        console.info("XML: ", this.xml)
 
         if (this.firstLoad){
           this.$nextTick(()=>{
-            for (let el of document.querySelectorAll('.element-name')){                
+            for (let el of document.querySelectorAll('.element-name')){
                 if (el.innerText == 'bf:Work' || el.innerText == 'bf:Instance' || el.innerText == 'void:DatasetDescription'){
                   el.click()
                   this.firstLoad = false
                 }
-            }            
+            }
           })
         }
 
       }
-      
+
 
 
 
@@ -70,7 +71,7 @@
       // this.profileStore.$subscribe(async (mutation, state)=>{
 
       //   if (mutation && mutation.events && mutation.events.target && mutation.events.target['@guid'] ){
-          
+
       //     window.clearTimeout(this.timeout)
       //     this.timeout = window.setTimeout(()=>{
 
@@ -79,11 +80,11 @@
       //     },500)
 
 
-          
+
       //   }
 
 
-      //   // if (state.profilesLoaded && Object.keys(state.activeProfile).length == 0){  
+      //   // if (state.profilesLoaded && Object.keys(state.activeProfile).length == 0){
       //   //   // the profilesLoaded flipped and there is no active profile, so load the data
       //   //   this.profileStore.loadRecordFromBackend(this.$route.params.recordId)
       //   // }else{
@@ -104,9 +105,9 @@
     },
 
     mounted() {
-     
 
-      
+
+
     }
   }
 
@@ -117,7 +118,7 @@
 <template>
 
   <div>
-    
+
     <XmlViewer ref="xmlviewer" :xml="xml" />
 
 
@@ -133,7 +134,7 @@
 
 
 
-.sidebar-header-text{  
+.sidebar-header-text{
   font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size', true) + 0.25  + 'em'");
   font-family: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-family')");
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;

--- a/src/components/panels/sidebar_preview_xml/Xml.vue
+++ b/src/components/panels/sidebar_preview_xml/Xml.vue
@@ -45,7 +45,6 @@
         let exportResult = await this.profileStore.buildExportXML()
 
         this.xml = exportResult.xlmStringBasic
-        console.info("XML: ", this.xml)
 
         if (this.firstLoad){
           this.$nextTick(()=>{

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -517,9 +517,7 @@ const utilsExport = {
 
 			xmlLog.push(`Looping through the PTs`)
 
-
 			for (let pt of profile.rt[rt].ptOrder){
-
         		// extract the pt, this is the individual component like a <mainTitle>
 				let ptObj = profile.rt[rt].pt[pt]
 				if (ptObj.deleted){

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -180,7 +180,7 @@ const utilsExport = {
   * @param {obj} userValue - the uservalue to test
   * @return {boolean}
   */
-	createLiteral: function(property,userValue){		
+	createLiteral: function(property,userValue){
 		let p = this.createElByBestNS(property)
 		// it should be stored under the same key
 		if (userValue[property]){
@@ -194,7 +194,7 @@ const utilsExport = {
 		if (userValue['@id']){
 			p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
 		}
-		
+
 		if (!this.checkForEDTFDatatype){ this.checkForEDTFDatatype = useConfigStore().checkForEDTFDatatype}
 
 		if (userValue['@datatype']){
@@ -202,7 +202,7 @@ const utilsExport = {
 		}else if (this.checkForEDTFDatatype.indexOf(property) >-1)  {
 			let dataType = false
 			// try to parse the value if it parses use the edtf data type
-			try { parseEDTF(userValue[property]); dataType = "http://id.loc.gov/datatypes/edtf" } catch { dataType = false }			
+			try { parseEDTF(userValue[property]); dataType = "http://id.loc.gov/datatypes/edtf" } catch { dataType = false }
 			if (dataType){
 				p.setAttributeNS(this.namespace.rdf, 'rdf:datatype', dataType)
 			}
@@ -217,7 +217,7 @@ const utilsExport = {
 		if (userValue['@gacs']){
 			p.setAttribute('rdf:datatype', userValue['@gacs'])
 		}
-		
+
 
 		// doesnt work :(
 		// p.removeAttributeNS("http://www.w3.org/2000/xmlns/", 'xmlns:rdfs')
@@ -345,7 +345,7 @@ const utilsExport = {
 		return false
 	}
 
-	
+
 
 	// if we are in dev mode let the error bubble, but otherwise catch the error and try to recover
 	if (useConfigStore().returnUrls.dev === true){
@@ -1116,6 +1116,7 @@ const utilsExport = {
 		let bf_AdminMetadtat = this.createElByBestNS("bf:AdminMetadata")
 		let bf_status = this.createElByBestNS("bf:status")
 		let bf_Status = this.createElByBestNS("bf:Status")
+
 		bf_Status.setAttributeNS(this.namespace.rdf, 'rdf:about','http://id.loc.gov/vocabulary/mstatus/c')
 		let bf_StatusLabel = this.createElByBestNS("rdfs:label")
 		bf_StatusLabel.innerHTML="changed"

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -149,7 +149,7 @@ const utilsNetwork = {
         uris=[uris]
       }
 
-      let results = {metadata:{ uri:uris[0]+'KEYWORD', values:{}  }}      
+      let results = {metadata:{ uri:uris[0]+'KEYWORD', values:{}  }}
       for (let uri of uris){
 
 
@@ -525,6 +525,7 @@ const utilsNetwork = {
           try{
             let response = await fetch(jsonuri);
             let data =  await response.json()
+
             return  data;
 
           }catch(err){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1971,7 +1971,6 @@ export const useProfileStore = defineStore('profile', {
             let thisLevelType
 
             for (let p of propertyPath){
-
                 // if the property is owl:sameAs it is the last field
                 // of where we are building the entitiy, so we don't  want
                 // bf:Agent -> owl:sameAs we just want the bf:Agent with values filed in there
@@ -2060,7 +2059,6 @@ export const useProfileStore = defineStore('profile', {
 
 
             }else if (subjectComponents.length>1){
-
                 //userValue
 
 
@@ -2083,8 +2081,6 @@ export const useProfileStore = defineStore('profile', {
                 currentUserValuePos["http://www.loc.gov/mads/rdf/v1#componentList"] = []
 
                 for (let c of subjectComponents){
-
-
                     let compo = {
                             "@guid": short.generate(),
                             "@type": c.type.replace('madsrdf:','http://www.loc.gov/mads/rdf/v1#'),


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/LCAP-3721

This should finish work started in a previous commit (#37). 

This addresses issues when a user adds something to a complex Authorized Heading. For example, if the user selects `Korea--History` and then adds `--Fiction` to it, the resulting MARC would maintain `Korea--History` as a single entry:

![image](https://github.com/user-attachments/assets/d9d0987d-c9f1-454b-aa87-ef140b5505f0)

Now, after the user adds the subject to the record, there's a check if there is a mixture of complex subjects, `Korea--History`, and non-complex, `Fiction`. If there is and the complex subject is not a GEO term, it will create new components for each piece of the complex heading with the appropriate type and URI in the componentList:

| Current XML            |  Updated XML |
:---------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/dc70dce6-861c-4758-aea9-f48876f6b26f)|![image](https://github.com/user-attachments/assets/4b52e7e4-8dea-4eea-985c-fcc12cbc39ff)

This loses some information. Namely that there is an authorized heading `Korea--History`. But I'm not sure if that matters because `Korea--History` is really `$aKorea$xHistory` which is what the result of the splitting is.
