### PR TITLE
[BFP 272] ComplexValues

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -328,16 +328,15 @@ export default {
 
 
     complexLookupValues(){
-        
-        let values = this.profileStore.returnComplexLookupValueFromProfile(this.guid,this.propertyPath)
-        return values
           
-      // try{
-          // let values = this.profileStore.returnComplexLookupValueFromProfile(this.guid,this.propertyPath)
-          // return values
-      // } catch {
-          // return false
-      // }
+      try{
+          let values = this.profileStore.returnComplexLookupValueFromProfile(this.guid,this.propertyPath)
+          return values
+      } catch(err) {
+          // this can run into an error when populating an empty complexValue field
+          // It mostly doesn't seem to matter, but might as well catch
+          return []
+      }
 
     },
 
@@ -532,7 +531,6 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-        console.info("contextValue: ", contextValue)
       delete contextValue.typeFull
       this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap, contextValue.marcKey)
       this.searchValue=''

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -328,10 +328,16 @@ export default {
 
 
     complexLookupValues(){
-
-
-      let values = this.profileStore.returnComplexLookupValueFromProfile(this.guid,this.propertyPath)
-      return values
+        
+        let values = this.profileStore.returnComplexLookupValueFromProfile(this.guid,this.propertyPath)
+        return values
+          
+      // try{
+          // let values = this.profileStore.returnComplexLookupValueFromProfile(this.guid,this.propertyPath)
+          // return values
+      // } catch {
+          // return false
+      // }
 
     },
 
@@ -526,6 +532,7 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
+        console.info("contextValue: ", contextValue)
       delete contextValue.typeFull
       this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap, contextValue.marcKey)
       this.searchValue=''

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -284,11 +284,11 @@ export default {
 			  let template = this.structure.valueConstraint.valueTemplateRefs[idx]
 			  if (parentUserValue && parentUserValue["@root"] == "http://id.loc.gov/ontologies/bibframe/contribution" && parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"]){
 				  let target = parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"][0]["http://id.loc.gov/ontologies/bibframe/agent"]
-				  if (target){
-					  let type = target[0]["@type"]
-					  if (type && this.rtLookup[template].resourceURI === type){
-						useId = template
-					  }
+				  if (target){                      
+                      let type = target[0]["@type"]
+                      if (type && this.rtLookup[template].resourceURI === type){
+                        useId = template
+                      }
 				  }
 			  }
 		  }

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 6,
+    versionPatch: 7,
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1843,10 +1843,6 @@ export const useProfileStore = defineStore('profile', {
       let valueLocation = utilsProfile.returnValueFromPropertyPath(pt,propertyPath)
       let deepestLevelURI = propertyPath[propertyPath.length-1].propertyURI
       
-      console.info("pt", JSON.parse(JSON.stringify(pt)))
-      console.info("valueLocation", valueLocation)
-      console.info("deepestLevelURI", deepestLevelURI)
-      
       if (valueLocation){
 
         let values = []
@@ -1861,7 +1857,6 @@ export const useProfileStore = defineStore('profile', {
               }
 
               for (let lP of LABEL_PREDICATES){
-                  console.info("lP", lP)
                   if (v[lP] && v[lP][0][lP]){
                       label = v[lP][0][lP]
                       break
@@ -1871,9 +1866,7 @@ export const useProfileStore = defineStore('profile', {
               // look for bf:title -> bf:mainTitle
               if (!label){
                 for (let lP1 of LABEL_PREDICATES){
-                    console.info("lP1", lP1)
                   for (let lP2 of LABEL_PREDICATES){
-                      console.info("lP2", lP2)
                     if (v[lP1][0][lP2] && v[lP1][0][lP2][0][lP2]){
                       label = v[lP1][0][lP2][0][lP2]
                       break

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2074,7 +2074,7 @@ export const useProfileStore = defineStore('profile', {
                   'http://id.loc.gov/ontologies/bflc/marcKey' : aMarcKeyNode
                 }
               )              
-            }else if (aMarcKeyNode['@value']){
+            }else if (aMarcKeyNode && aMarcKeyNode['@value']){
               let aNode = {
                 '@guid': short.generate(),
                 'http://id.loc.gov/ontologies/bflc/marcKey' : aMarcKeyNode['@value']


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-272

Fixes issue with not being able to edit complex values. The issue was demonstrated as being with names, but other complex values were also showing the issue such as "Geographic Coverage." The issue was that if there was existing data, it would be maintained when the new data was added. The fixes empties out the component before adding the new data.

Also fixes some issues:
* Literal names could cause an error when trying to parse marcKeys
* `complexLookupValue()` would throw an error when populating an empty complex value. Related commit has details.