### PR TITLE
Minor search updates

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -719,7 +719,6 @@ export default {
 
     // Open the authority `panel` for an given authority
     openAuthority: function() {
-      console.info("Opening Auth")
       let label = this.$refs.el[0].innerHTML
       this.profileData = this.profileStore.returnStructureByGUID(this.guid)
 

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -735,7 +735,6 @@ export default {
       this.searchValue = label
       this.displaySubjectModal = true
 
-      console.info("this.authorityLookup: ", this.authorityLookup)
     },
 
 

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -719,6 +719,7 @@ export default {
 
     // Open the authority `panel` for an given authority
     openAuthority: function() {
+      console.info("Opening Auth")
       let label = this.$refs.el[0].innerHTML
       this.profileData = this.profileStore.returnStructureByGUID(this.guid)
 
@@ -733,6 +734,8 @@ export default {
       this.authorityLookup = label
       this.searchValue = label
       this.displaySubjectModal = true
+
+      console.info("this.authorityLookup: ", this.authorityLookup)
     },
 
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -177,7 +177,6 @@
 
 
         this.searchTimeout = window.setTimeout(async ()=>{
-          console.info("searching: ", searchPayload)
           this.activeComplexSearchInProgress = true
           this.activeComplexSearch = []
           this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
@@ -185,7 +184,6 @@
           this.initalSearchState =false;
         }, 500)
       },
-
 
 
       inputKeydown: function(event){
@@ -335,7 +333,6 @@
 
       forceSearch: function(){
         //reset the search and do it again
-        console.info("search: ", this.searchValueLocal)
         this.currentPage = 1
         this.doSearch()
       },

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -332,9 +332,13 @@
         }
       },
 
+      forceSearch: function(){
+        console.info("search: ", this.searchValueLocal)
+        this.currentPage = 1
+        this.doSearch()
+      },
+
     },
-
-
 
     updated: function(){
       if (this.authorityLookup == null){
@@ -448,9 +452,9 @@
                 </select>
               </template>
               <input class="lookup-input" v-model="searchValueLocal" ref="inputLookup" @keydown="inputKeydown($event)" type="text" />
-
+              <button @click="forceSearch()">Search</button>
+              <hr style="margin-top: 5px;;">
               <div>
-
 
                   <select size="100" ref="selectOptions" class="modal-entity-select" @change="selectChange($event)"  @keydown="selectNav($event)">
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -175,14 +175,13 @@
             }
           })
 
-
         this.searchTimeout = window.setTimeout(async ()=>{
           this.activeComplexSearchInProgress = true
           this.activeComplexSearch = []
           this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
           this.activeComplexSearchInProgress = false
           this.initalSearchState =false;
-        }, 500)
+        }, 400)
       },
 
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -453,7 +453,7 @@
               </template>
               <input class="lookup-input" v-model="searchValueLocal" ref="inputLookup" @keydown="inputKeydown($event)" type="text" />
               <button @click="forceSearch()">Search</button>
-              <hr style="margin-top: 5px;;">
+              <hr style="margin-top: 5px;">
               <div>
 
                   <select size="100" ref="selectOptions" class="modal-entity-select" @change="selectChange($event)"  @keydown="selectNav($event)">

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -177,12 +177,13 @@
 
 
         this.searchTimeout = window.setTimeout(async ()=>{
+          console.info("searching: ", searchPayload)
           this.activeComplexSearchInProgress = true
           this.activeComplexSearch = []
           this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
           this.activeComplexSearchInProgress = false
           this.initalSearchState =false;
-        }, 400)
+        }, 500)
       },
 
 
@@ -333,6 +334,7 @@
       },
 
       forceSearch: function(){
+        //reset the search and do it again
         console.info("search: ", this.searchValueLocal)
         this.currentPage = 1
         this.doSearch()

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -807,6 +807,8 @@ methods: {
         console.error(err)
       }
     }
