### PR TITLE
BibID in title sometimes wrong

### DIFF
--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2413,10 +2413,10 @@ export const useProfileStore = defineStore('profile', {
           let env = config.returnUrls.env
 
           // populate the title
-          // if (type=='Instance'){
-            // let bibId =  this.activeProfile.rt[rt].URI.split("/")[this.activeProfile.rt[rt].URI.split('/').length - 1]
-            // document.title = `Marva | ${bibId}`;
-          // }
+          if (type=='Instance'){
+            let bibId =  this.activeProfile.rt[rt].URI.split("/")[this.activeProfile.rt[rt].URI.split('/').length - 1]
+            document.title = `Marva | ${bibId}`;
+          }
 
           pubResuts.resourceLinks.push({
             'type':type,


### PR DESCRIPTION
Reinstate the title bibID being set when a record is published. There's an issue when loading a record from memory, the BIBid might not be correct.