### PR TITLE
Display non uri related works better

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -12,7 +12,7 @@
 
       </template>
       <template v-else>
-
+        
         <template v-for="(avl,idx) in complexLookupValues" class="">
           <span class="bfcode-display-mode-holder-label" :title="structure.propertyLabel">{{profileStore.returnBfCodeLabel(structure)}}:</span>
 
@@ -56,7 +56,6 @@
   </template>
 
   <template v-else>
-
   <!-- <div>Complext Lookup ({{propertyPath.map((x)=>{return x.propertyURI}).join('->')}})</div> -->
       <form autocomplete="off" v-on:submit.prevent >
 
@@ -107,7 +106,7 @@
                 </div>
                 <div class="selected-value-container-title">
                   <!-- <span class="material-icons check-mark">check_circle_outline</span> -->
-                  <span v-if="!avl.needsDereference" style="padding-right: 0.3em; font-weight: bold">
+                  <span v-if="!avl.needsDereference && !avl.uneditable " style="padding-right: 0.3em; font-weight: bold">
                     <!-- <a v-if="!this.configStore.useSubjectEditor.includes(this.structure.propertyURI)" href="#" @click="openAuthority()" ref="el">{{avl.label}}</a>
                     <span v-else>{{avl.label}}</span> -->
                     <span v-if="avl.source && avl.source=='FAST'" style="font-weight: bold;">(FAST) </span>
@@ -118,9 +117,10 @@
                     <span v-if="!avl.isLiteral" title="Controlled Term" class="selected-value-icon" style="">
                     </span>
                   </span>
-                  <span v-else style="padding-right: 0.3em; font-weight: bold"><LabelDereference :URI="avl.URI"/><span v-if="!avl.isLiteral" title="Controlled Term" class="selected-value-icon"><span class="material-icons check-mark">check_circle_outline</span></span></span>
+                  <span v-else-if="avl.needsDereference" style="padding-right: 0.3em; font-weight: bold"><LabelDereference :URI="avl.URI"/><span v-if="!avl.isLiteral" title="Controlled Term" class="selected-value-icon"><span class="material-icons check-mark">check_circle_outline</span></span></span>
+                  <span v-else-if="avl.uneditable" style="padding-right: 0.3em; font-weight: bold">{{ avl.label }} (Uneditable)</span>
                 </div>
-                <div class="selected-value-container-action">
+                <div class="selected-value-container-action" v-if="!avl.uneditable">
                   <span @click="removeValue(idx)" style="border-left: solid 1px black; padding: 0 0.5em; font-size: 1em; cursor: pointer;">x</span>
                 </div>
               </div>

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -485,6 +485,8 @@ const utilsParse = {
               // check to see if this pt has that hint value in the valueConstraint  valueTemplateRefs
               if (ptk.valueConstraint.valueTemplateRefs.indexOf(e.attributes['local:pthint'].value) > -1){
                 // it matches, so use this one for sure
+                // make sure to remove the hint attribute
+                e.removeAttribute('local:pthint')
                 el.push(e)
               }else{
                 // if it doesn't match that might mean there is a better match further in the pts or it could mean it will never match
@@ -502,6 +504,7 @@ const utilsParse = {
                   continue
                 }else{
                   // we did not find a place to put this el, so we need to add it here
+                  e.removeAttribute('local:pthint')
                   el.push(e)
                 }
               }


### PR DESCRIPTION
When loading a resource with related works that are basically nested works inside the work it will flag those as uneditable and just display them. Before it just didn't display anything.
It looks like this:

![image](https://github.com/user-attachments/assets/456171db-28f8-4bc6-98f9-7f01bfebba9a)

The first related work does not have a URI, so it is just a big nested blanknode, you can edit other parts of the component like the relationship but you cannot edit the work itself, only remove it.