### PR TITLE
[BFP 231] Add close button to modals

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -454,7 +454,7 @@
 
         <div ref="complexLookupModalContainer" class="complex-lookup-modal-container">
 			<div class="menu-buttons">
-				<button @click="reset(); $emit('hideComplexModal')">X</button>
+				<button @click="reset(); $emit('hideComplexModal')">Close</button>
 			</div>
           <div class="complex-lookup-modal-container-parts">
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -113,7 +113,15 @@
     },
 
     methods: {
-
+	  // Reset stored values
+	  // This is for when the modal is closed, we want to reset things so nothing is preloaded
+	  // and the user starts from zero
+	  reset: function(){
+		  this.activeContext = null
+		  this.activeComplexSearch = []
+		  this.searchValueLocal = null
+          this.authorityLookupLocal = null
+	  },
 
       // watching the search input, when it changes kick off a search
       doSearch: async function(){
@@ -445,7 +453,9 @@
       >
 
         <div ref="complexLookupModalContainer" class="complex-lookup-modal-container">
-
+			<div class="menu-buttons">
+				<button @click="reset(); $emit('hideComplexModal')">X</button>
+			</div>
           <div class="complex-lookup-modal-container-parts">
 
             <div class="complex-lookup-modal-search">
@@ -857,6 +867,12 @@
 .toggle + .toggle-container div:last-child{
    color: black;
    transition: color 0.3s;
+}
+
+.menu-buttons{
+	margin-right: 5px;
+	padding-top: 5px;
+	float: right;
 }
 
 </style>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -16,10 +16,11 @@
     >
 
     <div ref="complexLookupModalContainer" class="complex-lookup-modal-container">
-
       <div style="position: relative;">
-
           <div style="position:absolute; right:2em; top:  0.25em; z-index: 100;">
+			  <div class="menu-buttons">
+				<button @click="closeEditor()">Close</button>
+			  </div>
             <button @click="editorModeSwitch('build')" data-tooltip="Build LCSH headings using a lookup list" class="subjectEditorModeButtons simptip-position-left" style="margin-right: 1em; background-color: black; height: 2em; display: inline-flex;">
       <!--         <svg fill="#F2F2F2" width="20px" height="20px" version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                <g>
@@ -634,6 +635,13 @@ padding-right: 0.25em;
 
 .clear-selected-button {
 margin-top: 10px;
+}
+
+.menu-buttons{
+	margin-right: 5px;
+	padding-top: 5px;
+	padding-left: 15px;
+	float: right;
 }
 
 /*
@@ -2168,10 +2176,10 @@ methods: {
 
 
   closeEditor: function(){
-    //after closing always open in `link` mode for consistency
+    //after closing always open in `build` mode
     this.subjectEditorMode = "build"
 	
-	//clear out the compoents and related field so things will start clean if it reopened
+	//clear out the components and related field so things will start clean if it reopened
 	this.cleanState()
 	
     this.$emit('hideSubjectModal', true)
@@ -2204,6 +2212,11 @@ methods: {
     this.typeLookup={}
     this.okayToAdd= false
     this.showTypes= false
+	
+	this.contextData = {nodeMap:{}}
+	this.authorityLookupLocal = null,
+    this.subjectString = ''
+
   },
 
 


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-231

Adds close buttons to complex modals and subject editor. These are the only ones that seem to be missing the ability to close after opening without using escape.

Button is in the top right of the modal.