### PR TITLE
Fix name is complex

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -884,7 +884,7 @@ methods: {
         uri: uri,
         id: id,
         type:type,
-        complex: ss.includes('‑'),
+        complex: ss.includes('‑‑'),
         literal:literal,
         posStart: activePosStart,
         posEnd: activePosStart + ss.length,

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -796,7 +796,7 @@ methods: {
         lookUp = "http://www.w3.org/2000/01/rdf-schema#label"
       }
       try {
-        let label = incomingSubjects[subjIdx][lookUp][0][lookUp].replaceAll("-", "‑")
+        let label = incomingSubjects[subjIdx][lookUp][0][lookUp].replaceAll("--", "‑‑")
 
         //Set up componentLookup, so the component builder can give them URIs
         this.componetLookup[subjIdx][label] = {
@@ -2248,7 +2248,7 @@ methods: {
             uri: uri,
             id: id,
             type:type,
-            complex: label.includes('‑'),
+            complex: label.includes('‑‑'),
             literal:literal,
             posStart: activePosStart,
             posEnd: activePosStart + label.length - 1,

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 14,
-    versionPatch: 16,
+    versionPatch: 17,
 
     regionUrls: {
 


### PR DESCRIPTION
The name was being marked as complex because it had a `not` hyphen in it. There was a birth date, but no death date. 

Whether some is "complex" is based on 2 `not` hyphens instead of one with some other adjustments to help.