### PR TITLE
Improve Subject Search Typing

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1718,6 +1718,9 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
+    console.info("subjectStringChanged: ", event.target.value)
+    console.info("    is ", this.subjectString)
+
     this.validateOkayToAdd()
 
     //fake the "click" so the results panel populates
@@ -1768,6 +1771,7 @@ methods: {
 
     // if they erase everything remove the components
     if (this.subjectString.length==0){
+      console.info("resetting search")
       this.activeComponent = null
       this.activeComponentIndex=0
       this.componetLookup = {}
@@ -1862,7 +1866,7 @@ methods: {
 
         this.updateAvctiveTypeSelected()
         this.validateOkayToAdd()
-      },100)
+      },400)
     })
 
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1718,9 +1718,6 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
-    console.info("subjectStringChanged: ", event.target.value)
-    console.info("    is ", this.subjectString)
-
     this.validateOkayToAdd()
 
     //fake the "click" so the results panel populates
@@ -1771,11 +1768,15 @@ methods: {
 
     // if they erase everything remove the components
     if (this.subjectString.length==0){
-      console.info("resetting search")
       this.activeComponent = null
       this.activeComponentIndex=0
       this.componetLookup = {}
       this.typeLookup={}
+      this.components=[]
+
+      //search for nothing. Otherwise, if the user deletes their search
+      // quickly, it will end up searcing on the last letter to be deleted
+      this.searchApis("", "", this)
     }
     if (!this.subjectString.endsWith("-")){
       this.buildComponents(this.subjectString)

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -19,6 +19,21 @@ const utilsNetwork = {
     // a cache to keep previosuly requested vocabularies and lookups in memory for use again
     lookupLibrary : {},
 
+    //Controllers to manage searches
+    controllers: {
+      "controllerNames": new AbortController(),
+      "controllerNamesSubdivision": new AbortController(),
+      "controllerSubjectsSimple": new AbortController(),
+      "controllerPayloadSubjectsSimpleSubdivision": new AbortController(),
+      "controllerSubjectsComplex": new AbortController(),
+      "controllerHierarchicalGeographic": new AbortController(),
+      "controllerWorksAnchored": new AbortController(),
+      "controllerWorksKeyword": new AbortController(),
+      "controllerHubsAnchored": new AbortController(),
+      "controllerHubsKeyword": new AbortController(),
+    },
+    subjectSearchActive: false,
+
     /**
     * processes the data returned from id vocabularies
     *
@@ -1318,28 +1333,28 @@ const utilsNetwork = {
         let searchPayloadNames = {
           processor: 'lcAuthorities',
           url: [namesUrl],
-          searchValue: searchVal
+          searchValue: searchVal,
         }
         let searchPayloadNamesSubdivision = {
           processor: 'lcAuthorities',
           url: [namesUrlSubdivision],
-          searchValue: searchVal
+          searchValue: searchVal,
         }
 
         let searchPayloadSubjectsSimple = {
           processor: 'lcAuthorities',
           url: [subjectUrlSimple],
-          searchValue: searchVal
+          searchValue: searchVal,
         }
         let searchPayloadSubjectsSimpleSubdivision = {
           processor: 'lcAuthorities',
           url: [subjectUrlSimpleSubdivison],
-          searchValue: searchVal
+          searchValue: searchVal,
         }
         let searchPayloadTemporal = {
           processor: 'lcAuthorities',
           url: [subjectUrlTemporal],
-          searchValue: searchVal
+          searchValue: searchVal,
         }
 
         let searchPayloadGenre = {
@@ -1945,6 +1960,15 @@ const utilsNetwork = {
     * @return {} -
     */
     subjectSearch: async function(searchVal,complexVal,mode){
+      if (this.subjectSearchActive){
+        for (let controller in this.controllers){
+          this.controllers[controller].abort()
+          this.controllers[controller] = new AbortController()
+        }
+      }
+
+
+      this.subjectSearchActive = true
       let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings'
       let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
@@ -1977,26 +2001,30 @@ const utilsNetwork = {
         processor: 'lcAuthorities',
         url: [namesUrl],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerNames.signal,
       }
       let searchPayloadNamesSubdivision = {
         processor: 'lcAuthorities',
         url: [namesUrlSubdivision],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerNamesSubdivision.signal,
       }
 
       let searchPayloadSubjectsSimple = {
         processor: 'lcAuthorities',
         url: [subjectUrlSimple],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerSubjectsSimple.signal,
       }
       let searchPayloadSubjectsSimpleSubdivision = {
         processor: 'lcAuthorities',
         url: [subjectUrlSimpleSubdivison],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerPayloadSubjectsSimpleSubdivision.signal,
       }
       let searchPayloadTemporal = {
         processor: 'lcAuthorities',
@@ -2013,7 +2041,8 @@ const utilsNetwork = {
         processor: 'lcAuthorities',
         url: [subjectUrlComplex],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerSubjectsComplex.signal,
       }
 
 
@@ -2021,35 +2050,40 @@ const utilsNetwork = {
         processor: 'lcAuthorities',
         url: [subjectUrlHierarchicalGeographic],
         searchValue: searchValHierarchicalGeographic,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerHierarchicalGeographic.signal,
       }
 
       let searchPayloadWorksAnchored = {
         processor: 'lcAuthorities',
         url: [worksUrlAnchored],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerWorksAnchored.signal,
       }
 
       let searchPayloadWorksKeyword = {
         processor: 'lcAuthorities',
         url: [worksUrlKeyword],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerWorksKeyword.signal,
       }
 
       let searchPayloadHubsAnchored = {
         processor: 'lcAuthorities',
         url: [hubsUrlAnchored],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerHubsAnchored.signal,
       }
 
       let searchPayloadHubsKeyword = {
         processor: 'lcAuthorities',
         url: [hubsUrlKeyword],
         searchValue: searchVal,
-        subjectSearch: true
+        subjectSearch: true,
+        signal: this.controllers.controllerHubsKeyword.signal,
       }
 
 
@@ -2160,6 +2194,8 @@ const utilsNetwork = {
         'names': pos == 0 ? resultsNames : resultsNamesSubdivision,
         'hierarchicalGeographic':  pos == 0 ? [] : resultsHierarchicalGeographic
       }
+
+      this.subjectSearchActive = false
       return results
 
     },

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -267,7 +267,7 @@ export const useConfigStore = defineStore('config', {
 
 
 
-    
+
     {lccn:'2024591512',label:"The Berkshires, Massachusetts discovery map 2022-2023", idUrl:'https://id.loc.gov/resources/instances/23486403.html', profile:'Cartographic',profileId:'lc:RT:bf2:Cartographic:Instance'},
     {lccn:'2016627557',label:"Wallflower", idUrl:'https://id.loc.gov/resources/instances/2016627557.html', profile:'Audio CD',profileId:'lc:RT:bf2:SoundRecording:Instance'},
     {lccn:'2024623510',label:"Ein deutsches Requiem", idUrl:'https://id.loc.gov/resources/instances/23704895.html', profile:'Audio CD',profileId:'lc:RT:bf2:SoundRecording:Instance'},

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 14,
-    versionPatch: 22,
+    versionPatch: 23,
 
     regionUrls: {
 


### PR DESCRIPTION
This adds the `AbortController()` to the subject builder to resolve issues related to typing and seeing unexpected results. Every search that the subject search performs gets its own controller so that they can be canceled independently and avoid the issue of the different searches cancelling each other. 

The results should more consistently reflect what is in the search bar. The inconsistency makes it difficult to test, but locally I'm not seeing the same issues I can produce in the currently deployed production Marva. In production slowly typing a word will result in the search results jumping backwards. Not seeing this locally with the changes.