### PR TITLE
Fix geographic subj as topic

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1970,11 +1970,6 @@ methods: {
 
         }
 
-        // always make the first one the topic
-        try {
-            this.components[0].type = 'madsrdf:Topic'
-        } catch {}
-
         this.updateAvctiveTypeSelected()
         this.validateOkayToAdd()
       },400)
@@ -2103,7 +2098,7 @@ methods: {
       // something like a name becomes a madsrdf:PersonalName instead of madsrdf:Topic
       if (c.uri && c.uri.includes('id.loc.gov/authorities/names/') && this.localContextCache && this.localContextCache[c.uri]){
         c.type = this.localContextCache[c.uri].typeFull.replace('http://www.loc.gov/mads/rdf/v1#','madsrdf:')
-      }
+      } 
     }
 
     // If the individual components together, match a complex subject, switch'em so the user ends up with a controlled term
@@ -2160,6 +2155,7 @@ methods: {
         for (let component in frozenComponents){
           // if (this.components[component].complex && !['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(this.components[component].type)){
 			const target = frozenComponents[component]
+            
 			if (!['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(target.type) && target.complex){			  
 				let uri = target.uri
 				let data = false //await this.parseComplexSubject(uri)  //This can take a while, and is only need for the URI, but lots of things don't have URIs

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1574,6 +1574,7 @@ methods: {
     }
 
     this.getContext()
+    
     if (this.contextData){
       this.localContextCache[this.contextData.uri] = JSON.parse(JSON.stringify(this.contextData))
     }
@@ -1765,8 +1766,25 @@ methods: {
       if (this.activeTypes[this.activeComponent.type]){
         this.activeTypes[this.activeComponent.type].selected=true
       }
-    }
+    } else if (this.activeComponent.type == null){ //fall back on the marcKey, this can be null if the selection is too fast?
+        let subfield = this.activeComponent.marcKey.slice(5, 7)
+        switch(subfield){
+            case("$v"):
+              subfield = "madsrdf:GenreForm"
+              break
+            case("$y"):
+              subfield = "madsrdf:Temporal"
+              break
+            case("$z"):
+              subfield = "madsrdf:Geographic"
+              break
+            default:
+              subfield = "madsrdf:Topic"
+        }
 
+        this.activeTypes[subfield].selected=true
+        this.activeComponent.type = subfield
+    }
 
   },
 
@@ -1955,15 +1973,14 @@ methods: {
 
             if (this.localContextCache[x.uri].type === 'GenreForm'){
               x.type = 'madsrdf:GenreForm'
-            }
-            if (this.localContextCache[x.uri].type === 'Temporal'){
+            } else if (this.localContextCache[x.uri].type === 'Temporal'){
               x.type = 'madsrdf:Temporal'
-            }
-            if (this.localContextCache[x.uri].type === 'Geographic'){
+            } else if (this.localContextCache[x.uri].type === 'Geographic'){
               x.type = 'madsrdf:Geographic'
-            }
-            if (this.localContextCache[x.uri].type === 'Topic'){
+            } else if (this.localContextCache[x.uri].type === 'Topic'){
               x.type = 'madsrdf:Topic'
+            } else {
+                x.type = 'madsrdf:Topic'
             }
 
           }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1766,7 +1766,7 @@ methods: {
       if (this.activeTypes[this.activeComponent.type]){
         this.activeTypes[this.activeComponent.type].selected=true
       }
-    } else if (this.activeComponent.type == null){ //fall back on the marcKey, this can be null if the selection is too fast?
+    } else if (this.activeComponent.type == null && this.activeComponent.marcKey != null){ //fall back on the marcKey, this can be null if the selection is too fast?
         let subfield = this.activeComponent.marcKey.slice(5, 7)
         switch(subfield){
             case("$v"):

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 8,
+    versionPatch: 9,
 
 
 


### PR DESCRIPTION
Marva was forcing the first element in a subject to always be `madsrdf:Topic`. This caused subjects that start with a geographic to be topics in the XML and then the marc could be off.

Also adds a fallback for the type selection based on the marcKey. If the selection is made too quickly, the type will be none, but there might be a marcKey.