### PR TITLE
Fix subdiv label

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1550,7 +1550,7 @@ methods: {
         out.push("Auth Hd")
       } else if (collections.includes("GenreFormSubdivisions")){
         out.push("GnFrm")
-      } else if (collections.includes("GeographicSubdivisions") || collections.includes("SubdivideGeographically")){
+      } else if (collections.includes("GeographicSubdivisions")){
         out.push("GeoSubDiv")
       } else if (collections.includes("Subdivisions")){
         out.push("SubDiv")

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 7,
+    versionPatch: 8,
 
 
 


### PR DESCRIPTION
Subdivisoins would sometimes be marked as `GeoSubDiv` when it shouldn't have been. This happened when the subdivision could be geographically subdivided.