### PR TITLE
Fix some errors in SubjectEditor when open GeoCoverage

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -527,7 +527,7 @@ export default {
     */
     setComplexValue: function(contextValue){
       delete contextValue.typeFull
-      this.profileStore.setValueComplex(this.guid,null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap, contextValue.marcKey)
+      this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap, contextValue.marcKey)
       this.searchValue=''
       this.displayModal=false
 
@@ -741,7 +741,7 @@ export default {
       // store the label to pass as a prop
       this.authorityLookup = label
       this.searchValue = label
-
+        
       if (!this.configStore.useSubjectEditor.includes(this.structure.propertyURI)) {
         this.displayModal = true
       } else {
@@ -753,7 +753,6 @@ export default {
 	  
         this.displaySubjectModal = true
       }
-
     },
   }
 };

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -815,7 +815,7 @@ methods: {
   buildLookupComponents: function(incomingSubjects){
     this.typeLookup = {}
     
-    if (typeof incomingSubjects == "undefined"){
+    if (!incomingSubjects || typeof incomingSubjects == "undefined"){
         return
     }
     
@@ -864,7 +864,7 @@ methods: {
     } else {
         // dealing with a complex subject
         this.componetLookup[0] = {}
-        let type = incomingSubjects["@type"]
+        let type = incomingSubjects["@type"] ? incomingSubjects["@type"] : ""
 
         if (type.includes("http://www.loc.gov/mads/rdf/v1#Topic")){
             this.typeLookup[0] = 'madsrdf:Topic'

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1938,7 +1938,6 @@ export const useProfileStore = defineStore('profile', {
       }
 	  
       if (pt !== false){
-
         pt.hasData = true
         pt.userModified = true
         pt.dataLoaded = false
@@ -2085,7 +2084,7 @@ export const useProfileStore = defineStore('profile', {
         this.dataChanged()
 
       }else{
-        console.error('setValueSimple: Cannot locate the component by guid', componentGuid, this.activeProfile)
+        console.error('setValueComplex: Cannot locate the component by guid', componentGuid, this.activeProfile)
       }
 
 


### PR DESCRIPTION
Opening an existing GEO coverage authority was triggering errors in the SubjectEditor. 
Why? No clue. 

Geo Coverage uses another modal, but the "Update" function for both was getting triggered and running into errors.