### PR TITLE
Fix Instance Variant/Parallel Titles being added to `Work` when duplicated

### DIFF
--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -722,6 +722,20 @@ const utilsProfile = {
 },
 
 
+// Get the RT type that a component ID is in
+getRtTypeFromGuid: function(profile, target){
+       for (let rt in profile["rt"]){
+           for (let pt in profile["rt"][rt]["pt"]){
+               if (profile["rt"][rt]["pt"][pt]["@guid"] == target){
+                   return rt
+               }
+           }
+       }
+       
+       return false
+},
+
+
 
 }
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 15,
-    versionPatch: 3,
+    versionPatch: 4,
 
 
     regionUrls: {

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3324,7 +3324,7 @@ export const useProfileStore = defineStore('profile', {
 
       //Ensure that the component is going to the right place by checking the structure.parentID
       // the parentId of different kinds of titles don't include `work` or `instance`, so check the RT in the profile
-      let rt = utilsProfile.getRtTypeFromGuid(this.activeProfile, componentGuid)
+      // let rt = utilsProfile.getRtTypeFromGuid(this.activeProfile, componentGuid)
       let actionTarget = null
       if (structure.parentId.includes("Instance") || rt.includes("Instance")) {
         actionTarget = "Instance"

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3323,10 +3323,12 @@ export const useProfileStore = defineStore('profile', {
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
       //Ensure that the component is going to the right place by checking the structure.parentID
+      // the parentId of different kinds of titles don't include `work` or `instance`, so check the RT in the profile
+      let rt = utilsProfile.getRtTypeFromGuid(this.activeProfile, componentGuid)
       let actionTarget = null
-      if (structure.parentId.includes("Instance")) {
+      if (structure.parentId.includes("Instance") || rt.includes("Instance")) {
         actionTarget = "Instance"
-      } else if (structure.parentId.includes("Work")) {
+      } else if (structure.parentId.includes("Work") || rt.includes("Work")) {
         actionTarget = "Work"
       }
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3324,7 +3324,7 @@ export const useProfileStore = defineStore('profile', {
 
       //Ensure that the component is going to the right place by checking the structure.parentID
       // the parentId of different kinds of titles don't include `work` or `instance`, so check the RT in the profile
-      // let rt = utilsProfile.getRtTypeFromGuid(this.activeProfile, componentGuid)
+      let rt = utilsProfile.getRtTypeFromGuid(this.activeProfile, componentGuid)
       let actionTarget = null
       if (structure.parentId.includes("Instance") || rt.includes("Instance")) {
         actionTarget = "Instance"


### PR DESCRIPTION
Variant and parallel titles were always appearing in the `Work` even when they were duplicated from the instance.