### PR TITLE
Improve bib id placement

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -230,6 +230,22 @@
           
           this.profileStore.setPropertyVisible(profile,event.target.value)
           event.target.value = "home"
+        },
+        
+        populateTitle: function(){
+            let eId = this.activeProfile.eId
+            for (let rt in this.activeProfile.rt){
+              let type = rt.split(':').slice(-1)[0]
+              let url = this.activeProfile.rt[rt].URI
+
+              // populate the title
+              if (type=='Instance'){
+                let bibId =  url.split("/")[url.split('/').length - 1]
+                if (eId != bibId){
+                    document.title = `Marva | ${bibId}`;
+                }
+              }
+            }
         }
 
 
@@ -274,22 +290,14 @@
 
 
     mounted: function(){
+        //populate when loading from a search
+        this.populateTitle()
     },
     
     updated: function(){
-		// Add the ID to the title
-        let eId = this.activeProfile.eId
-        for (let rt in this.activeProfile.rt){
-          let type = rt.split(':').slice(-1)[0]
-          let url = this.activeProfile.rt[rt].URI
-
-          // populate the title
-          if (type=='Instance'){
-            let bibId =  url.split("/")[url.split('/').length - 1]
-            if (eId != bibId){
-                document.title = `Marva | ${bibId}`;
-            }
-          }
+		// Add the ID to the title when loading from "Your Records"
+        if (document.title == "Marva"){
+            this.populateTitle()
         }
     }
 

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -232,6 +232,8 @@
           event.target.value = "home"
         },
         
+        
+        //Add the BibId to the title
         populateTitle: function(){
             let eId = this.activeProfile.eId
             for (let rt in this.activeProfile.rt){

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -274,27 +274,23 @@
 
 
     mounted: function(){
+    },
+    
+    updated: function(){
 		// Add the ID to the title
-		let eId = this.activeProfile.eId
-		for (let rt in this.activeProfile.rt){
+        let eId = this.activeProfile.eId
+        for (let rt in this.activeProfile.rt){
           let type = rt.split(':').slice(-1)[0]
           let url = this.activeProfile.rt[rt].URI
 
           // populate the title
           if (type=='Instance'){
             let bibId =  url.split("/")[url.split('/').length - 1]
-			if (eId != bibId){
-				document.title = `Marva | ${bibId}`;
-			}
+            if (eId != bibId){
+                document.title = `Marva | ${bibId}`;
+            }
           }
-		}
-		
-			
-		// populate the title
-          // if (type=='Instance'){
-            // let bibId =  this.activeProfile.rt[rt].URI.split("/")[this.activeProfile.rt[rt].URI.split('/').length - 1]
-            // document.title = `Marva | ${bibId}`;
-          // }
+        }
     }
 
   }


### PR DESCRIPTION
Was using `mounted` before, but that didn't have the correct `activeProfile` sometimes.

Moved logic to a function. `mounted` is needed to populate the title when loading from a search. However, relying only on this can cause the wrong bibID to be loaded when loading from the records list. The `activeProfile` when loading from the record list will be the last record opened.

`updated` updates the bibID in the title to reflect the currently open record.