+
+    console.info('Final componetLookup: ', this.componetLookup)
   },
   /**
    * Creates components from the search string
@@ -817,6 +819,8 @@ methods: {
   buildComponents: function(searchString){
     let subjectStringSplit = searchString.split('--')
 
+    console.info("subjectStringSplit: ", subjectStringSplit)
+    let targetIndex = []
     let componentLookUpCount = Object.keys(this.componetLookup).length
     if (componentLookUpCount > 0){ //We are dealing with a hierarchical GEO and need to stitch some terms together
       if (componentLookUpCount < subjectStringSplit.length){
@@ -825,22 +829,27 @@ methods: {
           for (let j in this.componetLookup[i]) {
             if (this.componetLookup[i][j].label.includes("--")){
               target = this.componetLookup[i][j].label.replaceAll("-", "‑")
+              targetIndex = i
             }
           }
         }
         let matchIndx = []
+        console.info("target: ", target)
         if (target){
           for (let i in subjectStringSplit){
             if (target.includes(subjectStringSplit[i])){
               matchIndx.push(i)
             }
           }
+          console.info("matchIndex: ", matchIndx)
+          console.info("targetIndex: ", targetIndex)
           //remove them
           for (let i = matchIndx.length-1; i >=0; i--){
             subjectStringSplit.splice(matchIndx[i], 1)
           }
           // add the combined terms
-          subjectStringSplit.push(target)
+          // subjectStringSplit.push(target)
+          subjectStringSplit.splice(targetIndex, 0, target)
         }
       }
     }
@@ -885,6 +894,8 @@ methods: {
 
     //make sure the searchString matches the components
     this.subjectString = this.components.map((component) => component.label).join("--")
+
+    console.info("built components: ", this.components)
   },
 
   /**
@@ -2323,8 +2334,10 @@ mounted: function(){},
 
 updated: function() {
   // this was opened from an existing subject
+  console.info("this one")
   let profileData = this.profileData
   let incomingSubjects
+
   if (profileData && profileData.propertyLabel != "Subjects"){
     incomingSubjects = false
   } else if (profileData) {
@@ -2335,6 +2348,7 @@ updated: function() {
     }
   }
 
+  console.info("incomingSubjects: ", incomingSubjects)
   //When there is existing data, we need to make sure that the number of components matches
   // the number subjects in the searchValue
   if (this.searchValue && this.components.length != this.searchValue.split("--")){

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -796,7 +796,6 @@ methods: {
         lookUp = "http://www.w3.org/2000/01/rdf-schema#label"
       }
       try {
-        console.info("???1")
         let label = incomingSubjects[subjIdx][lookUp][0][lookUp].replaceAll("-", "‑")
 
         //Set up componentLookup, so the component builder can give them URIs
@@ -820,9 +819,7 @@ methods: {
    * but there won't be components.
    */
   buildComponents: function(searchString){
-    console.info("building components: ", searchString)
     let subjectStringSplit = searchString.split('--')
-    console.info("subjectStringSplit: ", subjectStringSplit)
 
     let targetIndex = []
     let componentLookUpCount = Object.keys(this.componetLookup).length
@@ -832,9 +829,7 @@ methods: {
         for (let i in this.componetLookup){
           for (let j in this.componetLookup[i]) {
             if (this.componetLookup[i][j].label.includes("--")){
-              console.info("???2", this.componetLookup[i][j])
               target = this.componetLookup[i][j].label.replaceAll("-", "‑")
-              console.info("target: ", target)
               targetIndex = i  // needs this to ensure the target will go into the search string in the right place
             }
           }
@@ -901,11 +896,9 @@ methods: {
       id++
     }
 
-    console.info("built components: ", this.components)
     //make sure the searchString matches the components
     this.subjectString = this.components.map((component) => component.label).join("--")
 
-    console.info("subjectString: ", this.subjectString)
 
   },
 
@@ -1019,7 +1012,6 @@ methods: {
         if (this.components[c].uri == null && this.components[c].literal != true){
           looseComponents.push(this.components[c])
           indx.push(c)
-          console.info("???3")
           componentMap.push("-")
         } else {
           componentMap.push(c)
@@ -1200,7 +1192,6 @@ methods: {
     }, 10000)
 
 
-    console.info("???8")
     searchString=searchString.replaceAll('‑','-')
     searchStringFull=searchStringFull.replaceAll('‑','-')
 
@@ -1607,7 +1598,6 @@ methods: {
       this.searchModeSwitch("WORKS")
 
     }else if (this.searchMode == 'GEO' && event.key == "-"){
-      console.info("???4")
       if (this.components.length>0){
         let lastC = this.components[this.components.length-1]
         console.log(lastC)
@@ -1619,7 +1609,6 @@ methods: {
         }
 
         // if the last string is a normal "-" then make this one normal too
-        console.info("???5")
         if (this.subjectString.slice(-1) == '-'){
           return true
         }
@@ -1793,7 +1782,6 @@ methods: {
           this.activeComponentIndex = c.id
           // it is not empty
           // it dose not end with "-" so it the '--' typing doesn't trigger
-          console.info("???6", c)
           if (c.label.trim() != '' && !c.label.endsWith('-')){
             this.searchApis(c.label,event.target.value,this)
 
@@ -1992,7 +1980,6 @@ methods: {
     console.log('this.components',this.components)
     // remove our werid hyphens before we send it back
     for (let c of this.components){
-      console.info("???7")
       c.label = c.label.replaceAll('‑','-')
 
       // we have the full mads type from the build process, check if the component is a id name authortiy
@@ -2350,7 +2337,6 @@ mounted: function(){},
 
 
 updated: function() {
-  console.info("updating", this.searchValue)
   // this was opened from an existing subject
   let profileData = this.profileData
   let incomingSubjects

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -201,10 +201,11 @@ const utilsNetwork = {
     */
     fetchSimpleLookup: async function(url, json) {
       // if there is already a controller, send the abort command
-      if (this.controller){
-        this.controller.abort()
-      }
-      this.controller = new AbortController();
+      // if (this.controller){
+      //   this.controller.abort()
+      // }
+      // this.controller = new AbortController();
+      // const signal = this.controller.signal
 
       url = url || config.profileUrl
       if (url.includes("id.loc.gov")){
@@ -221,7 +222,8 @@ const utilsNetwork = {
       // console.log("url:",url)
       // console.log('options:',options)
       try{
-        let response = await fetch(url,options, {signal: signal});
+        // let response = await fetch(url,options, {signal: signal});
+        let response = await fetch(url,options);
         let data = null
         if (response.status == 404){
           return false
@@ -233,12 +235,13 @@ const utilsNetwork = {
           data =  await response.json()
         }
         //reset the controller
-        this.controller = false
+        // this.controller = false
 
         //If the signal was abort, don't return anything
-        if (signal.aborted){
-          return false
-        }
+        // if (signal.aborted){
+        //   console.info("aborted")
+        //   return false
+        // }
         return  data;
       }catch(err){
         //alert("There was an error retriving the record from:",url)
@@ -299,8 +302,6 @@ const utilsNetwork = {
     * @return {array} - An array of {@link searchComplexResult} results
     */
     searchComplex: async function(searchPayload){
-
-
       // console.log("searchPayload",searchPayload)
 
 
@@ -1965,7 +1966,6 @@ const utilsNetwork = {
     * @return {} -
     */
     subjectSearch: async function(searchVal,complexVal,mode){
-
       let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_NamesAuthorizedHeadings'
       let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 


### PR DESCRIPTION
This has some updates to help with search.

1) Adds a dedicated `search` button. This is for when the search results are showing results that match some part of the entered value, but not the whole value. For example, searching "pak, yun", but seeing results for "pak." The button does a fresh search

2) Better handling of Indirect GEOs for incoming data. These weren't being properly parsed when they were coming in. There is a catch, when opening an existing heading that has indirect GEO, that term will need to be re-validated. There's some strangeness in the incoming data that makes it say that the two parts aren't connected.

@thisismattmiller I also tried using the [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to avoid the weird behavior related to typing speed. It worked well for the name search, but broke the subject search. I think because of the `await newPromilse.all([...])` in the subject search. It's doing several calls all at once, and they end up getting aborted, except for the last one which is often just empty. I can't figure out how to reconcile this behavior. One option might be to use a different `fetchSimpleLookup` for the subject lookups than the other lookups, or pass it a flag? The code is still there but commented out.