### PR TITLE
Cutter Tool Fixes

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -261,10 +261,10 @@
         this.activeContext = {
             "contextValue": true,
             "source": [],
-            "type": (toLoad != null && toLoad.literal) ? "Literal Value" : null,
+            "type": (toLoad !== null && toLoad.literal) ? "Literal Value" : null,
             "variant": [],
-            "uri": (toLoad.literal) ? null : toLoad.uri,
-            "title": toLoad.label,
+            "uri": (toLoad == null || toLoad.literal) ? null : toLoad.uri,
+            "title": toLoad !== null ? toLoad.label : "",
             "contributor": [],
             "date": null,
             "genreForm": null,
@@ -278,8 +278,13 @@
           return false
         }
 
-        let results = await utilsNetwork.returnContext(toLoad.uri)
-        results.loading = false
+        let results = null
+        try {
+            results = await utilsNetwork.returnContext(toLoad.uri)
+            results.loading = false
+        } catch {
+            results = null
+        }
 
         // if this happens it means they selected something else very quickly
         // so don't go on and set it to this context, because its no longer the one they have selected

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -895,6 +895,14 @@ export const useProfileStore = defineStore('profile', {
       // let lastProperty = propertyPath.at(-1).propertyURI
       // // locate the correct pt to work on in the activeProfile
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
+      
+      //should be safe to delete the cache when swaping templates
+      if (Object.keys(cachePt).includes(componentGuid)){
+          delete cachePt[componentGuid]
+      }
+      for (let guid of Object.keys(cacheGuid)){
+          cleanCacheGuid(cacheGuid,  JSON.parse(JSON.stringify(pt.userValue)), guid)
+      }
 
       if (pt !== false){
 


### PR DESCRIPTION
This has some adjustments to deal with issues with the cutter tool freezing.

Still not sure what the issue was exactly, but adding a bunch of subject components and then deleting some of them could cause the freezing. 

There were two console errors in `ComplexLookupModal.vue` -> `selectChange()`. `toLoad` was null and causing issues in the function.

The errors have been fixed by adding logic to handle a `toLoad == nul` and the cutter issue seems resolved.

Also fix a literal caching issue when switching to NLM classification and back to LCC.