### PR TITLE
Variant title order and sort key

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -582,7 +582,7 @@ export default {
           if (this.diacriticUse.length>0){
             for (let macro of this.diacriticUseValues){
               if (event.code == macro.code && event.ctrlKey == macro.ctrlKey && event.altKey == macro.altKey && event.shiftKey == macro.shiftKey){
-                console.log("run this macro", macro)
+                // console.log("run this macro", macro)
                 event.preventDefault()
 
                 this.runMacroExpressMacro(event)
@@ -783,7 +783,7 @@ export default {
         let data = this.profileStore.returnLccInfo(this.guid, this.structure)
         if (data.contributors && data.contributors.length>0){
           data.contributors[0].secondLetterLabel = data.contributors[0].label.substring(1)
-        }
+        }        
         return data
       }
       return false
@@ -824,7 +824,7 @@ export default {
     //     this.lccFeatureData = this.profileStore.returnLccInfo(this.guid, this.structure)
     //   }
     // }
-    dataChangedTimestamp(newVal, oldVal) {
+    dataChangedTimestamp(newVal, oldVal) {      
       this.lccFeatureDataCounter++
     }
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 14,
+    versionPatch: 15,
 
 
     regionUrls: {

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3022,15 +3022,12 @@ export const useProfileStore = defineStore('profile', {
 
 
 
-
       if (pt && pt.userValue && pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'] && pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'].length>0){
         let uv = pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]
-
 
         if (uv && uv['@type'] && uv['@type'] == 'http://id.loc.gov/ontologies/bibframe/ClassificationLcc'){
 
         // this is a LCC field then
-
           // we need to gather info from the component and the rest of the work to build links/suggestions
 
 
@@ -3049,7 +3046,7 @@ export const useProfileStore = defineStore('profile', {
 
 
 
-
+          
 
           if (titleNonSort && titleNonSort.trim().length >0 && title){
             if (isNaN(parseInt(titleNonSort)) == false ){
@@ -3099,6 +3096,13 @@ export const useProfileStore = defineStore('profile', {
 
 
         if (pt && pt.userValue && pt.propertyURI == 'http://id.loc.gov/ontologies/bibframe/classification' && Object.keys(pt.userValue).length == 1){
+
+          if (titleNonSort && titleNonSort.trim().length >0 && title){
+            if (isNaN(parseInt(titleNonSort)) == false ){
+              titleNonSort = parseInt(titleNonSort)
+              title = title.substr(titleNonSort).trim()
+            }
+          }
 
           // it is a new record, so there is no info but the LCC classification is by default so populate the other stuff
           return {


### PR DESCRIPTION
Fix non-sort not effecting the title in the cutter tool display if there was no LCC already populated.