### PR TITLE
Scriptshifter ver update

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -670,13 +670,10 @@ export default {
       }
 
       if (cmd == 'trans'){
-        // this.profileStore.setValueLiteral(this.guid,short.generate(),this.propertyPath,"new value",null,true)
 
         let fieldValue = this.literalValues.filter((v)=>{ return (v['@guid'] == options.fieldGuid) })
-
-
         let transValue = await utilsNetwork.scriptShifterRequestTrans(options.lang,fieldValue[0].value,null,options.dir)
-        transValue = JSON.parse(transValue)
+        
 
         let toLang = null
         let fromLang = null

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -59,21 +59,10 @@
             <template v-for="(lang,index) in scriptShifterOptionsForMenu">
 
                 <button   style="width:100%"   class="" :id="`action-button-command-${fieldGuid}-${index + 7}`"  @click="$emit('actionButtonCommand', 'trans', {lang:lang.lang,dir:lang.dir, fieldGuid: fieldGuid} )">
-                  <span v-if="index<3" class="button-shortcut-label">{{index + 7}}</span>
-                  <span class="material-icons icon" style="font-size:95%; vertical-align: middle; padding-right: 5px;">translate</span><span>{{ lang.name }}</span>
+                  <span v-if="index<3" class="button-shortcut-label">{{index + 7}}</span>                  
+                  <span class="material-icons icon" style="font-size:95%; vertical-align: middle; padding-right: 5px;">translate</span><span>{{ lang.label||lang.name }}</span>
 
                 </button>
-
-
-
-<!--
-              <button  v-if="scriptShifterOptions[lang].s2r"  style="width:100%"   class=""  @click="$emit('actionButtonCommand', 'trans', {lang:lang,dir:'s2r', fieldGuid: fieldGuid} )">
-
-                <span class="material-icons icon" style="font-size:95%; vertical-align: middle; padding-right: 5px;">translate</span><span>{{scriptShifterOptions[lang].name}} S2R</span>
-              </button>
-              <button v-if="scriptShifterOptions[lang].r2s"  style="width:100%" class=""  @click="$emit('actionButtonCommand', 'trans', {lang:lang,dir:'r2s', fieldGuid: fieldGuid} )">
-                <span class="material-icons icon" style="font-size:95%; vertical-align: middle; padding-right: 5px;">translate</span><span>{{scriptShifterOptions[lang].name}} R2S</span>
-              </button> -->
 
             </template>
 
@@ -190,14 +179,14 @@
             menuOptions.push({
               dir:'s2r',
               lang: lang,
-              name:this.scriptShifterOptions[lang].name + ' S2R'
+              name:this.scriptShifterOptions[lang].label + ' S2R'
             })
           }
           if (this.scriptShifterOptions[lang].r2s){
             menuOptions.push({
               dir:'r2s',
               lang: lang,
-              name:this.scriptShifterOptions[lang].name + ' R2S'
+              name:this.scriptShifterOptions[lang].label + ' R2S'
 
             })
           }

--- a/src/components/panels/edit/modals/ScriptshifterConfigModal.vue
+++ b/src/components/panels/edit/modals/ScriptshifterConfigModal.vue
@@ -31,7 +31,7 @@
       // other computed properties
       // ...
       // gives access to this.counterStore and this.userStore
-      // ...mapStores(usePreferenceStore),
+      ...mapStores(usePreferenceStore),
       ...mapStores(useConfigStore),
 
       
@@ -39,7 +39,19 @@
       ...mapWritableState(usePreferenceStore, ['showScriptshifterConfigModal','scriptShifterOptions']),
       ...mapWritableState(useConfigStore, ['scriptshifterLanguages']),
 
+      // 
 
+      capitalizeFirstWord: {
+      // getter
+        get() {
+          return this.preferenceStore.returnValue('--b-scriptshifter-capitalize-first-letter')
+        },
+        // setter
+        set(newValue) {
+          // Note: we are using destructuring assignment syntax here.
+          this.preferenceStore.setValue('--b-scriptshifter-capitalize-first-letter',newValue)
+        }
+      }
 
       
       
