### PR TITLE
Fix only having 1 GACs code

### DIFF
--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -897,7 +897,8 @@ const utilsExport = {
 											bnodeLvl1.setAttributeNS(this.namespace.rdf, 'rdf:about', value1['@id'])
 										}
 									}
-									if (keys.length>0){
+                                    
+                                    if (keys.length>0){
 										for (let key2 of keys){
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
 												// its a label or some other literal

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 9,
+    versionPatch: 10,
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2049,13 +2049,16 @@ export const useProfileStore = defineStore('profile', {
 
           //Add gacs code to user data
           if (nodeMap["GAC(s)"]){
-            blankNode["http://www.loc.gov/mads/rdf/v1#code"] = [
-              {
-                '@guid': short.generate(),
-                "@gacs": "http://id.loc.gov/datatypes/codes/gac",
-                'http://www.loc.gov/mads/rdf/v1#code': nodeMap["GAC(s)"][0]
-              }
-            ]
+            blankNode["http://www.loc.gov/mads/rdf/v1#code"] = []
+            for (let code in nodeMap["GAC(s)"]){
+                blankNode["http://www.loc.gov/mads/rdf/v1#code"].push(
+                  {
+                    '@guid': short.generate(),
+                    "@gacs": "http://id.loc.gov/datatypes/codes/gac",
+                    'http://www.loc.gov/mads/rdf/v1#code': nodeMap["GAC(s)"][code]
+                  }
+                )
+            }
           }
 
           if (!Array.isArray(marcKey)){


### PR DESCRIPTION
If there's more than 1 GACs code for a location, only the first one would appear in the XML. It should work with multiple codes now.