### PR TITLE
Lang note parse fix

### DIFF
--- a/public/test_files/2023546355.xml
+++ b/public/test_files/2023546355.xml
@@ -1,0 +1,649 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
+    xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+    xmlns:lclocal="http://id.loc.gov/ontologies/lclocal/"
+    xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:pmo="http://performedmusicontology.org/ontology/"
+    xmlns:streams="info:lc/streams#"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/">
+    <bf:Work rdf:about="http://id.loc.gov/resources/works/23591130">
+        <bflc:aap>Hyŏn, Mu-am, 1969- 'P'osŭt'ŭ cheguk' ŭi Tong Asia</bflc:aap>
+        <bflc:aap-normalized>hyŏnmuam1969'p'osŭt'ŭcheguk'ŭitongasia</bflc:aap-normalized>
+        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Text"/>
+        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Monograph"/>
+        <bf:language>
+            <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/kor">
+                <rdfs:label xml:lang="en">Korean</rdfs:label>
+                <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kor</bf:code>
+            </bf:Language>
+        </bf:language>
+        <bf:illustrativeContent>
+            <bf:Illustration rdf:about="http://id.loc.gov/vocabulary/millus/ill">
+                <rdfs:label>Illustrations</rdfs:label>
+                <bf:code>ill</bf:code>
+            </bf:Illustration>
+        </bf:illustrativeContent>
+        <bf:supplementaryContent>
+            <bf:SupplementaryContent rdf:about="http://id.loc.gov/vocabulary/msupplcont/bibliography">
+                <rdfs:label>bibliography</rdfs:label>
+                <bf:code>bibliography</bf:code>
+            </bf:SupplementaryContent>
+        </bf:supplementaryContent>
+        <bf:supplementaryContent>
+            <bf:SupplementaryContent rdf:about="http://id.loc.gov/vocabulary/msupplcont/index">
+                <rdfs:label>index</rdfs:label>
+                <bf:code>index</bf:code>
+            </bf:SupplementaryContent>
+        </bf:supplementaryContent>
+        <bf:note>
+            <bf:Note>
+                <rdfs:label>Includes translation or is translation</rdfs:label>
+            </bf:Note>
+        </bf:note>
+        <bf:note>
+            <bf:Note>
+                <rdf:type rdf:resource="http://id.loc.gov/vocabulary/resourceComponents/otx"/>
+                <bf:language>
+                    <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/jpn">
+                        <rdfs:label xml:lang="en">Japanese</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jpn</bf:code>
+                    </bf:Language>
+                </bf:language>
+            </bf:Note>
+        </bf:note>
+        <bf:geographicCoverage>
+            <bf:GeographicCoverage rdf:about="http://id.loc.gov/vocabulary/geographicAreas/a-ko">
+                <rdfs:label xml:lang="en">Korea (South)</rdfs:label>
+                <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a-ko</bf:code>
+            </bf:GeographicCoverage>
+        </bf:geographicCoverage>
+        <bf:geographicCoverage>
+            <bf:GeographicCoverage rdf:about="http://id.loc.gov/vocabulary/geographicAreas/a-ja">
+                <rdfs:label xml:lang="en">Japan</rdfs:label>
+                <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a-ja</bf:code>
+            </bf:GeographicCoverage>
+        </bf:geographicCoverage>
+        <bf:classification>
+            <bf:ClassificationLcc>
+                <bf:classificationPortion>DS910.2.J3</bf:classificationPortion>
+                <bf:itemPortion>H95164 2023</bf:itemPortion>
+                <bf:assigner>
+                    <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Organization>
+                </bf:assigner>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/uba">
+                        <rdfs:label>used by assigner</rdfs:label>
+                        <bf:code>uba</bf:code>
+                    </bf:Status>
+                </bf:status>
+            </bf:ClassificationLcc>
+        </bf:classification>
+        <bf:contribution>
+            <bf:Contribution>
+                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/PrimaryContribution"/>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/rwo/agents/n2010057779">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Person"/>
+                        <rdfs:label>Hyŏn, Mu-am, 1969-</rdfs:label>
+                        <bflc:marcKey>1001 $aHyŏn, Mu-am,$d1969-</bflc:marcKey>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/aut">
+                        <rdfs:label>Author</rdfs:label>
+                        <bf:code>aut</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+        <bf:expressionOf>
+            <bf:Hub rdf:about="http://id.loc.gov/resources/hubs/32733ddd-cdea-d06c-3d66-63e50727009e">
+                <rdfs:label>Hyŏn, Mu-am, 1969- 'Posuto teikoku' no Higashi Ajia. Korean</rdfs:label>
+                <bf:contribution>
+                    <bf:Contribution>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/PrimaryContribution"/>
+                        <bf:agent>
+                            <bf:Agent rdf:about="http://id.loc.gov/rwo/agents/n2010057779">
+                                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Person"/>
+                                <rdfs:label>Hyŏn, Mu-am, 1969-</rdfs:label>
+                                <bflc:marcKey>1001 $aHyŏn, Mu-am,$d1969-</bflc:marcKey>
+                            </bf:Agent>
+                        </bf:agent>
+                        <bf:role>
+                            <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/ctb">
+                                <rdfs:label>Contributor</rdfs:label>
+                                <bf:code>ctb</bf:code>
+                            </bf:Role>
+                        </bf:role>
+                    </bf:Contribution>
+                </bf:contribution>
+                <bf:title>
+                    <bf:Title>
+                        <bf:mainTitle>'Posuto teikoku' no Higashi Ajia. Korean</bf:mainTitle>
+                    </bf:Title>
+                </bf:title>
+                <bf:title>
+                    <bf:VariantTitle>
+                        <bf:mainTitle>East Asia in post-imperial Japan</bf:mainTitle>
+                    </bf:VariantTitle>
+                </bf:title>
+                <bf:title>
+                    <bf:VariantTitle>
+                        <bf:mainTitle>'P'osŭt'ŭ cheguk' ŭi Tong Asia</bf:mainTitle>
+                    </bf:VariantTitle>
+                </bf:title>
+                <bflc:marcKey>1001 $aHyŏn, Mu-am,$d1969-$t'Posuto teikoku' no Higashi Ajia.$lKorean</bflc:marcKey>
+            </bf:Hub>
+        </bf:expressionOf>
+        <bf:title>
+            <bf:Title>
+                <bf:mainTitle>'P'osŭt'ŭ cheguk' ŭi Tong Asia</bf:mainTitle>
+                <bf:mainTitle xml:lang="ko-hang">'포스트 제국' 의 동 아시아</bf:mainTitle>
+            </bf:Title>
+        </bf:title>
+        <bf:title>
+            <bf:ParallelTitle>
+                <bf:mainTitle>East Asia in post-imperial Japan</bf:mainTitle>
+                <bf:subtitle>discourse, representation and memory</bf:subtitle>
+            </bf:ParallelTitle>
+        </bf:title>
+        <bf:content>
+            <bf:Content rdf:about="http://id.loc.gov/vocabulary/contentTypes/txt">
+                <rdfs:label>text</rdfs:label>
+                <bf:code>txt</bf:code>
+            </bf:Content>
+        </bf:content>
+        <bf:subject>
+            <bf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh2008115757">
+                <rdfs:label xml:lang="en">Korea (South)--Relations--Japan</rdfs:label>
+                <madsrdf:componentList rdf:parseType="Collection">
+                    <madsrdf:Geographic>
+                        <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                        <madsrdf:authoritativeLabel xml:lang="en">Korea (South)</madsrdf:authoritativeLabel>
+                        <madsrdf:elementList rdf:parseType="Collection">
+                            <madsrdf:GeographicElement>
+                                <madsrdf:elementValue xml:lang="en">Korea (South)</madsrdf:elementValue>
+                            </madsrdf:GeographicElement>
+                        </madsrdf:elementList>
+                    </madsrdf:Geographic>
+                    <madsrdf:Topic>
+                        <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                        <madsrdf:authoritativeLabel xml:lang="en">Relations</madsrdf:authoritativeLabel>
+                        <madsrdf:elementList rdf:parseType="Collection">
+                            <madsrdf:TopicElement>
+                                <madsrdf:elementValue xml:lang="en">Relations</madsrdf:elementValue>
+                            </madsrdf:TopicElement>
+                        </madsrdf:elementList>
+                    </madsrdf:Topic>
+                    <madsrdf:Geographic>
+                        <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                        <madsrdf:authoritativeLabel xml:lang="en">Japan</madsrdf:authoritativeLabel>
+                        <madsrdf:elementList rdf:parseType="Collection">
+                            <madsrdf:GeographicElement>
+                                <madsrdf:elementValue xml:lang="en">Japan</madsrdf:elementValue>
+                            </madsrdf:GeographicElement>
+                        </madsrdf:elementList>
+                    </madsrdf:Geographic>
+                </madsrdf:componentList>
+                <bflc:marcKey>151  $aKorea (South)$xRelations$zJapan</bflc:marcKey>
+            </bf:Topic>
+        </bf:subject>
+        <bf:subject>
+            <bf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh2008115658">
+                <rdfs:label xml:lang="en">Japan--Relations--Korea (South)</rdfs:label>
+                <madsrdf:componentList rdf:parseType="Collection">
+                    <madsrdf:Geographic>
+                        <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                        <madsrdf:authoritativeLabel xml:lang="en">Japan</madsrdf:authoritativeLabel>
+                        <madsrdf:elementList rdf:parseType="Collection">
+                            <madsrdf:GeographicElement>
+                                <madsrdf:elementValue xml:lang="en">Japan</madsrdf:elementValue>
+                            </madsrdf:GeographicElement>
+                        </madsrdf:elementList>
+                    </madsrdf:Geographic>
+                    <madsrdf:Topic>
+                        <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                        <madsrdf:authoritativeLabel xml:lang="en">Relations</madsrdf:authoritativeLabel>
+                        <madsrdf:elementList rdf:parseType="Collection">
+                            <madsrdf:TopicElement>
+                                <madsrdf:elementValue xml:lang="en">Relations</madsrdf:elementValue>
+                            </madsrdf:TopicElement>
+                        </madsrdf:elementList>
+                    </madsrdf:Topic>
+                    <madsrdf:Geographic>
+                        <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+                        <madsrdf:authoritativeLabel xml:lang="en">Korea (South)</madsrdf:authoritativeLabel>
+                        <madsrdf:elementList rdf:parseType="Collection">
+                            <madsrdf:GeographicElement>
+                                <madsrdf:elementValue xml:lang="en">Korea (South)</madsrdf:elementValue>
+                            </madsrdf:GeographicElement>
+                        </madsrdf:elementList>
+                    </madsrdf:Geographic>
+                </madsrdf:componentList>
+                <bflc:marcKey>151  $aJapan$xRelations$zKorea (South)</bflc:marcKey>
+            </bf:Topic>
+        </bf:subject>
+        <bf:subject>
+            <bf:Topic>
+                <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+                <rdfs:label>Japan--Foreign relations--1945</rdfs:label>
+                <madsrdf:authoritativeLabel>Japan--Foreign relations--1945</madsrdf:authoritativeLabel>
+                <madsrdf:isMemberOfMADSScheme>
+                    <madsrdf:MADSScheme rdf:about="http://id.loc.gov/authorities/subjects">
+                        <rdfs:label xml:lang="en">Library of Congress Subject Headings</rdfs:label>
+                    </madsrdf:MADSScheme>
+                </madsrdf:isMemberOfMADSScheme>
+                <madsrdf:componentList rdf:parseType="Collection">
+                    <madsrdf:Geographic rdf:about="http://id.loc.gov/rwo/agents/n78089021">
+                        <rdfs:label>Japan</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/codes/gac">a-ja---</bf:code>
+                        <bflc:marcKey>151  $aJapan</bflc:marcKey>
+                    </madsrdf:Geographic>
+                    <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh00005791">
+                        <rdfs:label xml:lang="en">Foreign relations</rdfs:label>
+                        <bflc:marcKey>180  $xForeign relations</bflc:marcKey>
+                    </madsrdf:Topic>
+                    <madsrdf:Temporal>
+                        <madsrdf:authoritativeLabel>1945-</madsrdf:authoritativeLabel>
+                    </madsrdf:Temporal>
+                </madsrdf:componentList>
+                <bflc:aap-normalized>japanforeignrelations1945</bflc:aap-normalized>
+                <bf:source>
+                    <bf:Source rdf:about="http://id.loc.gov/authorities/subjects">
+                        <rdfs:label xml:lang="en">Library of Congress Subject Headings</rdfs:label>
+                    </bf:Source>
+                </bf:source>
+            </bf:Topic>
+        </bf:subject>
+        <bf:contribution>
+            <bf:Contribution>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/rwo/agents/n2021021814">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Person"/>
+                        <rdfs:label>Kim, Kyŏng-ok, 1971-</rdfs:label>
+                        <bflc:marcKey>1001 $aKim, Kyŏng-ok,$d1971-</bflc:marcKey>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/trl">
+                        <rdfs:label>Translator</rdfs:label>
+                        <bf:code>trl</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+        <bf:contribution>
+            <bf:Contribution>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/rwo/agents/no2007113113">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>Hallim Taehakkyo (Korea). Ilbonhak Yŏn'guso</rdfs:label>
+                        <bflc:marcKey>1102 $aHallim Taehakkyo (Korea).$bIlbonhak Yŏn'guso</bflc:marcKey>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/pdr">
+                        <rdfs:label>Project director</rdfs:label>
+                        <bf:code>pdr</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+        <dcterms:isPartOf rdf:resource="http://id.loc.gov/resources/works"/>
+        <bf:relation>
+            <bf:Relation>
+                <bf:relationship rdf:resource="http://id.loc.gov/ontologies/bibframe/hasSeries"/>
+                <bf:seriesEnumeration>03</bf:seriesEnumeration>
+                <bf:associatedResource>
+                    <bf:Series>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bflc/Uncontrolled"/>
+                        <bf:status>
+                            <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/t">
+                                <rdfs:label>transcribed</rdfs:label>
+                                <bf:code>t</bf:code>
+                            </bf:Status>
+                        </bf:status>
+                        <bf:title>
+                            <bf:Title>
+                                <bf:mainTitle>P'omundong Haktang Tong Asia ŭi munhwa kwŏllyŏk ;</bf:mainTitle>
+                                <bf:mainTitle xml:lang="ko-hang">포문동 학당 동 아시아 의 문화 권력</bf:mainTitle>
+                            </bf:Title>
+                        </bf:title>
+                    </bf:Series>
+                </bf:associatedResource>
+            </bf:Relation>
+        </bf:relation>
+        <bf:hasInstance rdf:resource="http://id.loc.gov/resources/instances/23591130"/>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/n">
+                        <rdfs:label>new</rdfs:label>
+                        <bf:code>n</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-05</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-04-22T09:11:52</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlcmrc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress, Network Development and MARC Standards Office</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC-MRC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlcmrc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlcmrc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:generationProcess rdf:resource="https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.8.0"/>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-10-03T11:51:06.186057-04:00</bf:date>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:descriptionLevel rdf:resource="http://id.loc.gov/ontologies/bibframe-2-4-0/"/>
+                <bflc:encodingLevel>
+                    <bflc:EncodingLevel rdf:about="http://id.loc.gov/vocabulary/menclvl/f">
+                        <rdfs:label>full</rdfs:label>
+                        <bf:code>f</bf:code>
+                    </bflc:EncodingLevel>
+                </bflc:encodingLevel>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/isbd">
+                        <rdfs:label>ISBD: International standard bibliographic description</rdfs:label>
+                        <bf:code>isbd</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:identifiedBy>
+                    <bf:Local>
+                        <rdf:value>23591130</rdf:value>
+                        <bf:assigner>
+                            <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                                <rdfs:label>United States, Library of Congress</rdfs:label>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                            </bf:Organization>
+                        </bf:assigner>
+                    </bf:Local>
+                </bf:identifiedBy>
+                <lclocal:d906>=906     $a 7 $b cbc $c origres $d 2 $e ncip $f 20 $g y-nonroman</lclocal:d906>
+                <lclocal:d925>=925  0  $a acquire $b 1 shelf copy $x policy default</lclocal:d925>
+                <lclocal:d955>=955     $b cf21 2024-04-09 z-processor JACKPHY $i cf28 2024-04-19 Telework to PresSrvs</lclocal:d955>
+                <bf:descriptionLanguage>
+                    <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/eng">
+                        <rdfs:label xml:lang="en">English</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eng</bf:code>
+                    </bf:Language>
+                </bf:descriptionLanguage>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/rda">
+                        <rdfs:label>Resource description and access</rdfs:label>
+                        <bf:code>rda</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:note>
+                    <bf:Note>
+                        <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/internal"/>
+                        <rdfs:label>040  $aDLC$beng$erda$cDLC</rdfs:label>
+                    </bf:Note>
+                </bf:note>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/pcc">
+                        <rdfs:label>Program for Cooperative Cataloging</rdfs:label>
+                        <bf:code>pcc</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+    </bf:Work>
+    <bf:Instance rdf:about="http://id.loc.gov/resources/instances/23591130">
+        <bf:issuance>
+            <bf:Issuance rdf:about="http://id.loc.gov/vocabulary/issuance/mono">
+                <rdfs:label>single unit</rdfs:label>
+                <bf:code>mono</bf:code>
+            </bf:Issuance>
+        </bf:issuance>
+        <bf:provisionActivity>
+            <bf:ProvisionActivity>
+                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Publication"/>
+                <bf:date rdf:datatype="http://id.loc.gov/datatypes/edtf">2023</bf:date>
+                <bf:place>
+                    <bf:Place rdf:about="http://id.loc.gov/vocabulary/countries/ko">
+                        <rdfs:label xml:lang="en">Korea (South)</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ko</bf:code>
+                    </bf:Place>
+                </bf:place>
+                <bflc:simplePlace>Sŏul-si</bflc:simplePlace>
+                <bflc:simplePlace xml:lang="ko-hang">서울시</bflc:simplePlace>
+                <bflc:simpleAgent>Somyŏng Ch'ulp'an</bflc:simpleAgent>
+                <bflc:simpleAgent xml:lang="ko-hang">소명 출판</bflc:simpleAgent>
+                <bflc:simpleDate>2023</bflc:simpleDate>
+                <bflc:simpleDate xml:lang="ko-hang">2023</bflc:simpleDate>
+            </bf:ProvisionActivity>
+        </bf:provisionActivity>
+        <bf:publicationStatement>Sŏul-si: Somyŏng Ch'ulp'an, 2023</bf:publicationStatement>
+        <bflc:publicationStatement xml:lang="ko-hang">서울시: 소명 출판, 2023</bflc:publicationStatement>
+        <bf:identifiedBy>
+            <bf:Lccn>
+                <rdf:value>  2023546355</rdf:value>
+            </bf:Lccn>
+        </bf:identifiedBy>
+        <bf:identifiedBy>
+            <bf:Isbn>
+                <rdf:value>9791159058318</rdf:value>
+            </bf:Isbn>
+        </bf:identifiedBy>
+        <bf:responsibilityStatement>Hyŏn Mu-am chiŭm ; Kim Kyŏng-ok [and eight others] omgim ; Hallim Taehakkyo Ilbonhak Yŏn'guso kihoek</bf:responsibilityStatement>
+        <bf:responsibilityStatement xml:lang="ko-hang">현 무암 지음 ; 김 경옥 [and eight others] 옮김 ; 한림 대학교 일본학 연구소 기획</bf:responsibilityStatement>
+        <bf:title>
+            <bf:Title>
+                <bf:mainTitle>'P'osŭt'ŭ cheguk' ŭi Tong Asia</bf:mainTitle>
+                <bf:subtitle>tamnon, p'yosang, kiŏk = East Asia in post-imperial Japan : discourse, representation and memory</bf:subtitle>
+                <bf:mainTitle xml:lang="ko-hang">'포스트 제국' 의 동 아시아</bf:mainTitle>
+                <bf:subtitle xml:lang="ko-hang">담론, 표상, 기억 = East Asia in post-imperial Japan : discourse, representation and memory</bf:subtitle>
+            </bf:Title>
+        </bf:title>
+        <bf:editionStatement>Ch'op'an</bf:editionStatement>
+        <bf:editionStatement xml:lang="ko-hang">초판</bf:editionStatement>
+        <bf:extent>
+            <bf:Extent>
+                <rdfs:label>542 pages</rdfs:label>
+            </bf:Extent>
+        </bf:extent>
+        <bf:note>
+            <bf:Note>
+                <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/physical"/>
+                <rdfs:label>illustrations</rdfs:label>
+            </bf:Note>
+        </bf:note>
+        <bf:dimensions>23 cm</bf:dimensions>
+        <bf:media>
+            <bf:Media rdf:about="http://id.loc.gov/vocabulary/mediaTypes/n">
+                <rdfs:label>unmediated</rdfs:label>
+                <bf:code>n</bf:code>
+            </bf:Media>
+        </bf:media>
+        <bf:carrier>
+            <bf:Carrier rdf:about="http://id.loc.gov/vocabulary/carriers/nc">
+                <rdfs:label>volume</rdfs:label>
+                <bf:code>nc</bf:code>
+            </bf:Carrier>
+        </bf:carrier>
+        <bf:note>
+            <bf:Note>
+                <rdfs:label>Originally published by Seidosha, Japan in 2022.</rdfs:label>
+            </bf:Note>
+        </bf:note>
+        <bf:supplementaryContent>
+            <bf:SupplementaryContent>
+                <rdfs:label>Includes bibliographical references (pages 510-529) and index.</rdfs:label>
+            </bf:SupplementaryContent>
+        </bf:supplementaryContent>
+        <dcterms:isPartOf rdf:resource="http://id.loc.gov/resources/instances"/>
+        <bf:instanceOf rdf:resource="http://id.loc.gov/resources/works/23591130"/>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/n">
+                        <rdfs:label>new</rdfs:label>
+                        <bf:code>n</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-03-05</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-04-22T09:11:52</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlcmrc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress, Network Development and MARC Standards Office</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC-MRC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlcmrc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlcmrc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:generationProcess rdf:resource="https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.8.0"/>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-10-03T11:51:06.186057-04:00</bf:date>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:descriptionLevel rdf:resource="http://id.loc.gov/ontologies/bibframe-2-4-0/"/>
+                <bflc:encodingLevel>
+                    <bflc:EncodingLevel rdf:about="http://id.loc.gov/vocabulary/menclvl/f">
+                        <rdfs:label>full</rdfs:label>
+                        <bf:code>f</bf:code>
+                    </bflc:EncodingLevel>
+                </bflc:encodingLevel>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/isbd">
+                        <rdfs:label>ISBD: International standard bibliographic description</rdfs:label>
+                        <bf:code>isbd</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:identifiedBy>
+                    <bf:Local>
+                        <rdf:value>23591130</rdf:value>
+                        <bf:assigner>
+                            <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                                <rdfs:label>United States, Library of Congress</rdfs:label>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                            </bf:Organization>
+                        </bf:assigner>
+                    </bf:Local>
+                </bf:identifiedBy>
+                <lclocal:d906>=906     $a 7 $b cbc $c origres $d 2 $e ncip $f 20 $g y-nonroman</lclocal:d906>
+                <lclocal:d925>=925  0  $a acquire $b 1 shelf copy $x policy default</lclocal:d925>
+                <lclocal:d955>=955     $b cf21 2024-04-09 z-processor JACKPHY $i cf28 2024-04-19 Telework to PresSrvs</lclocal:d955>
+                <bf:descriptionLanguage>
+                    <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/eng">
+                        <rdfs:label xml:lang="en">English</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eng</bf:code>
+                    </bf:Language>
+                </bf:descriptionLanguage>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/rda">
+                        <rdfs:label>Resource description and access</rdfs:label>
+                        <bf:code>rda</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:note>
+                    <bf:Note>
+                        <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/internal"/>
+                        <rdfs:label>040  $aDLC$beng$erda$cDLC</rdfs:label>
+                    </bf:Note>
+                </bf:note>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/pcc">
+                        <rdfs:label>Program for Cooperative Cataloging</rdfs:label>
+                        <bf:code>pcc</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+    </bf:Instance>
+</rdf:RDF>

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -273,6 +273,27 @@ const utilsParse = {
     return xml
   },
 
