### PR TITLE
[BFP-245] Fix contributor emptying out when switching type

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -356,7 +356,11 @@ export default {
 
   },
 
-
+  updated: function(){
+		console.info("updated???????????????")
+		//this.profileStore.dataChanged()
+		// this.setComplexValue("test") //causes a loop
+  },
 
   created: function(){
 
@@ -523,6 +527,7 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
+		console.info("set value: ", contextValue)
       delete contextValue.typeFull
       this.profileStore.setValueComplex(this.guid,null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap)
       this.searchValue=''
@@ -739,8 +744,6 @@ export default {
       }
 
     },
-
-
   }
 };
 </script>

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -356,11 +356,6 @@ export default {
 
   },
 
-  updated: function(){
-		//this.profileStore.dataChanged()
-		// this.setComplexValue("test") //causes a loop
-  },
-
   created: function(){
 
     // this.checkForUserData()

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -357,7 +357,6 @@ export default {
   },
 
   updated: function(){
-		console.info("updated???????????????")
 		//this.profileStore.dataChanged()
 		// this.setComplexValue("test") //causes a loop
   },
@@ -527,7 +526,6 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-		console.info("set value: ", contextValue)
       delete contextValue.typeFull
       this.profileStore.setValueComplex(this.guid,null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap)
       this.searchValue=''

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -484,10 +484,6 @@ export default {
     // Takes the list of values from this lookup uri and filters it based on the input
 
     filter: async function(recursive){
-		
-		console.info("uri: ", this.uri)
-		console.info("stucture: ", this.structure)
-
       this.displayList = []
       this.activeSelect = ''
       this.activeKeyword = false

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -484,6 +484,9 @@ export default {
     // Takes the list of values from this lookup uri and filters it based on the input
 
     filter: async function(recursive){
+		
+		console.info("uri: ", this.uri)
+		console.info("stucture: ", this.structure)
 
       this.displayList = []
       this.activeSelect = ''

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -393,15 +393,6 @@ export default {
       let thisRef = this.thisRtTemplate
 	  
       this.profileStore.changeRefTemplate(this.guid, this.propertyPath, nextRef, thisRef)
-	  
-	// if (this.structure.parentId == "lc:RT:bflc:Agents:PrimaryContribution"){
-		// this.manualOverride = "lc:RT:bflc:Agents:PrimaryContribution"
-	// } else {
-		// this.manualOverride = event.target.value
-	// }
-
-
-
     }
 
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -223,12 +223,15 @@ export default {
 
 
     thisRtTemplate(){
+		console.info("!! change !!", this.rtLookup)
+		console.info("override: ", this.manualOverride)
       if (this.manualOverride !== null){
         for (let tmpid of this.structure.valueConstraint.valueTemplateRefs){
           console.log('tmpid',tmpid)
           if (tmpid === this.manualOverride){
             let use = JSON.parse(JSON.stringify(this.rtLookup[tmpid]))
             console.log(use)
+			console.info("Override use: ", use)
             return use
           }
         }
@@ -246,9 +249,11 @@ export default {
         userValue = this.structure.userValue[this.structure.propertyURI][0]
       }
 	  
+	  console.info("userValue: ", JSON.parse(JSON.stringify(userValue)))
+	  
       // do we have user data and a possible @type to use
       if (userValue['@type']){
-
+		console.info("we've a type: ", userValue['@type'])
         // loop thrugh all the refs and see if there is a URI that matches it better
         this.structure.valueConstraint.valueTemplateRefs.forEach((tmpid)=>{
           if (foundBetter) return false
@@ -285,9 +290,12 @@ export default {
 			  let template = this.structure.valueConstraint.valueTemplateRefs[idx]
 			  if (parentUserValue && parentUserValue["@root"] == "http://id.loc.gov/ontologies/bibframe/contribution" && parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"]){
 				  let target = parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"][0]["http://id.loc.gov/ontologies/bibframe/agent"]
-				  let type = target[0]["@type"]
-				  if (type && this.rtLookup[template].resourceURI === type){
-					useId = template
+				  if (target){
+					  let type = target[0]["@type"]
+					  if (type && this.rtLookup[template].resourceURI === type){
+						  console.info("set useId: ", template)
+						useId = template
+					  }
 				  }
 			  }
 		  }
@@ -298,6 +306,8 @@ export default {
       // if (this.parentStructure && this.parentStructure.indexOf(useId) ==-1){
         if (this.rtLookup[useId]){
           let use = JSON.parse(JSON.stringify(this.rtLookup[useId]))
+		  
+		  console.info("use: ", use)
 		  
           return use
           // this.multiTemplateSelect = use.resourceLabel
@@ -390,11 +400,22 @@ export default {
     templateChange(event){
       let nextRef = this.allRtTemplate.filter((v)=>{ return (v.id === event.target.value) })[0]
       let thisRef = this.thisRtTemplate
+	  
+	  console.info("@@@@@@@@@@@@@@@@@@@@")
+	  console.info("nextRef: ", JSON.parse(JSON.stringify(nextRef)))
+	  console.info("thisRef: ", JSON.parse(JSON.stringify(thisRef)))
+	  
+	  console.info("structure: ", JSON.parse(JSON.stringify(this.structure)))
 
-      this.profileStore.changeRefTemplate(this.guid,this.propertyPath,nextRef,thisRef)
-
-
-      this.manualOverride = event.target.value
+      this.profileStore.changeRefTemplate(this.guid, this.propertyPath, nextRef, thisRef)
+	  
+	  
+	console.info("template change propertyPath: ", this.propertyPath)
+	// if (this.structure.parentId == "lc:RT:bflc:Agents:PrimaryContribution"){
+		// this.manualOverride = "lc:RT:bflc:Agents:PrimaryContribution"
+	// } else {
+		// this.manualOverride = event.target.value
+	// }
 
 
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -223,9 +223,14 @@ export default {
 
 
     thisRtTemplate(){
+		console.info("looking for template: ", this.rtLookup)
+		console.info("structure: ", this.structure )
+		console.info(this.rtLookup["lc:RT:bf2:Agents:Contribution"] )
       if (this.manualOverride !== null){
+		  console.info("override: ", this.manualOverride )
         for (let tmpid of this.structure.valueConstraint.valueTemplateRefs){
           console.log('tmpid',tmpid)
+		  console.info("tmpid", tmpid)
           if (tmpid === this.manualOverride){
             let use = JSON.parse(JSON.stringify(this.rtLookup[tmpid]))
             console.log(use)
@@ -363,6 +368,13 @@ export default {
     // }
   // }),
   created: function () {
+	  //if this is for contributors, set manualOverride
+	  if (this.structure.propertyURI == "http://id.loc.gov/ontologies/bibframe/contribution"){
+		console.info("setting manualOverride")
+		let userValue = this.structure.userValue
+		this.manualOverride = userValue["http://id.loc.gov/ontologies/bibframe/contribution"][0]["http://id.loc.gov/ontologies/bibframe/agent"][0]["@type"]
+		console.info(this.manualOverride )
+	  }
   },
   methods: {
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -223,15 +223,12 @@ export default {
 
 
     thisRtTemplate(){
-		console.info("!! change !!", this.rtLookup)
-		console.info("override: ", this.manualOverride)
       if (this.manualOverride !== null){
         for (let tmpid of this.structure.valueConstraint.valueTemplateRefs){
           console.log('tmpid',tmpid)
           if (tmpid === this.manualOverride){
             let use = JSON.parse(JSON.stringify(this.rtLookup[tmpid]))
             console.log(use)
-			console.info("Override use: ", use)
             return use
           }
         }
@@ -249,11 +246,8 @@ export default {
         userValue = this.structure.userValue[this.structure.propertyURI][0]
       }
 	  
-	  console.info("userValue: ", JSON.parse(JSON.stringify(userValue)))
-	  
       // do we have user data and a possible @type to use
       if (userValue['@type']){
-		console.info("we've a type: ", userValue['@type'])
         // loop thrugh all the refs and see if there is a URI that matches it better
         this.structure.valueConstraint.valueTemplateRefs.forEach((tmpid)=>{
           if (foundBetter) return false
@@ -293,7 +287,6 @@ export default {
 				  if (target){
 					  let type = target[0]["@type"]
 					  if (type && this.rtLookup[template].resourceURI === type){
-						  console.info("set useId: ", template)
 						useId = template
 					  }
 				  }
@@ -306,8 +299,6 @@ export default {
       // if (this.parentStructure && this.parentStructure.indexOf(useId) ==-1){
         if (this.rtLookup[useId]){
           let use = JSON.parse(JSON.stringify(this.rtLookup[useId]))
-		  
-		  console.info("use: ", use)
 		  
           return use
           // this.multiTemplateSelect = use.resourceLabel
@@ -401,16 +392,8 @@ export default {
       let nextRef = this.allRtTemplate.filter((v)=>{ return (v.id === event.target.value) })[0]
       let thisRef = this.thisRtTemplate
 	  
-	  console.info("@@@@@@@@@@@@@@@@@@@@")
-	  console.info("nextRef: ", JSON.parse(JSON.stringify(nextRef)))
-	  console.info("thisRef: ", JSON.parse(JSON.stringify(thisRef)))
-	  
-	  console.info("structure: ", JSON.parse(JSON.stringify(this.structure)))
-
       this.profileStore.changeRefTemplate(this.guid, this.propertyPath, nextRef, thisRef)
 	  
-	  
-	console.info("template change propertyPath: ", this.propertyPath)
 	// if (this.structure.parentId == "lc:RT:bflc:Agents:PrimaryContribution"){
 		// this.manualOverride = "lc:RT:bflc:Agents:PrimaryContribution"
 	// } else {

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -429,6 +429,7 @@ const utilsExport = {
   * @return {object} multiple XML strings
   */
   buildXMLProcess: async function(profile){
+	  console.info("building XML")
     // console.log(profile)
 
     // keep track of the proces for later
@@ -1179,7 +1180,7 @@ const utilsExport = {
 
 
 
-
+		console.info("tleLookup: ", JSON.parse(JSON.stringify(tleLookup)))
 		// also just build a basic version tosave
 		for (let URI in tleLookup['Work']){
 			let theWork = (new XMLSerializer()).serializeToString(tleLookup['Work'][URI])
@@ -1187,6 +1188,7 @@ const utilsExport = {
 			theWork = xmlParser.parseFromString(theWork, "text/xml").children[0];
 			rdfBasic.appendChild(theWork)
 		}
+		console.info("tleLookup with work: ", JSON.parse(JSON.stringify(tleLookup)))
 
 		for (let URI in tleLookup['Hub']){
 			let theHub = (new XMLSerializer()).serializeToString(tleLookup['Hub'][URI])
@@ -1313,19 +1315,28 @@ const utilsExport = {
 		}else{
 			console.warn('no title found for db')
 		}
-
+		
+		let elements = rdfBasic.querySelectorAll("*")
+		console.info("rdfBasic: ", rdfBasic)
+		console.info("elements: ", elements)
+		
 
 		if (rdfBasic.getElementsByTagName("bf:PrimaryContribution").length>0){
+			console.info("set primary")
 			if (rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label").length>0){
 				xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
 			}
 		}else{
+			console.info("set contributor?")
 			if (rdfBasic.getElementsByTagName("bf:Contribution").length>0){
 				if (rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label").length>0){
 					xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
 				} else {
 					console.warn('no PrimaryContribution or Contribution found for db')
 				}
+			} else if (rdfBasic.getElementsByTagName("bf:contribution").length>0){
+				console.info("contribution: ", rdfBasic.getElementsByTagName("bf:contribution")[0].getElementsByTagName("rdfs:label"))
+				xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:contribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
 			}else{
 				console.warn('no PrimaryContribution or Contribution found for db')
 			}

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -429,7 +429,6 @@ const utilsExport = {
   * @return {object} multiple XML strings
   */
   buildXMLProcess: async function(profile){
-	  console.info("building XML")
     // console.log(profile)
 
     // keep track of the proces for later
@@ -1180,7 +1179,6 @@ const utilsExport = {
 
 
 
-		console.info("tleLookup: ", JSON.parse(JSON.stringify(tleLookup)))
 		// also just build a basic version tosave
 		for (let URI in tleLookup['Work']){
 			let theWork = (new XMLSerializer()).serializeToString(tleLookup['Work'][URI])
@@ -1188,8 +1186,6 @@ const utilsExport = {
 			theWork = xmlParser.parseFromString(theWork, "text/xml").children[0];
 			rdfBasic.appendChild(theWork)
 		}
-		console.info("tleLookup with work: ", JSON.parse(JSON.stringify(tleLookup)))
-
 		for (let URI in tleLookup['Hub']){
 			let theHub = (new XMLSerializer()).serializeToString(tleLookup['Hub'][URI])
 			// theHub = theHub.replace(/\sxmlns:[a-z]+="http.*?"/g,'')
@@ -1317,17 +1313,12 @@ const utilsExport = {
 		}
 		
 		let elements = rdfBasic.querySelectorAll("*")
-		console.info("rdfBasic: ", rdfBasic)
-		console.info("elements: ", elements)
-		
 
 		if (rdfBasic.getElementsByTagName("bf:PrimaryContribution").length>0){
-			console.info("set primary")
 			if (rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label").length>0){
 				xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
 			}
 		}else{
-			console.info("set contributor?")
 			if (rdfBasic.getElementsByTagName("bf:Contribution").length>0){
 				if (rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label").length>0){
 					xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:Contribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
@@ -1335,7 +1326,6 @@ const utilsExport = {
 					console.warn('no PrimaryContribution or Contribution found for db')
 				}
 			} else if (rdfBasic.getElementsByTagName("bf:contribution").length>0){
-				console.info("contribution: ", rdfBasic.getElementsByTagName("bf:contribution")[0].getElementsByTagName("rdfs:label"))
 				xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:contribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
 			}else{
 				console.warn('no PrimaryContribution or Contribution found for db')

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1311,8 +1311,6 @@ const utilsExport = {
 		}else{
 			console.warn('no title found for db')
 		}
-		
-		let elements = rdfBasic.querySelectorAll("*")
 
 		if (rdfBasic.getElementsByTagName("bf:PrimaryContribution").length>0){
 			if (rdfBasic.getElementsByTagName("bf:PrimaryContribution")[0].getElementsByTagName("rdfs:label").length>0){
@@ -1325,9 +1323,7 @@ const utilsExport = {
 				} else {
 					console.warn('no PrimaryContribution or Contribution found for db')
 				}
-			} else if (rdfBasic.getElementsByTagName("bf:contribution").length>0){
-				xmlVoidDataContributor = rdfBasic.getElementsByTagName("bf:contribution")[0].getElementsByTagName("rdfs:label")[0].innerHTML
-			}else{
+			} else{
 				console.warn('no PrimaryContribution or Contribution found for db')
 			}
 		}

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -215,7 +215,6 @@ const utilsProfile = {
   * @return {array} - will return an array with the pt as 0 and the new @guid of the blanknode as 1
   */
   buildBlanknode: function(pt,propertyPath){
-	  console.info("build blank node")
       // link to the base userValue
       let pointer = pt.userValue
 
@@ -270,11 +269,7 @@ const utilsProfile = {
   * @param {array} propertyPath - the array of URI strings that points to the place to build the blank node obj
   * @return {void} - doesn't return anything it works on the reference to the pt.userValue updating the orginal
   */
-  setTypesForBlankNode: async function(pt, propertyPath){    
-	console.info("setTypeForBlankNode")
-	console.info("pt: ", JSON.parse(JSON.stringify(pt)))
-	console.info("propertyPath: ", JSON.parse(JSON.stringify(propertyPath)))
-	
+  setTypesForBlankNode: async function(pt, propertyPath){
     let pointer = pt.userValue
     let pointerParent = null
     let parentP = null
@@ -291,8 +286,6 @@ const utilsProfile = {
           type = await utilsRDF.suggestTypeNetwork(p)
         }
         if (type !== false){
-
-		console.info("suggested type: ", type)
 
           // first we test to see if the type is a literal (the type returned, not the property of the value), if so then we
           // don't need to set the type, as its not a blank node, just a nested property

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -215,6 +215,7 @@ const utilsProfile = {
   * @return {array} - will return an array with the pt as 0 and the new @guid of the blanknode as 1
   */
   buildBlanknode: function(pt,propertyPath){
+	  console.info("build blank node")
       // link to the base userValue
       let pointer = pt.userValue
 
@@ -270,6 +271,10 @@ const utilsProfile = {
   * @return {void} - doesn't return anything it works on the reference to the pt.userValue updating the orginal
   */
   setTypesForBlankNode: async function(pt, propertyPath){    
+	console.info("setTypeForBlankNode")
+	console.info("pt: ", JSON.parse(JSON.stringify(pt)))
+	console.info("propertyPath: ", JSON.parse(JSON.stringify(propertyPath)))
+	
     let pointer = pt.userValue
     let pointerParent = null
     let parentP = null
@@ -287,7 +292,7 @@ const utilsProfile = {
         }
         if (type !== false){
 
-
+		console.info("suggested type: ", type)
 
           // first we test to see if the type is a literal (the type returned, not the property of the value), if so then we
           // don't need to set the type, as its not a blank node, just a nested property

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -645,7 +645,7 @@ export const useConfigStore = defineStore('config', {
     "http://id.loc.gov/vocabulary/mtechnique" : {"name":"mtechnique", "type":"simple", "modes":[]},
     "http://id.loc.gov/vocabulary/organizations" : {"name":"organizations", "type":"simple", "modes":[]},
     "http://id.loc.gov/vocabulary/relators" : {"name":"relators", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/resourceComponents" : {"name":"resourceComponents", "type":"simple", "modes":[]},
+    "http://id.loc.gov/vocabulary/resourceComponents" : {"name":"resourceComponents", "type":"simple", "modes":[]},												//update this
     "http://id.loc.gov/vocabulary/resourceTypes" : {"name":"resourceTypes", "type":"simple", "modes":[]},
     "http://id.loc.gov/vocabulary/subjectSchemes" : {"name":"subjectSchemes", "type":"simple", "modes":[]},
     "http://mlvlp04.loc.gov:3000/verso/api/configs?filter[where][configType]=noteTypes&filter[fields][json]=true" : {"name":"true", "type":"simple", "modes":[]},

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 15,
-    versionPatch: 0,
+    versionPatch: 1,
 
 
     regionUrls: {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 14,
-    versionPatch: 38,
+    versionPatch: 39,
 
     regionUrls: {
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -647,7 +647,7 @@ export const useConfigStore = defineStore('config', {
     "http://id.loc.gov/vocabulary/mtechnique" : {"name":"mtechnique", "type":"simple", "modes":[]},
     "http://id.loc.gov/vocabulary/organizations" : {"name":"organizations", "type":"simple", "modes":[]},
     "http://id.loc.gov/vocabulary/relators" : {"name":"relators", "type":"simple", "modes":[]},
-    "http://id.loc.gov/vocabulary/resourceComponents" : {"name":"resourceComponents", "type":"simple", "modes":[]},												//update this
+    "http://id.loc.gov/vocabulary/resourceComponents" : {"name":"resourceComponents", "type":"simple", "modes":[]},
     "http://id.loc.gov/vocabulary/resourceTypes" : {"name":"resourceTypes", "type":"simple", "modes":[]},
     "http://id.loc.gov/vocabulary/subjectSchemes" : {"name":"subjectSchemes", "type":"simple", "modes":[]},
     "http://mlvlp04.loc.gov:3000/verso/api/configs?filter[where][configType]=noteTypes&filter[fields][json]=true" : {"name":"true", "type":"simple", "modes":[]},

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -935,26 +935,13 @@ export const useProfileStore = defineStore('profile', {
         // if there are properties in the old template that are not in the new one then we need to remove them from the userValue
         let possibleProperties = nextRef.propertyTemplates.map((p) => {return p.propertyURI})
 		
-		//Look at the userValue for additional properties, only looking at the path misses role
-		if (
-				userValue["@type"].includes("/Jurisdiction") || 
-				userValue["@type"].includes("/Person") || 
-				userValue["@type"].includes("/Family") || 
-				userValue["@type"].includes("/Organization") || 
-				userValue["@type"].includes("/Meeting") ||
-				userValue["@type"].includes("/PrimaryContribution") ||
-				userValue["@type"].includes("/Contribution")
-		   ){
-			possibleProperties = possibleProperties.concat(Object.keys(userValue).map((key) => {return !key.startsWith("@") ? key : ""}))
-		}
-		
-		
         if (!pt.refTemplateUserValue){
             pt.refTemplateUserValue = {}
         }
 
         for (let key in userValue){
-            if (!key.startsWith('@')){
+			//For contributions, keep the keys for agent role so the data persists
+			if (!key.startsWith('@') && !["http://id.loc.gov/ontologies/bibframe/agent", "http://id.loc.gov/ontologies/bibframe/role"].includes(key)){
                 if (possibleProperties.indexOf(key)==-1){
                     //
                     // this property has no place in the ref template we are about to switch to
@@ -1515,7 +1502,6 @@ export const useProfileStore = defineStore('profile', {
 
         }
 
-
         if (!blankNode[lastProperty]){
           console.error('Trying to find the value of this literal, unable to:',componentGuid, fieldGuid, propertyPath, value, lang, pt)
         }
@@ -1533,13 +1519,10 @@ export const useProfileStore = defineStore('profile', {
 
         // if we just set an empty value, remove the value property, and if there are no other values, remvoe the entire property
         if (value.trim() === ''){
-
-
           delete blankNode[lastProperty]
 
-
           let parent = utilsProfile.returnPropertyPathParent(pt,propertyPath)
-
+		  
           if (parent && parent[lastProperty]){
             let keep = []
             if (parent[lastProperty].length>0){
@@ -1553,10 +1536,9 @@ export const useProfileStore = defineStore('profile', {
               }
             }
 
-
             parent[lastProperty] = keep
 
-            if (parent[lastProperty].length==0){
+            if (parent[lastProperty].length==0){				
               delete parent[lastProperty]
             }
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -891,10 +891,14 @@ export const useProfileStore = defineStore('profile', {
       // let lastProperty = propertyPath.at(-1).propertyURI
       // // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
+	  
+	  console.info("------------------------")
+	  console.info("starting pt: ", JSON.parse(JSON.stringify(pt)))
 
       if (pt !== false){
 
         pt.activeType = nextRef.resourceURI
+		console.info("activeType: ", JSON.parse(JSON.stringify(pt)).activeType)
         let baseURI = pt.propertyURI
 
         // map to the first level
@@ -902,12 +906,17 @@ export const useProfileStore = defineStore('profile', {
             pt.userValue[baseURI]=[{}]
         }
         let userValue = pt.userValue[baseURI][0]
+		console.info(">>> userValue: ", JSON.parse(JSON.stringify(userValue)))
         // always remove the @id
         if (userValue['@id']){
             delete userValue['@id']
         }
 
-        userValue['@type'] = nextRef.resourceURI
+		console.info("type1: ",  JSON.parse(JSON.stringify(userValue))['@type'])
+		if (userValue['@type'] != "http://id.loc.gov/ontologies/bibframe/PrimaryContribution"){
+			userValue['@type'] = nextRef.resourceURI
+		}
+		console.info("type2: ",  JSON.parse(JSON.stringify(userValue))['@type'])
 
         // store the other properies as well
         if (!pt.refTemplateUserValueKeys){
@@ -927,20 +936,37 @@ export const useProfileStore = defineStore('profile', {
         // if there are properties in the old template that are not in the new one then we need to remove them from the userValue
         let possibleProperties = nextRef.propertyTemplates.map((p) => {return p.propertyURI})
 		
+		console.info("nextRef:", JSON.parse(JSON.stringify(nextRef)))
+		console.info("thisRef:", JSON.parse(JSON.stringify(thisRef)))
+		
+		console.info("starting userValue: ", JSON.parse(JSON.stringify(userValue)))
+		
+		let structure = this.returnStructureByComponentGuid(componentGuid)
+		console.info("structure: ", JSON.parse(JSON.stringify(structure)))
+		
+		
+		console.info("possibleProperties1: ", JSON.parse(JSON.stringify(possibleProperties)))
 		//Look at the userValue for additional properties, only looking at the path misses role
 		possibleProperties = possibleProperties.concat(Object.keys(userValue).map((key) => {return !key.startsWith("@") ? key : ""}))
 		//possibleProperties = possibleProperties.concat(propertyPath.map((p) => {return p.propertyURI}))
+		console.info("possibleProperties2: ", JSON.parse(JSON.stringify(possibleProperties)))
+		
 		
         if (!pt.refTemplateUserValue){
             pt.refTemplateUserValue = {}
         }
 
         for (let key in userValue){
+			console.info("key: ", key)
             if (!key.startsWith('@')){
                 if (possibleProperties.indexOf(key)==-1){
                     //
                     // this property has no place in the ref template we are about to switch to
                     // so store them over in the refTemplateUserValue for later if needed
+					console.info("???")
+					console.info("???")
+					console.info("???")
+					console.info("???")
                     pt.refTemplateUserValue[key] =JSON.parse(JSON.stringify(userValue[key]))
                     delete userValue[key]
                 }
@@ -951,19 +977,22 @@ export const useProfileStore = defineStore('profile', {
         // can be filled into this template
 
         for (let pp of possibleProperties){
+			console.info("pp: ", pp, "--", pt.refTemplateUserValue[pp])
             if (pt.refTemplateUserValue[pp]){
                 // don't use http://id.loc.gov/ontologies/bibframe/assigner aka source
                 // kind of a hackish thing, but the source is really not transferable between
                 // differnt types of classifications so leave it out, it will get populated with the default so
                 // we shouldn't loose any data, only if they change it then cycle the options then it will be lost and need to re-add
                 if (pp != 'http://id.loc.gov/ontologies/bibframe/assigner'){
+					console.info("setting value: ", JSON.parse(JSON.stringify(pt.refTemplateUserValue[pp])))
                     userValue[pp]= JSON.parse(JSON.stringify(pt.refTemplateUserValue[pp]))
                 }
+				console.info("deleting: ", pt.refTemplateUserValue[pp])
                 delete pt.refTemplateUserValue[pp]
             }
-
         }
-
+		
+		console.info("final pt: ", JSON.parse(JSON.stringify(pt)))
 
         // also check to see if there are default values in the orignal profile that we might need to over write with if they are switching
 
@@ -1033,7 +1062,7 @@ export const useProfileStore = defineStore('profile', {
         // they changed something
         this.dataChanged()
 
-
+		console.info("ending userValue: ", JSON.parse(JSON.stringify(userValue)))
 
       }else{
         console.error('changeRefTemplate: Cannot locate the component by guid', componentGuid, this.activeProfile)
@@ -1895,6 +1924,7 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null){
+		console.info("setValueComplse")
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -891,14 +891,10 @@ export const useProfileStore = defineStore('profile', {
       // let lastProperty = propertyPath.at(-1).propertyURI
       // // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
-	  
-	  console.info("------------------------")
-	  console.info("starting pt: ", JSON.parse(JSON.stringify(pt)))
 
       if (pt !== false){
 
         pt.activeType = nextRef.resourceURI
-		console.info("activeType: ", JSON.parse(JSON.stringify(pt)).activeType)
         let baseURI = pt.propertyURI
 
         // map to the first level
@@ -906,17 +902,16 @@ export const useProfileStore = defineStore('profile', {
             pt.userValue[baseURI]=[{}]
         }
         let userValue = pt.userValue[baseURI][0]
-		console.info(">>> userValue: ", JSON.parse(JSON.stringify(userValue)))
         // always remove the @id
         if (userValue['@id']){
             delete userValue['@id']
         }
 
-		console.info("type1: ",  JSON.parse(JSON.stringify(userValue))['@type'])
-		if (userValue['@type'] != "http://id.loc.gov/ontologies/bibframe/PrimaryContribution"){
+
+		// keep PrimaryContribution
+		if (!["http://id.loc.gov/ontologies/bibframe/PrimaryContribution"].includes(userValue['@type'])){
 			userValue['@type'] = nextRef.resourceURI
 		}
-		console.info("type2: ",  JSON.parse(JSON.stringify(userValue))['@type'])
 
         // store the other properies as well
         if (!pt.refTemplateUserValueKeys){
@@ -936,20 +931,10 @@ export const useProfileStore = defineStore('profile', {
         // if there are properties in the old template that are not in the new one then we need to remove them from the userValue
         let possibleProperties = nextRef.propertyTemplates.map((p) => {return p.propertyURI})
 		
-		console.info("nextRef:", JSON.parse(JSON.stringify(nextRef)))
-		console.info("thisRef:", JSON.parse(JSON.stringify(thisRef)))
-		
-		console.info("starting userValue: ", JSON.parse(JSON.stringify(userValue)))
-		
 		let structure = this.returnStructureByComponentGuid(componentGuid)
-		console.info("structure: ", JSON.parse(JSON.stringify(structure)))
 		
-		
-		console.info("possibleProperties1: ", JSON.parse(JSON.stringify(possibleProperties)))
 		//Look at the userValue for additional properties, only looking at the path misses role
 		possibleProperties = possibleProperties.concat(Object.keys(userValue).map((key) => {return !key.startsWith("@") ? key : ""}))
-		//possibleProperties = possibleProperties.concat(propertyPath.map((p) => {return p.propertyURI}))
-		console.info("possibleProperties2: ", JSON.parse(JSON.stringify(possibleProperties)))
 		
 		
         if (!pt.refTemplateUserValue){
@@ -957,16 +942,11 @@ export const useProfileStore = defineStore('profile', {
         }
 
         for (let key in userValue){
-			console.info("key: ", key)
             if (!key.startsWith('@')){
                 if (possibleProperties.indexOf(key)==-1){
                     //
                     // this property has no place in the ref template we are about to switch to
                     // so store them over in the refTemplateUserValue for later if needed
-					console.info("???")
-					console.info("???")
-					console.info("???")
-					console.info("???")
                     pt.refTemplateUserValue[key] =JSON.parse(JSON.stringify(userValue[key]))
                     delete userValue[key]
                 }
@@ -977,23 +957,18 @@ export const useProfileStore = defineStore('profile', {
         // can be filled into this template
 
         for (let pp of possibleProperties){
-			console.info("pp: ", pp, "--", pt.refTemplateUserValue[pp])
             if (pt.refTemplateUserValue[pp]){
                 // don't use http://id.loc.gov/ontologies/bibframe/assigner aka source
                 // kind of a hackish thing, but the source is really not transferable between
                 // differnt types of classifications so leave it out, it will get populated with the default so
                 // we shouldn't loose any data, only if they change it then cycle the options then it will be lost and need to re-add
                 if (pp != 'http://id.loc.gov/ontologies/bibframe/assigner'){
-					console.info("setting value: ", JSON.parse(JSON.stringify(pt.refTemplateUserValue[pp])))
                     userValue[pp]= JSON.parse(JSON.stringify(pt.refTemplateUserValue[pp]))
                 }
-				console.info("deleting: ", pt.refTemplateUserValue[pp])
                 delete pt.refTemplateUserValue[pp]
             }
         }
 		
-		console.info("final pt: ", JSON.parse(JSON.stringify(pt)))
-
         // also check to see if there are default values in the orignal profile that we might need to over write with if they are switching
 
 
@@ -1061,9 +1036,6 @@ export const useProfileStore = defineStore('profile', {
 
         // they changed something
         this.dataChanged()
-
-		console.info("ending userValue: ", JSON.parse(JSON.stringify(userValue)))
-
       }else{
         console.error('changeRefTemplate: Cannot locate the component by guid', componentGuid, this.activeProfile)
       }
@@ -1924,7 +1896,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null){
-		console.info("setValueComplse")
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -935,10 +935,18 @@ export const useProfileStore = defineStore('profile', {
         // if there are properties in the old template that are not in the new one then we need to remove them from the userValue
         let possibleProperties = nextRef.propertyTemplates.map((p) => {return p.propertyURI})
 		
-		let structure = this.returnStructureByComponentGuid(componentGuid)
-		
 		//Look at the userValue for additional properties, only looking at the path misses role
-		possibleProperties = possibleProperties.concat(Object.keys(userValue).map((key) => {return !key.startsWith("@") ? key : ""}))
+		if (
+				userValue["@type"].includes("/Jurisdiction") || 
+				userValue["@type"].includes("/Person") || 
+				userValue["@type"].includes("/Family") || 
+				userValue["@type"].includes("/Organization") || 
+				userValue["@type"].includes("/Meeting") ||
+				userValue["@type"].includes("/PrimaryContribution") ||
+				userValue["@type"].includes("/Contribution")
+		   ){
+			possibleProperties = possibleProperties.concat(Object.keys(userValue).map((key) => {return !key.startsWith("@") ? key : ""}))
+		}
 		
 		
         if (!pt.refTemplateUserValue){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -926,8 +926,11 @@ export const useProfileStore = defineStore('profile', {
 
         // if there are properties in the old template that are not in the new one then we need to remove them from the userValue
         let possibleProperties = nextRef.propertyTemplates.map((p) => {return p.propertyURI})
-		possibleProperties = possibleProperties.concat(propertyPath.map((p) => {return p.propertyURI}))
-
+		
+		//Look at the userValue for additional properties, only looking at the path misses role
+		possibleProperties = possibleProperties.concat(Object.keys(userValue).map((key) => {return !key.startsWith("@") ? key : ""}))
+		//possibleProperties = possibleProperties.concat(propertyPath.map((p) => {return p.propertyURI}))
+		
         if (!pt.refTemplateUserValue){
             pt.refTemplateUserValue = {}
         }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -926,6 +926,7 @@ export const useProfileStore = defineStore('profile', {
 
         // if there are properties in the old template that are not in the new one then we need to remove them from the userValue
         let possibleProperties = nextRef.propertyTemplates.map((p) => {return p.propertyURI})
+		possibleProperties = possibleProperties.concat(propertyPath.map((p) => {return p.propertyURI}))
 
         if (!pt.refTemplateUserValue){
             pt.refTemplateUserValue = {}


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-245

If you input a creator and then switched the type, the data disappears and needs to be re-entered.

The issue was that the carry-over data was being built and stored, but when the time came to insert it into the new component there was a failure to match on the properties.

For `creator/contribution` it was trying to match on `sameAs` because this is the propertyURI for the `nextRef` but it saves the carry-over value as `bf:agent` so there would never be a match

The fix here is to add the `propertyPath` uris to the `possibleProperties` to ensure that they are available for the match.

@thisismattmiller You might want to take a look at this. I'm not seeing any issues with similar fields like Title or classification, but this feels like a very naive solution. I looked at the methods available in `utils_profile.js` to try and get the propertyURI for the [PrimaryContributor](https://github.com/lcnetdev/bfe-profiles/blob/main/profile-prod/src/lc%3ART%3Abf2%3AHub%3APrimaryContribution.json) profile to supplement `possibleProperties`, but wasn't having any luck. It's also a mystery to me why Title doesn't empty out without this fix. It seems like it's doing things a little different that I couldn't pin down. Very likely that I've overlooked something big.