### PR TITLE
[LCAP 3744] Fix messy XML

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -447,10 +447,8 @@ const utilsNetwork = {
     * @return {array} - An array of {@link contextResult} results
     */
     returnContext: async function(uri){
-      console.info("getting context for ", uri)
         let d = await this.fetchContextData(uri)
         d.uri = uri
-      console.info("d: ", d)
         let results
 
         if (uri.includes('resources/works/') || uri.includes('resources/hubs/')){
@@ -459,7 +457,6 @@ const utilsNetwork = {
           results =  this.extractContextData(d)
         }
 
-        console.info("results: ", results)
         return results
 
     },
@@ -765,7 +762,6 @@ const utilsNetwork = {
               || data.uri.includes('id.loc.gov/resources/instances/')
               || data.uri.includes('id.loc.gov/resources/hubs/')
           ){
-            console.info("data.uri: ", data.uri)
             let uriIdPart = data.uri.split('/').slice(-1)[0]
 
             //find the right graph
@@ -792,7 +788,6 @@ const utilsNetwork = {
 
                   if (g['@type'] && g['@type'][0]){
                     results.type = this.rdfType(g['@type'][0])
-                    console.info("setting type: ", g['@type'][0])
                     results.typeFull = g['@type'][0]
                   }
                 }
@@ -804,8 +799,6 @@ const utilsNetwork = {
             if (data['@graph']){
               data = data['@graph'];
             }
-
-            console.info("data: ", data)
 
             var nodeMap = {};
 
@@ -978,8 +971,6 @@ const utilsNetwork = {
               }
 
               if (n['@id'] && n['@id'] == data.uri && n['@type']){
-                console.info(n)
-                  console.info("Another one: ", n["@type"])
                   n['@type'].forEach((t)=>{
                       if (results.type===null){
                           results.type = this.rdfType(t)

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -447,10 +447,10 @@ const utilsNetwork = {
     * @return {array} - An array of {@link contextResult} results
     */
     returnContext: async function(uri){
-
+      console.info("getting context for ", uri)
         let d = await this.fetchContextData(uri)
         d.uri = uri
-
+      console.info("d: ", d)
         let results
 
         if (uri.includes('resources/works/') || uri.includes('resources/hubs/')){
@@ -459,6 +459,7 @@ const utilsNetwork = {
           results =  this.extractContextData(d)
         }
 
+        console.info("results: ", results)
         return results
 
     },
@@ -764,6 +765,7 @@ const utilsNetwork = {
               || data.uri.includes('id.loc.gov/resources/instances/')
               || data.uri.includes('id.loc.gov/resources/hubs/')
           ){
+            console.info("data.uri: ", data.uri)
             let uriIdPart = data.uri.split('/').slice(-1)[0]
 
             //find the right graph
@@ -790,6 +792,7 @@ const utilsNetwork = {
 
                   if (g['@type'] && g['@type'][0]){
                     results.type = this.rdfType(g['@type'][0])
+                    console.info("setting type: ", g['@type'][0])
                     results.typeFull = g['@type'][0]
                   }
                 }
@@ -801,6 +804,8 @@ const utilsNetwork = {
             if (data['@graph']){
               data = data['@graph'];
             }
+
+            console.info("data: ", data)
 
             var nodeMap = {};
 
@@ -973,7 +978,8 @@ const utilsNetwork = {
               }
 
               if (n['@id'] && n['@id'] == data.uri && n['@type']){
-
+                console.info(n)
+                  console.info("Another one: ", n["@type"])
                   n['@type'].forEach((t)=>{
                       if (results.type===null){
                           results.type = this.rdfType(t)

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -123,7 +123,6 @@ const utilsProfile = {
   * @return {object|boolean} - will return the obj or false if not found
   */
   returnPt: function(profile,guid){
-
       for (let rt in profile.rt){
         for (let pt in profile.rt[rt].pt){
           if (profile.rt[rt].pt[pt]['@guid'] === guid){
@@ -257,7 +256,7 @@ const utilsProfile = {
         console.error("There was an unknown error trying to create a blank node in", propertyPath, ' in ', pt)
       }
 
-      this.setTypesForBlankNode(pt,propertyPath)      
+      this.setTypesForBlankNode(pt,propertyPath)
       return [pt, pointer['@guid']]
   },
 
@@ -678,7 +677,7 @@ const utilsProfile = {
                     // workUriUsed=true
                 }
             }
-        }      
+        }
         // if there are no instances yet use the instanceURIbasedOnWork
         if (instanceCount==0){
             return instanceURIbasedOnWork

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -25,8 +25,8 @@ export const useConfigStore = defineStore('config', {
         profiles : 'http://localhost:9401/util/profiles/profile/prod',
         starting: 'http://localhost:9401/util/profiles/starting/prod',
 
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2942,9 +2942,6 @@ export const useProfileStore = defineStore('profile', {
     // locate the correct pt to work on in the activeProfile
     let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
-    console.info("pt: ", pt)
-    console.info("structure: ", structure)
-
     if (pt !== false){
 
       let baseURI = pt.propertyURI

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2961,7 +2961,7 @@ export const useProfileStore = defineStore('profile', {
           if (this.rtLookup[structure.parentId]){
               for (let p of this.rtLookup[structure.parentId].propertyTemplates){
                 // dose it have a default value?
-                if (p.valueConstraint.defaults && p.valueConstraint.defaults.length>0){
+                if (p.valueConstraint.defaults && p.valueConstraint.defaults.length>0 && p.propertyURI == baseURI){
                   if (p.valueConstraint.valueTemplateRefs && p.valueConstraint.valueTemplateRefs.length>0){
                     // they are linking to another template in this template, so if we ant to populate the imformation we would need to know what predicate to use :(((((
                     if (this.rtLookup[p.valueConstraint.valueTemplateRefs[0]] && this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates && this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates.length==1){
@@ -3033,12 +3033,12 @@ export const useProfileStore = defineStore('profile', {
                         }
 
                       }
-                      // userValue[p.propertyURI].push(value)
+                      userValue[p.propertyURI].push(value)
                       // don't add the defaults if the @type doesn't match the baseURI
                       // Is there any danger here of side effects?
-                      if (baseURI == value['@type']){
-                        userValue[p.propertyURI].push(value)
-                      }
+                      // if (baseURI == value['@type']){
+                      //   userValue[p.propertyURI].push(value)
+                      // }
                     }
                   }
                 }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2942,6 +2942,9 @@ export const useProfileStore = defineStore('profile', {
     // locate the correct pt to work on in the activeProfile
     let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
+    console.info("pt: ", pt)
+    console.info("structure: ", structure)
+
     if (pt !== false){
 
       let baseURI = pt.propertyURI

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1849,15 +1849,14 @@ export const useProfileStore = defineStore('profile', {
       // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
-      console.info("lastProp: ", lastProperty)
       if (!type && URI && !lastProperty.includes("intendedAudience")){
         // I regretfully inform you we will need to look this up
         let context = await utilsNetwork.returnContext(URI)
-        console.info("context: ", context)
         type = context.typeFull
 
       }
-      // literals don't have a type or a URI & intended audience has extra considerations
+      // literals don't have a type or a URI & intendedAudience has extra considerations
+      // namely that the rdf:Type in BF is bf:Authority
       if ((!type && !URI) || lastProperty.includes("intendedAudience")){
         type = await utilsRDF.suggestTypeProfile(lastProperty, pt)
         if (type == false){
@@ -1890,7 +1889,6 @@ export const useProfileStore = defineStore('profile', {
 
           // overwrite whatever the helper methods set the type to for this one, we know the final
           // type and what it needs to be
-          console.info("setting type: ", type)
           blankNode['@type'] = type
 
 
@@ -1953,8 +1951,6 @@ export const useProfileStore = defineStore('profile', {
 
 
       console.log("pt is ",pt)
-
-
     },
 
     /**
@@ -2940,7 +2936,6 @@ export const useProfileStore = defineStore('profile', {
       */
 
   insertDefaultValuesComponent: async function(componentGuid, structure){
-
     // console.log(componentGuid)
     // console.log("structure",structure)
 
@@ -3038,7 +3033,12 @@ export const useProfileStore = defineStore('profile', {
                         }
 
                       }
-                      userValue[p.propertyURI].push(value)
+                      // userValue[p.propertyURI].push(value)
+                      // don't add the defaults if the @type doesn't match the baseURI
+                      // Is there any danger here of side effects?
+                      if (baseURI == JSON.parse(JSON.stringify(userValue))["@type"]){
+                        userValue[p.propertyURI].push(value)
+                      }
                     }
                   }
                 }
@@ -3058,7 +3058,6 @@ export const useProfileStore = defineStore('profile', {
     }else{
       console.error('insertDefaultValuesComponent: Cannot locate the component by guid', componentGuid, this.activeProfile)
     }
-
   },
 
 
@@ -3173,8 +3172,6 @@ export const useProfileStore = defineStore('profile', {
         console.error('duplicateComponent: Cannot locate the component by guid', componentGuid, this.activeProfile)
 
       }
-
-
     },
 
     /**

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1849,13 +1849,16 @@ export const useProfileStore = defineStore('profile', {
       // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
-      if (!type && URI){
+      console.info("lastProp: ", lastProperty)
+      if (!type && URI && !lastProperty.includes("intendedAudience")){
         // I regretfully inform you we will need to look this up
         let context = await utilsNetwork.returnContext(URI)
+        console.info("context: ", context)
         type = context.typeFull
+
       }
-      // literals don't have a type or a URI
-      if (!type && !URI){
+      // literals don't have a type or a URI & intended audience has extra considerations
+      if ((!type && !URI) || lastProperty.includes("intendedAudience")){
         type = await utilsRDF.suggestTypeProfile(lastProperty, pt)
         if (type == false){
           type = await utilsRDF.suggestTypeNetwork(lastProperty)
@@ -1887,6 +1890,7 @@ export const useProfileStore = defineStore('profile', {
 
           // overwrite whatever the helper methods set the type to for this one, we know the final
           // type and what it needs to be
+          console.info("setting type: ", type)
           blankNode['@type'] = type
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3036,7 +3036,7 @@ export const useProfileStore = defineStore('profile', {
                       // userValue[p.propertyURI].push(value)
                       // don't add the defaults if the @type doesn't match the baseURI
                       // Is there any danger here of side effects?
-                      if (baseURI == JSON.parse(JSON.stringify(userValue))["@type"]){
+                      if (baseURI == value['@type']){
                         userValue[p.propertyURI].push(value)
                       }
                     }


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/LCAP-3744

@thisismattmiller I think this is going to need you to look over it.

It has fixes for two bugs.

1) The `fullType` returned by `returnContext()` was `bf:Authority` for intended audience. This was because that is the `rdf:type` in the rdf for the record. The fix relies on the `suggestTypeProfile()` function just like it uses for literals. I'm not sure if there's something else that is going on or needs to be done. [RDF file](https://id.loc.gov/authorities/demographicTerms/dg2015060024.rdf). The result was XML like
```xml
<bf:intendedAudience>
  <madsrdf:Authority xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"rdf:about="http://id.loc.gov/authorities/demographicTerms/dg2022060116">
  <rdfs:label xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
    Bulgarian, Students of
  </rdfs:label>
  <bflc:marcKey xmlns:bflc="http://id.loc.gov/ontologies/bflc/">
    150 $aBulgarian, Students of
  </bflc:marcKey>
  </madsrdf:Authority>
</bf:intendedAudience>
```

2) This is the one that needs a look because I'm not sure if there could be some side effect. There was a weird bug where when you add an additional `IntendedAudience` field, it would pull the defaults from the `Context` template. I added a check that uses the URIs of the components to make sure that defaults don't bleed into other components. This [line](https://github.com/lcnetdev/marva-quartz/blob/main/src/stores/profile.js#L3037) is where the `bf:Content` defaults are getting added to the `userValue`

I think it should be fine because the fix is only making sure that defaults are being added when the `baseURI` of the duplicated component matches the `@type` of the component that is the source of the default information.

To reproduce:
1) open Marva (any instance)
2) Create an additional `Intended Audience`
3) add something to the new audience field
4) look at the XML preview and you'll see `bf:content` block

```xml
<bf:intendedAudience>
    <bf:IntendedAudience>
        <bf:content>
            <bf:Contentrdf:about="http://id.loc.gov/vocabulary/contentTypes/txt">
                <rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
                    text
                </rdfs:label>
            </bf:Content>
        </bf:content>
        <rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
                literal2
        </rdfs:label>
    </bf:IntendedAudience>
</bf:intendedAudience>
```