### PR TITLE
[BFP 130] Disappearing Cutter

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 14,
-    versionPatch: 24,
+    versionPatch: 25,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2862,6 +2862,18 @@ export const useProfileStore = defineStore('profile', {
             classGuid:classGuid
           }
 
+        } else {
+          // This is a LCC field, it shouldn't return `false`. False causes things to disappear
+          return {
+            title: null,
+            classNumber:null,
+            cutterNumber:null,
+            titleNonSort:null,
+            contributors:[],
+            firstSubject:null,
+            cutterGuid:null,
+            classGuid:null
+          }
         }
 
 


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/projects/BFP/issues/BFP-130?filter=allissues

If things were empty, `returnLccInfo()` would return false for the LCC component. This would cause the Cutter tool to disappear when inserting default values. It also meant that if you create a new component, the cutter tool wouldn't be there.

I don't think this is related to the class number disappearing. But maybe? They both seem to be related to inserting defaults.