+  /**
+  * Takes the XML marks any bf:note properties with hints to use in the parsing of it
+  *
+  * @param {Node} xml - the XML payload
+  * @return {Node}
+  */
+  sniffNoteType(xml){
+    for (let child of xml.children){
+      if (child.tagName == 'bf:note'){
+        if ( child.innerHTML.indexOf("bf:language")>-1){
+          child.setAttribute('local:pthint', 'lc:RT:bf2:LangNote')
+        }else{
+          // leave blank?
+        }
+      }
+    }
+    return xml
+  },
+
+  
+
 
   specialTransforms: {
     // not currently used
@@ -447,6 +468,7 @@ const utilsParse = {
       // first try to give hints to which PT to use based on some rules we are using at LC
       if (tle == "bf:Work"){
         xml = this.sniffWorkRelationType(xml)
+        xml = this.sniffNoteType(xml)
       }
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -267,7 +267,10 @@ export const useConfigStore = defineStore('config', {
 
     {lccn:'2007052988',label:"A journey to the Western Islands of Scotland", idUrl:'https://id.loc.gov/resources/instances/15146892.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
+    {lccn:'2023546355',label:"'P'osŭt'ŭ cheguk' ŭi Tong Asia", idUrl:'https://id.loc.gov/resources/instances/23591130.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
+
+    
 
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 14,
-    versionPatch: 29,
+    versionPatch: 30,
 
     regionUrls: {
 


### PR DESCRIPTION
Added sniffNoteType which makes use of the <xxx "local:pthint"="yyy"/> system used for the bf:relation issues to detect if a bf:note is a language note and not a normal note.