### PR TITLE
[BFP 114] Subject & Contribution reordering

### DIFF
--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -55,7 +55,6 @@
               Set Language
             </button><br>
 
-
             <template v-for="(lang,index) in scriptShifterOptionsForMenu">
 
                 <button   style="width:100%"   class="" :id="`action-button-command-${fieldGuid}-${index + 7}`"  @click="$emit('actionButtonCommand', 'trans', {lang:lang.lang,dir:lang.dir, fieldGuid: fieldGuid} )">
@@ -65,14 +64,21 @@
                 </button>
 
             </template>
-
-
-
-
-
-
             <hr>
-
+        </template>
+        
+        <template v-if="structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' || structure.propertyURI == 'http://www.loc.gov/mads/rdf/v1#Topic' && showUpDownButtons()[0]">
+          <button style="width:100%" class="" :id="`action-button-command-${fieldGuid}-u`" @click="moveUp()">
+            <span class="button-shortcut-label">u</span>
+            Move Up
+          </button>
+        </template>
+        
+        <template v-if="structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' || structure.propertyURI == 'http://www.loc.gov/mads/rdf/v1#Topic' && showUpDownButtons()[1]">
+          <button style="width:100%" class="" :id="`action-button-command-${fieldGuid}-d`" @click="moveDown()">
+            <span class="button-shortcut-label">d</span>
+            Move Down
+          </button>
         </template>
 
 
@@ -296,6 +302,18 @@
       makeSubjectHeadingPrimary: function(){
         this.profileStore.makeSubjectHeadingPrimary(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'])
 
+      },
+      
+      moveUp: function(){
+        this.profileStore.moveUpDown(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'], "up") 
+      },
+      moveDown: function(){
+        this.profileStore.moveUpDown(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'], "down") 
+      },
+      
+      showUpDownButtons: function(){
+        let show = this.profileStore.showUpDownButtons(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'])
+        return show
       },
 
       openRemark(){

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -67,14 +67,14 @@
             <hr>
         </template>
         
-        <template v-if="structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' || structure.propertyURI == 'http://www.loc.gov/mads/rdf/v1#Topic' && showUpDownButtons()[0]">
+        <template v-if="(structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' || structure.parent.includes(':Agents:') || structure.propertyURI == 'http://www.loc.gov/mads/rdf/v1#Topic') && showUpDownButtons()[0]">
           <button style="width:100%" class="" :id="`action-button-command-${fieldGuid}-u`" @click="moveUp()">
             <span class="button-shortcut-label">u</span>
             Move Up
           </button>
         </template>
         
-        <template v-if="structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' || structure.propertyURI == 'http://www.loc.gov/mads/rdf/v1#Topic' && showUpDownButtons()[1]">
+        <template v-if="(structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' || structure.parent.includes(':Agents:') || structure.propertyURI == 'http://www.loc.gov/mads/rdf/v1#Topic') && showUpDownButtons()[1]">
           <button style="width:100%" class="" :id="`action-button-command-${fieldGuid}-d`" @click="moveDown()">
             <span class="button-shortcut-label">d</span>
             Move Down
@@ -312,7 +312,9 @@
       },
       
       showUpDownButtons: function(){
+        console.info("show?")
         let show = this.profileStore.showUpDownButtons(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'])
+        console.info(show)
         return show
       },
 

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -32,7 +32,6 @@
           Delete Component
         </button>
 
-
         <template v-if="structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' || structure.propertyURI == 'http://www.loc.gov/mads/rdf/v1#Topic'">
           <button style="width:100%" class="" :id="`action-button-command-${fieldGuid}-4`" @click="makeSubjectHeadingPrimary()">
             <span class="button-shortcut-label">4</span>
@@ -234,18 +233,14 @@
 
       processShortcutKeypress(event){
 
-        if (event && event.key && ['0','1','2','3','4','5','6','7','8','9','-'].indexOf(event.key) > -1){
+        if (event && event.key && ['0','1','2','3','4','5','6','7','8','9','-', 'u', 'd'].indexOf(event.key) > -1){
 
           let buttonToClick = document.getElementById(`action-button-command-${this.fieldGuid}-${event.key}`)
           if (buttonToClick){
             buttonToClick.click()
             this.isMenuShown=false
             this.sendFocusHome()
-
-
-
           }
-
         }
       },
 
@@ -255,7 +250,6 @@
           document.querySelector(`[data-guid='${this.structure["@guid"]}']`).focus()
         }else if (document.querySelector(`[data-guid='${this.fieldGuid}']`)){
           document.querySelector(`[data-guid='${this.fieldGuid}']`).focus()
-
         }
       },
 
@@ -312,9 +306,7 @@
       },
       
       showUpDownButtons: function(){
-        console.info("show?")
         let show = this.profileStore.showUpDownButtons(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'])
-        console.info(show)
         return show
       },
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -33,7 +33,7 @@
       // gives access to this.counterStore and this.userStore
       ...mapStores(useProfileStore,usePreferenceStore),
       // // gives read access to this.count and this.double
-      ...mapState(useProfileStore, ['profilesLoaded','activeProfile','rtLookup', 'activeComponent']),
+      ...mapState(useProfileStore, ['profilesLoaded','activeProfile', 'dataChanged','rtLookup', 'activeComponent']),
       ...mapState(usePreferenceStore, ['styleDefault']),
 
       ...mapWritableState(useProfileStore, ['activeComponent']),
@@ -96,16 +96,12 @@
 
 
       },
-
-
-
-    },
-
-    mounted() {
-
-
-
-    }
+      
+      change: function(){
+          // A property was moved. Make the current state savable and update the xml
+          this.dataChanged()
+      }
+    },    
   }
 
 
