### PR TITLE
[BFP 247] Fix failure to match indirect geo when there's a space

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -599,7 +599,6 @@ export default {
               this.marcDeliminatedLCSHMode = true
 
 
-
               this.marcDeliminatedLCSHModeResults = await utilsNetwork.subjectLinkModeResolveLCSH(this.searchValue)
               this.marcDeliminatedLCSHModeSearching = false
               let sendResults = []

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1201,6 +1201,10 @@ const utilsNetwork = {
 		if (lcsh.includes(" --")){
 			lcsh = lcsh.replace(" --", "--")
 		}
+		//Also remove spaces after the hyphens
+		if (lcsh.includes("-- ")){
+			lcsh = lcsh.replace("-- ", "--")
+		}
 
       }
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1196,6 +1196,11 @@ const utilsNetwork = {
         }
 
         lcsh = lcsh.replace(secondDollarZ,collapsedDollarZ)
+		
+		//if there is a space before the hyphens remove it. It prevents matches
+		if (lcsh.includes(" --")){
+			lcsh = lcsh.replace(" --", "--")
+		}
 
       }
 


### PR DESCRIPTION
Ticket: https://staff.loc.gov/tasks/browse/BFP-247

MARC Delimited subjects will now match indirect geo even when there is a space between the two pieces:

`$z Pennsylvania $z Lancaster` ✔️ 
`$zPennsylvania$zLancaster` ✔️ 