@@ -112,6 +124,8 @@
           for (let x in this.scriptshifterLanguages){
             if (this.scriptshifterLanguages[x].s2r || this.scriptshifterLanguages[x].r2s ){
               current[x] = this.scriptshifterLanguages[x]
+              current[x].name = this.scriptshifterLanguages[x].label
+              current[x].label = this.scriptshifterLanguages[x].label
             }else{
               if (current[x]){
                 delete current[x]
@@ -255,8 +269,17 @@
             </div>
             <p>Visit <a href="https://bibframe.org/scriptshifter" target="_blank">bibframe.org/scriptshifter</a> to test these languages.</p>
             
-            <hr style="margin-top: 1em; margin-bottom: 1em;"/>
+            <hr style="margin-top: 1em; margin-bottom: 1em;">
+            <div style="display: flex; align-items: center;">
+              <div style="flex: 0;"><input type="checkbox" v-model="capitalizeFirstWord" id="capitalizeFirstWord"></div>
+              <div style="flex:1; padding-left: 1em;"><label for="capitalizeFirstWord"> Capitalize first letter of transliteration</label></div>
+          
 
+
+            </div>
+
+
+            <hr style="margin-top: 1em; margin-bottom: 1em;"/>
             <table>
               <!-- <tr v-for=""></tr> -->
               <thead>
@@ -267,17 +290,17 @@
             
               <tr  v-for="l in scriptshifterLanguages">
                 <td style="width: 66%;">
-                  {{ l.name }}
+                  {{ l.label }}
                   <template v-if="l.description">
                     <br/>
                     <span style="font-size: 90%;">{{ l.description }}</span>
                   </template>
                 </td>
                 <td style="text-align: center;">
-                  <input type="checkbox" @change="updateLocalStorage" v-model="l.s2r"/>
+                  <input :disabled="l.has_s2r==false" type="checkbox" @change="updateLocalStorage" v-model="l.s2r"/>
                 </td>
                 <td style="text-align: center;"> 
-                  <input type="checkbox" @change="updateLocalStorage" v-model="l.r2s"/>
+                  <input :disabled="l.has_r2s==false" type="checkbox" @change="updateLocalStorage" v-model="l.r2s"/>
                 </td>              
               </tr>
               <!-- <input type="checkbox" v-model="optionChecks[z']"> -->

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1,4 +1,6 @@
 import {useConfigStore} from "../stores/config";
+import {usePreferenceStore} from "../stores/preference";
+
 import short from 'short-uuid'
 const translator = short();
 
@@ -2420,15 +2422,17 @@ const utilsNetwork = {
     },
 
     /**
-    * Send off a rdf bibframe xml files in the format <rdf:RDF><bf:Work/><bf:Instance/>...etc...</rdf:RDF>
+    * Request string transliteration via the backend scriptshifter API
     * @async
-    * @param {string} xml - The xml string
-    * @return {string} - the MARC in XML response
+    * @param {string} lang - The scriptshifter language code
+    * @param {string} text - The string to send to scriptshifter
+    * @param {boolean} capitalize - ask to caplitalize all the words
+    * @param {string} t_dir - s2r or r2s, not both directions are supported for all languages
+    * @return {object|false} - the response from the service
     */
     scriptShifterRequestTrans: async function(lang,text,capitalize,t_dir){
 
-
-      let url = useConfigStore().returnUrls.scriptshifter + 'trans'
+            let url = useConfigStore().returnUrls.scriptshifter + 'trans'
 
       let r = await fetch(url, {
         method: 'POST',
@@ -2450,24 +2454,18 @@ const utilsNetwork = {
         alert(results)
         return false
       }else{
+
+        results = JSON.parse(results)
+
+        // capitalize the first char if that preference is set true        
+        if (results.output){
+          if (usePreferenceStore().returnValue('--b-scriptshifter-capitalize-first-letter')){
+            results.output = results.output.charAt(0).toUpperCase() + results.output.slice(1);
+          }
+        }
         return results
       }
 
-
-
-      // const rawResponse = await fetch(url, {
-      //   method: 'POST',
-      //   headers: {
-      //     'Accept': 'application/json',
-      //     'Content-Type': 'application/json'
-      //   },
-      //   body: JSON.stringify({rdfxml:xml})
-      // });
-      // const content = await rawResponse.json();
-
-      // console.log(content);
-
-      // return content
 
     },
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 14,
-    versionPatch: 21,
+    versionPatch: 22,
 
     regionUrls: {
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -776,6 +776,18 @@ export const usePreferenceStore = defineStore('preference', {
         range: [true,false]
     },
 
+      // scriptshifter
+
+      '--b-scriptshifter-capitalize-first-letter' : {
+        desc: 'Capitalize the first letter of the transliterated string.',
+        descShort: 'Capitalize the first letter',
+        value: false,
+        type: 'boolean',
+        unit: null,
+        group: 'Scriptshifter',
+        range: [true,false]
+      },
+
 
 
     }

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -886,7 +886,6 @@ export const usePreferenceStore = defineStore('preference', {
         styleDefault: this.styleDefault,
         panelDisplay: this.panelDisplay
       }
-      console.log(bfPrefs)
       let prefs = JSON.stringify(bfPrefs)
       window.localStorage.setItem('marva-preferences',prefs)
     },
@@ -960,9 +959,6 @@ export const usePreferenceStore = defineStore('preference', {
     * @return {boolean} - Did it work
     */
     setValue: function(propertyName,value){
-      console.log(propertyName,value)
-      console.log(this.styleDefault)
-      console.log(this.styleDefault[propertyName])
       if (!this.styleDefault[propertyName]){
         return false
       }


### PR DESCRIPTION
The script shifter API had changed a property from .name to .label so the names of the languages were not displaying in the scriptshifter preference box. The API also no supports communicating if s2r and r2s directions are available, marva disables unavailable directions for each langauge.

Also add the option to capitalize first letter:

![image](https://github.com/user-attachments/assets/a017a44d-14c3-4fc4-9403-4a58c18a6356)