@@ -162,6 +158,7 @@
                             group="people"
                             @start="drag=true"
                             @end="drag=false"
+                            @change="change"
                             item-key="id">
                             <template #item="{element}">
                               <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI)">

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 15,
-    versionPatch: 0,
+    versionPatch: 2,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2961,9 +2961,7 @@ export const useProfileStore = defineStore('profile', {
         let subjItems = []
         let contribItems = []
        
-        
         if (pt !== false){
-            // loop through all the headings and find the place the headings start
             let workRtId = null
             for (let rtId in this.activeProfile.rt){
               if (rtId.indexOf(":Work") > -1){
@@ -3013,7 +3011,7 @@ export const useProfileStore = defineStore('profile', {
     * Moves the selected heading up or down
     *
     * @param {string} componentGuid - the guid of the component (the parent of all fields)
-    * @param {string} direction - which way the item should move `up` or `down`
+    * @param {string} dir - which way the item should move `up` or `down`
     * @return {void}
     */
     moveUpDown: function(componentGuid, dir){
@@ -3021,7 +3019,6 @@ export const useProfileStore = defineStore('profile', {
       let target
       
       if (pt !== false){
-        // loop through all the headings and find the place the headings start
         let firstHeading = null
         let workRtId = null
         for (let rtId in this.activeProfile.rt){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2955,7 +2955,12 @@ export const useProfileStore = defineStore('profile', {
         let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
         
         let target
-        let items = []
+        let targetType
+        
+        let items
+        let subjItems = []
+        let contribItems = []
+       
         
         if (pt !== false){
             // loop through all the headings and find the place the headings start
@@ -2963,11 +2968,22 @@ export const useProfileStore = defineStore('profile', {
             for (let rtId in this.activeProfile.rt){
               if (rtId.indexOf(":Work") > -1){
                 workRtId = rtId
-                for (let [idx, ptId] of this.activeProfile.rt[rtId].ptOrder.entries()){
+                for (let ptId of this.activeProfile.rt[rtId].ptOrder){
                   if (this.activeProfile.rt[rtId].pt[ptId].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'){
-                    items.push(ptId)
+                    subjItems.push(ptId)
                     if (this.activeProfile.rt[rtId].pt[ptId]["@guid"] == componentGuid){
                         target = ptId
+                        targetType = "subject"
+                    }
+                  }
+                  if (
+                        this.activeProfile.rt[rtId].pt[ptId].propertyURI == 'http://id.loc.gov/ontologies/bibframe/contribution' && 
+                        this.activeProfile.rt[rtId].pt[ptId].propertyLabel != "Creator of Work"
+                     ){
+                    contribItems.push(ptId)
+                    if (this.activeProfile.rt[rtId].pt[ptId]["@guid"] == componentGuid){
+                        target = ptId
+                        targetType = "contribution"
                     }
                   }
                 }
@@ -2975,6 +2991,7 @@ export const useProfileStore = defineStore('profile', {
             }
         }
         
+        items = targetType == "subject" ? subjItems : contribItems
         if (items.length <= 1){
             return [false, false]
         } else {
@@ -2983,7 +3000,9 @@ export const useProfileStore = defineStore('profile', {
                 return [false, true]
             } else if (pos == items.length-1){
                 return [true, false]
-            } else {
+            } else if (pos < 0){
+                return [false, false]
+            }else {
                 return [true, true]
             }
         }
@@ -3009,7 +3028,10 @@ export const useProfileStore = defineStore('profile', {
           if (rtId.indexOf(":Work") > -1){
             workRtId = rtId
             for (let ptId of this.activeProfile.rt[rtId].ptOrder){
-              if (this.activeProfile.rt[rtId].pt[ptId].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'){
+              if (
+                    this.activeProfile.rt[rtId].pt[ptId].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject' ||
+                    this.activeProfile.rt[rtId].pt[ptId].propertyURI == 'http://id.loc.gov/ontologies/bibframe/contribution'
+                 ){
                 if (this.activeProfile.rt[rtId].pt[ptId]["@guid"] == componentGuid){
                         target = ptId
                     }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3042,7 +3042,6 @@ export const useProfileStore = defineStore('profile', {
           } else {
               newPos = currentPos+1
           }
-          const swapValue =  this.activeProfile.rt[workRtId].ptOrder[newPos]
           
           //swap the target with the element in the desired position
           //delete from current pos


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-114

Adds "Move Up" and "Move Down" buttons to subjects and contributors when there is more than 1 field. Also limits the buttons so that the first item can only be moved down and the last item can only be moved up. Shortcuts are on `u` and `d`.

Moving items in the properties menu will make the record savable and rebuild the XML.