### PR TITLE
[LCAP-3777] Complex Search Tuning

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -160,7 +160,7 @@
           processor: null,
           url: [],
           searchValue: this.searchValueLocal,   //This changed from searchValueLocal, to match what is expected in `utils_network.js`
-          signal: this.controller.signal
+          signal: this.controller.signal        //Allows canceling the correct call
         }
         // if (this.modeSelect == 'All'){
         //   this.modalSelectOptions.forEach((a)=>{
@@ -183,12 +183,13 @@
             }
           })
 
+        // wrapping this in setTimeout might not be needed anymore
         this.searchTimeout = window.setTimeout(async ()=>{
           this.activeComplexSearchInProgress = true
           this.activeComplexSearch = []
           this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
           this.activeComplexSearchInProgress = false
-          this.initalSearchState =false;
+          this.initalSearchState =false
         }, 400)
       },
 
@@ -237,6 +238,7 @@
               toLoad = this.activeComplexSearch[idx]
               try{
                 this.$refs.selectOptions.selectedIndex = idx
+                break
               } catch(err) {
                 console.log("")
               }
@@ -262,6 +264,7 @@
             "literal": true,
             "loading":true,
           }
+
         if (toLoad && toLoad.literal){
           return false
         }
@@ -281,8 +284,6 @@
 
 
         this.activeContext = results
-
-
       },
 
       rewriteURI: function(uri){

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -38,6 +38,7 @@
 
         activeComplexSearch: [],
         activeComplexSearchInProgress: false,
+        controller: new AbortController(),
 
         initalSearchState: true,
 
@@ -117,6 +118,12 @@
 
       // watching the search input, when it changes kick off a search
       doSearch: async function(){
+        //if there is an ongoing search, abort it
+        if (this.activeComplexSearchInProgress){
+          this.controller.abort()
+          this.controller = new AbortController()
+        }
+
         if (!this.searchValueLocal){ return false}
 
         if (this.searchValueLocal.trim()==''){
@@ -152,7 +159,8 @@
         let searchPayload = {
           processor: null,
           url: [],
-          searchValue: this.searchValueLocal   //This changed from searchValueLocal, to match what is expected in `utils_network.js`
+          searchValue: this.searchValueLocal,   //This changed from searchValueLocal, to match what is expected in `utils_network.js`
+          signal: this.controller.signal
         }
         // if (this.modeSelect == 'All'){
         //   this.modalSelectOptions.forEach((a)=>{

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1946,8 +1946,8 @@ const utilsNetwork = {
     * @return {} -
     */
     subjectSearch: async function(searchVal,complexVal,mode){
-      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_NamesAuthorizedHeadings'
-      let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings'
+      let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
 
       let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
@@ -2165,7 +2165,7 @@ const utilsNetwork = {
         'names': pos == 0 ? resultsNames : resultsNamesSubdivision,
         'hierarchicalGeographic':  pos == 0 ? [] : resultsHierarchicalGeographic
       }
-
+      console.info(results)
       return results
 
     },

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1947,7 +1947,7 @@ const utilsNetwork = {
     */
     subjectSearch: async function(searchVal,complexVal,mode){
       let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings'
-      let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
+      let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
       let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -17,12 +17,6 @@ const utilsNetwork = {
     // a cache to keep previosuly requested vocabularies and lookups in memory for use again
     lookupLibrary : {},
 
-    //abort controller
-    searching: false,
-    controller: new AbortController(),
-    currentURL: "",
-    prevURL: "",
-
     /**
     * processes the data returned from id vocabularies
     *

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -354,10 +354,14 @@ const utilsNetwork = {
                 // console.log("URL",url)
                 // console.log("r",r)
                 for (let hit of r.hits){
-                  let context = await this.returnContext(hit.uri)
+                  let context = null
+                  // we only need the context for the subject search to have collection information in the output
+                  if(searchPayload.subjectSearch == true){
+                    context = await this.returnContext(hit.uri)
+                  }
 
                   let hitAdd = {
-                    collections: context.nodeMap["MADS Collection"],
+                    collections: context ? context.nodeMap["MADS Collection"] : [],
                     label: hit.aLabel,
                     vlabel: hit.vLabel,
                     suggestLabel: hit.suggestLabel,
@@ -372,11 +376,7 @@ const utilsNetwork = {
                     hitAdd.label  = hitAdd.suggestLabel.split('(DEPRECATED')[0] + ' DEPRECATED'
                     hitAdd.depreciated = true
                   }
-
-
                   results.push(hitAdd)
-
-
                 }
 
 
@@ -1985,23 +1985,27 @@ const utilsNetwork = {
       let searchPayloadNames = {
         processor: 'lcAuthorities',
         url: [namesUrl],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
       let searchPayloadNamesSubdivision = {
         processor: 'lcAuthorities',
         url: [namesUrlSubdivision],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
 
       let searchPayloadSubjectsSimple = {
         processor: 'lcAuthorities',
         url: [subjectUrlSimple],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
       let searchPayloadSubjectsSimpleSubdivision = {
         processor: 'lcAuthorities',
         url: [subjectUrlSimpleSubdivison],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
       let searchPayloadTemporal = {
         processor: 'lcAuthorities',
@@ -2017,38 +2021,44 @@ const utilsNetwork = {
       let searchPayloadSubjectsComplex = {
         processor: 'lcAuthorities',
         url: [subjectUrlComplex],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
 
 
       let searchPayloadHierarchicalGeographic = {
         processor: 'lcAuthorities',
         url: [subjectUrlHierarchicalGeographic],
-        searchValue: searchValHierarchicalGeographic
+        searchValue: searchValHierarchicalGeographic,
+        subjectSearch: true
       }
 
       let searchPayloadWorksAnchored = {
         processor: 'lcAuthorities',
         url: [worksUrlAnchored],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
 
       let searchPayloadWorksKeyword = {
         processor: 'lcAuthorities',
         url: [worksUrlKeyword],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
 
       let searchPayloadHubsAnchored = {
         processor: 'lcAuthorities',
         url: [hubsUrlAnchored],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
 
       let searchPayloadHubsKeyword = {
         processor: 'lcAuthorities',
         url: [hubsUrlKeyword],
-        searchValue: searchVal
+        searchValue: searchVal,
+        subjectSearch: true
       }
 
 


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/LCAP-3777

This should address issues in the ticket:

* Timing and results: this will now `abort` the previous search if hasn't finished yet but the user is still typing. This should prevent timing issues that cause the results of the most recent search to be overridden by the results of an earlier search. [Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
* Slowness: In order to get the collection information to display in the search results, "Dogs **(Auth Hd)**", it was necessary to get the context for each term in the search result. This works fine with the subjects because the results are limited to just a few, but was happening with every search and was causing slowdown in the complex search results.

Unfortunately, this fix for the timing does not work with the subject search. Because the subject search performs several searches at once, using an `AbortController` doesn't work because each subsequent search will cancel the one before it and there will only be results for the last search.

Also fixes an unrelated bug.