### PR TITLE
update subjects to support multiple 2.8 multiple auth labels and marc…

### DIFF
--- a/src/components/panels/edit/modals/NonLatinAgentModal.vue
+++ b/src/components/panels/edit/modals/NonLatinAgentModal.vue
@@ -146,15 +146,13 @@
 
 
       window.setTimeout(()=>{
-        console.log(this.profileStore)
-        console.log(this.profileStore.returnAllNonLatinLiterals())
-
+        
         
         this.nonLatinAgents = this.profileStore.returnAllNonLatinAgentOptions()
-        console.log(this.nonLatinAgents)
+        
 
         for (let key in this.nonLatinAgents){
-          console.log(key)
+        
           if (this.nonLatinScriptAgents[key]){
             this.localMap[key] = this.nonLatinScriptAgents[key]
           }else{
@@ -164,7 +162,7 @@
         }
 
 
-      },1000)
+      },100)
 
 
 
@@ -212,6 +210,7 @@
             <div v-if="Object.keys(nonLatinAgents).length == 0">No Non-Latin Agents/Headings Found.</div>
             
             <div v-for="nlA in nonLatinAgents" class="non-latin-access-point">
+              <div style="color: #636363;">{{ nlA.propertyURI.replace("http://id.loc.gov/ontologies/bibframe/",'bf:') }}</div>
               <div>{{ nlA.nonLatin }}</div>
               Use script to build access points:<select @change="scriptChange" :data-key="nlA['@guid']" v-model="localMap[nlA['@guid']]">
                 <option v-for="s in nlA.scripts">{{s}}</option>

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -591,7 +591,8 @@ const utilsExport = {
 				// multiple auth labels one with no @lang tag and ones that do have it
 				// check specific properties for now? (10/2024)
 				if ([
-					'http://id.loc.gov/ontologies/bibframe/contribution'
+					'http://id.loc.gov/ontologies/bibframe/contribution',
+					'http://id.loc.gov/ontologies/bibframe/subject'
 				].indexOf(ptObj.propertyURI)>-1){
 
 					// recusrive function to go through each key in the userValue and keep going till we find labels or marckeys 
@@ -605,7 +606,7 @@ const utilsExport = {
 							for (let k in obj){
 							if (Array.isArray(obj[k])){
 								// we only care about these properties
-								if (k == 'http://www.w3.org/2000/01/rdf-schema#label' || k == 'http://id.loc.gov/ontologies/bflc/marcKey'){
+								if (k == 'http://www.w3.org/2000/01/rdf-schema#label' || k == 'http://id.loc.gov/ontologies/bflc/marcKey' || k == 'http://www.loc.gov/mads/rdf/v1#authoritativeLabel'){
 									func(k,obj[k])
 								}else{
 									process(obj[k], func);

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -388,6 +388,8 @@ const utilsNetwork = {
                     total: r.count
                   }
 
+
+
                   if (hitAdd.label=='' && hitAdd.suggestLabel.includes('DEPRECATED')){
                     hitAdd.label  = hitAdd.suggestLabel.split('(DEPRECATED')[0] + ' DEPRECATED'
                     hitAdd.depreciated = true
@@ -834,7 +836,6 @@ const utilsNetwork = {
             genreForm: null,
             nodeMap:{},
           };
-          console.log('data.uri',data.uri,data)
           if (data.uri.includes('wikidata.org')){
             if (data.entities){
               let qid = Object.keys(data.entities)[0]
@@ -909,7 +910,6 @@ const utilsNetwork = {
             }
             // console.log(uriIdPart)
           }else{
-            console.log("data",data)
             // if it is in jsonld format
             if (data['@graph']){
               data = data['@graph'];
@@ -917,8 +917,7 @@ const utilsNetwork = {
 
             var nodeMap = {};
 
-            data.forEach(function(n){
-              console.log(n)
+            data.forEach(function(n){              
               if (n['http://www.loc.gov/mads/rdf/v1#birthDate']){
                 nodeMap['Birth Date'] = n['http://www.loc.gov/mads/rdf/v1#birthDate'].map(function(d){ return d['@value']})
               }
@@ -976,7 +975,6 @@ const utilsNetwork = {
               }
 
             })
-            console.log(nodeMap)
             
             // pull out the labels
             data.forEach(function(n){
@@ -1153,8 +1151,6 @@ const utilsNetwork = {
               delete results.nodeMap[k]
             }
           })
-
-          console.log('results',results)
 
           return results;
         },

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 0,
+    versionPatch: 1,
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2217,6 +2217,40 @@ export const useProfileStore = defineStore('profile', {
 
                 }
 
+                // add in the non latin if present
+                if (subjectComponents[0].nonLatinLabel && subjectComponents[0].nonLatinLabel.length>0){
+                  for (let nlL of subjectComponents[0].nonLatinLabel){
+
+                    currentUserValuePos["http://www.loc.gov/mads/rdf/v1#authoritativeLabel"].push(
+                      {
+                        "@guid": short.generate(),
+                        "@language": nlL['@language'],
+                        "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": nlL['@value']
+                      }
+                    )
+                    currentUserValuePos["http://www.w3.org/2000/01/rdf-schema#label"].push(
+                      {
+                        "@guid": short.generate(),
+                        "@language": nlL['@language'],
+                        "http://www.w3.org/2000/01/rdf-schema#label": nlL['@value']
+                      }
+                    )
+                  }
+                }
+
+                if (subjectComponents[0].nonLatinMarkKey && subjectComponents[0].nonLatinMarkKey.length>0){
+                  for (let nlMK of subjectComponents[0].nonLatinMarkKey){
+                    currentUserValuePos["http://id.loc.gov/ontologies/bflc/marcKey"].push(
+                      {
+                        "@guid": short.generate(),
+                        "@language": nlMK['@language'],
+                        "http://id.loc.gov/ontologies/bflc/marcKey": nlMK['@value']
+                      }
+                    )                    
+                  }
+                }
+
+
 
                 // store.state.activeUndoLog.push(`Added subject heading ${subjectComponents[0].label}`)
 
@@ -2258,12 +2292,34 @@ export const useProfileStore = defineStore('profile', {
                     }
 
                     if (c.marcKey){
-
                       compo['http://id.loc.gov/ontologies/bflc/marcKey'] = [{
                         "@guid": short.generate(),
                         'http://id.loc.gov/ontologies/bflc/marcKey': c.marcKey
                       }]
 
+                      if (c.nonLatinMarkKey && c.nonLatinMarkKey.length>0){
+                        for (let nlMK of c.nonLatinMarkKey){
+                          compo["http://id.loc.gov/ontologies/bflc/marcKey"].push(
+                            {
+                              "@guid": short.generate(),
+                              "@language": nlMK['@language'],
+                              "http://id.loc.gov/ontologies/bflc/marcKey": nlMK['@value']
+                            }
+                          )                    
+                        }
+                      }
+                    }
+
+                    if (c.nonLatinLabel && c.nonLatinLabel.length>0){
+                      for (let nlL of c.nonLatinLabel){
+                        compo["http://www.loc.gov/mads/rdf/v1#authoritativeLabel"].push(
+                          {
+                            "@guid": short.generate(),
+                            "@language": nlL['@language'],
+                            "http://www.loc.gov/mads/rdf/v1#authoritativeLabel": nlL['@value']
+                          }
+                        )
+                      }
                     }
 
                     currentUserValuePos["http://www.loc.gov/mads/rdf/v1#componentList"].push(compo)
@@ -3912,6 +3968,7 @@ export const useProfileStore = defineStore('profile', {
               nonLatinMap[ptFound['@guid']] = {
                 scripts: [],
                 '@guid' : ptFound['@guid'],
+                'propertyURI': ptFound.propertyURI,
                 nonLatin: this.returnLatinLabelForPt(ptFound)
               }
            }          


### PR DESCRIPTION
…Keys in authority records

Adds logic to process auth records with multiple labels with @language tags. 

@f-osorio 
just FYI, made some changes to the subject stuff, but just additive, it passes through nonLatinLabel and nonLatinMarkKey from the authority record context if it is there  to the setValueSubject profile process. 

The multiple labels and keys live in the userValue but get filtered out on export for bf:contribution and bf:subject properties based on what script is being used for the record or you can customize it in the Non-Lating Agent menu under Tools.
