### PR TITLE
Bfp 103 load improvments and add literal improvments

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -626,6 +626,14 @@ export default {
         }
       }
 
+      // if the value is empty then wait 2 seconds and check if it is empty again, if it is then continue with the removal
+      if (v == ''){
+        await new Promise(r => setTimeout(r, 2000));        
+        if (event && event.target && event.target.value != ''){
+          return false
+        }
+      }
+
 
       await this.profileStore.setValueLiteral(this.guid,event.target.dataset.guid,this.propertyPath,v,event.target.dataset.lang)
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 14,
-    versionPatch: 32,
+    versionPatch: 33,
 
     regionUrls: {
 

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -554,6 +554,33 @@
       },
 
 
+     async refreshSavedRecords(){
+
+
+
+        let records = await utilsNetwork.searchSavedRecords(this.preferenceStore.returnUserNameForSaving)
+
+          let lccnLookup = {}
+
+          // in this view we want to remove any records that are repeats, so only show the latest LCCN being edited
+          this.continueRecords = []
+          for (let r of records){
+            if (r.lccn && r.lccn != '' && r.lccn !== null){
+              if (!lccnLookup[r.lccn]){
+                this.continueRecords.push(r)
+                lccnLookup[r.lccn]=true
+              }
+            }else{
+              // no LCCN just add it
+              this.continueRecords.push(r)
+            }
+
+          }
+
+
+      },
+
+
 
 
 
@@ -562,31 +589,21 @@
 
 
     },
+
+    mounted: async function(){
+
+      this.refreshSavedRecords()
+
+    },
+
+
+
     created: async function(){
 
+      this.refreshSavedRecords()
 
-
-      let records = await utilsNetwork.searchSavedRecords(this.preferenceStore.returnUserNameForSaving)
-
-      let lccnLookup = {}
-
-      // in this view we want to remove any records that are repeats, so only show the latest LCCN being edited
-      this.continueRecords = []
-      for (let r of records){
-        if (r.lccn && r.lccn != '' && r.lccn !== null){
-          if (!lccnLookup[r.lccn]){
-            this.continueRecords.push(r)
-            lccnLookup[r.lccn]=true
-          }
-        }else{
-          // no LCCN just add it
-          this.continueRecords.push(r)
-        }
-
-      }
-
+      // this is checking to see if the route is available to load the passed URL to it
       let inerval = window.setInterval(()=>{
-
           if (this.$route && this.$route.query && this.$route.query.url){
 
             this.urlToLoad = this.$route.query.url
@@ -594,21 +611,6 @@
             window.clearInterval(inerval)
 
           }
-
-
-
-          // if (this.$router.currentRoute && this.$router.currentRoute.query && this.$router.currentRoute.query.url){
-          //   let url = this.$router.currentRoute.query.url
-          //   if (this.$router.currentRoute && this.$router.currentRoute.query && this.$router.currentRoute.query.action && this.$router.currentRoute.query.action == 'loadwork'){
-          //     url = url.replace('.jsonld','.rdf')
-          //   }
-          //   if (this.$router.currentRoute && this.$router.currentRoute.query && this.$router.currentRoute.query.action && this.$router.currentRoute.query.action == 'loadibc'){
-          //     url = url.replace('.jsonld','.xml')
-          //   }
-          //   this.instanceEditorLink = url
-          //   this.testInstance()
-          //   window.clearInterval(inerval)
-          // }
         },500)
 
 


### PR DESCRIPTION
Address bfp-103
It will attempt to refresh the save list more often.

Also there is now a 2 second delay when an additonal literal is set to empty before the interface updates and removes it from the component. Before if the user adds additonal literal, then highlights the value and delete it would remove the field as it was empty, now it waits 2 seconds to see if they cleared it with intention to paste or whatever.