### PR TITLE
Decode subject searches after url creation

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1342,6 +1342,8 @@ const utilsNetwork = {
         let subjectUrlGeographicLCSH = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
         let subjectUrlGeographicLCNAF = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=Geographic&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
+        searchVal = decodeURIComponent(searchVal)
+
         // console.log('subjectUrlSimpleSubdivison',subjectUrlSimpleSubdivison)
         let searchPayloadNames = {
           processor: 'lcAuthorities',
@@ -2023,6 +2025,8 @@ const utilsNetwork = {
         subjectUrlHierarchicalGeographic = subjectUrlHierarchicalGeographic.replace('&count=4','&count=12').replace("<OFFSET>", "1")
       }
 
+      searchVal = decodeURIComponent(searchVal)
+      complexVal = decodeURIComponent(complexVal)
 
       let searchPayloadNames = {
         processor: 'lcAuthorities',


### PR DESCRIPTION
The encoded search strings were finding their way in to the literals. So if there was a space, you get `cabello%20de`