### PR TITLE
[BFP 244] Fix org creator not PrimaryContribution

### DIFF
--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -290,7 +290,8 @@ const utilsProfile = {
           // don't need to set the type, as its not a blank node, just a nested property
           if (utilsRDF.isUriALiteral(type) === false){
             // if it doesn't yet have a type then go ahead and set it
-            if (!pointer[p][0]['@type']){
+			// OR if the suggested type is PrimaryContribution, override the existing type
+            if (!pointer[p][0]['@type'] || type.includes("PrimaryContribution")){
               pointer[p][0]['@type'] = type
             }
           }else{
@@ -375,7 +376,6 @@ const utilsProfile = {
   * @return {object} - will return the userValue pruned
   */
   pruneUserValue: function(userValue){
-
     for (let key in userValue){
 
       if (Array.isArray(userValue[key])){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -139,7 +139,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     async buildProfiles() {
-
       const config = useConfigStore()
 
       let profileData;
@@ -1900,7 +1899,7 @@ export const useProfileStore = defineStore('profile', {
       let lastProperty = propertyPath.at(-1).propertyURI
       // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
-
+	  
       if (!type && URI && !lastProperty.includes("intendedAudience")){
         // I regretfully inform you we will need to look this up
         let context = await utilsNetwork.returnContext(URI)
@@ -1915,6 +1914,7 @@ export const useProfileStore = defineStore('profile', {
           type = await utilsRDF.suggestTypeNetwork(lastProperty)
         }
       }
+	  
       if (pt !== false){
 
         pt.hasData = true
@@ -1927,7 +1927,7 @@ export const useProfileStore = defineStore('profile', {
           console.log('buildBlankNodeResult',buildBlankNodeResult)
 
           pt = buildBlankNodeResult[0]
-
+		  
           // now we can make a link to the parent of where the literal value should live
           blankNode = utilsProfile.returnGuidLocation(pt.userValue,buildBlankNodeResult[1])
 
@@ -1970,7 +1970,6 @@ export const useProfileStore = defineStore('profile', {
             ]
           }
         }else{
-
           let parent = utilsProfile.returnGuidParent(pt.userValue,fieldGuid)
 
           // make sure we can find where to put the new one


### PR DESCRIPTION
If an Organization is the primary contributor, it would only be listed as a contributor at first. Setting it a second time would set it as primary. 

The cause was that the active profile would have a type already, which prevented `setTypesForBlankNode()` from using the suggested type. Now if the suggested type is `PrimaryContribution` it will override the existing type.