### PR TITLE
Update electronic locator

### DIFF
--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -383,6 +383,8 @@
       },
 
       hasDefaultValues: function(){
+          // console.info("this.structure", this.structure.propertyLabel)
+          // console.info("this.structure", this.structure)
         // if the selected item has defaults
         if (this.structure.valueConstraint.defaults.length > 0){
           return true
@@ -390,9 +392,13 @@
 
         // if it's part of a group with members that have defaults, and that group isn't the whole thing
         let parentId = this.structure.parentId
+        // console.info("parentId", parentId)
+        // console.info("this.profileStore.rtLookup[parentId]: ", this.profileStore.rtLookup[parentId])
 
         if (!parentId.endsWith("Work") && !parentId.endsWith("Instance") && !parentId.endsWith("Hub") && !parentId.endsWith("Item")){
+            
           for (let sibling of this.profileStore.rtLookup[parentId].propertyTemplates){
+              // console.info("sibling: ", sibling.propertyLabel)
             if (sibling.valueConstraint.defaults.length > 0){
               return true
             }

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -198,18 +198,12 @@ const utilsExport = {
 	createLiteral: function(property,userValue){
         let p = this.createElByBestNS(property)
         
-        //ignore electronicLocator, after setting the id
-        // Otherwise, the "literal," which is really a URI, will update the ID and the value in the tags
-        // if (property == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
-            // // does it also have a URI?
-            // if (userValue['@id']){
-                // p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
-            // }
-            // return p
-        // }
         
 		// it should be stored under the same key
 		if (userValue[property] && property != "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
+            // without this exception, an edit to an incoming URL in SupplementaryContentNote's "Electronic Location" will update the "rdf:resource"
+            // but will also add it to the inside of the tag.
+
 			// one last sanity check, don't make empty literals
 			if (userValue[property].trim()==''){
 				return false
@@ -838,18 +832,13 @@ const utilsExport = {
 
 										xmlLog.push(`Creating lvl 3 property: ${pLvl3.tagName} for ${key2}`)
                                         
-                                        //Handles Supplementary Content
-                                        if (typeof value1[key2] == "string" && key2 == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
-                                            //instead of appending
-                                            // do this at lvl1?
+                                        // another change makes this unnecessary
+                                        // if (typeof value1[key2] == "string" && key2 == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
+                                            // pLvl2.setAttributeNS(this.namespace.rdf, 'rdf:resource', value1[key2])
                                             
-                                            console.info(">>>>> setting namespace", value1[key2])
-                                            //set the rdf:resource at pLvl2
-                                            pLvl2.setAttributeNS(this.namespace.rdf, 'rdf:resource', value1[key2])           //here!
-                                            
-                                            //delete bnodeLvl2, it's not needed
-                                            bnodeLvl2.remove()
-                                        }else {
+                                            // delete bnodeLvl2, it's not needed
+                                            // bnodeLvl2.remove()
+                                        // }else {
                                             for (let value2 of value1[key2]){
                                                 if (this.isBnode(value2)){
                                                     // more nested bnode
@@ -929,7 +918,7 @@ const utilsExport = {
                                                     }
                                                 }
                                             }
-                                        }
+                                        // }
 									}
 								}else{
 									xmlLog.push(`It's value at lvl is not a bnode, looping through and adding a literal value`)
@@ -949,14 +938,14 @@ const utilsExport = {
 										for (let key2 of keys){
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
 												// its a label or some other literal
-                                                if (pLvl1.tagName == "bf:electronicLocator"){  // handle url of instance when typing
-                                                     pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue[key1])
-                                                     bnodeLvl1.remove()
-                                                } else {
+                                                // if (pLvl1.tagName == "bf:electronicLocator"){  // handle `url of instance` when typing
+                                                     // pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue[key1])
+                                                     // bnodeLvl1.remove()
+                                                // } else {
                                                     let p2 = this.createLiteral(key2, value1)
                                                     xmlLog.push(`Creating literal ${JSON.stringify(value1)}`)
                                                     if (p2!==false) bnodeLvl1.appendChild(p2);
-                                                }
+                                                //}
 											}else if (Array.isArray(value1[key2])){
 												for (let arrayValue of value1[key2]){
 													let keysLevel2 = Object.keys(arrayValue).filter(k => (!k.includes('@') ? true : false ) )
@@ -1136,7 +1125,7 @@ const utilsExport = {
 									}
 								}
 								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
-                            //Exception for electronicLocator so it is handled by in the next block
+                            //Exception for electronicLocator so it is handled by in the next block, otherwise, it won't appear in the XML
 							}else if (ptObj.propertyURI != "http://id.loc.gov/ontologies/bibframe/electronicLocator" && await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
 								// if it is a marked in the profile as a literal and has expected value of rdf:Resource flatten it to a string literal
 								let allXMLFragments = ''

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -188,7 +188,7 @@ const utilsExport = {
         //ignore electronicLocator, after setting the id
         // Otherwise, the "literal," which is really a URI, will update the ID and the value in the tags
         // if (property == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
-            // //does it also have a URI?
+            // // does it also have a URI?
             // if (userValue['@id']){
                 // p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
             // }
@@ -196,7 +196,7 @@ const utilsExport = {
         // }
         
 		// it should be stored under the same key
-		if (userValue[property]){
+		if (userValue[property] && property != "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
 			// one last sanity check, don't make empty literals
 			if (userValue[property].trim()==''){
 				return false

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -813,91 +813,83 @@ const utilsExport = {
 
 										xmlLog.push(`Creating lvl 3 property: ${pLvl3.tagName} for ${key2}`)
                                         
-                                        // another change makes this unnecessary
-                                        // if (typeof value1[key2] == "string" && key2 == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
-                                            // pLvl2.setAttributeNS(this.namespace.rdf, 'rdf:resource', value1[key2])
-                                            
-                                            // delete bnodeLvl2, it's not needed
-                                            // bnodeLvl2.remove()
-                                        // }else {
-                                            for (let value2 of value1[key2]){
-                                                if (this.isBnode(value2)){
-                                                    // more nested bnode
-                                                    // one more level
-                                                    let bnodeLvl3 = this.createBnode(value2,key2)
-                                                    pLvl3.appendChild(bnodeLvl3)
-                                                    bnodeLvl2.appendChild(pLvl3)
-                                                    xmlLog.push(`Creating lvl 3 bnode: ${bnodeLvl3.tagName} for ${key2}`)
+                                        for (let value2 of value1[key2]){
+                                            if (this.isBnode(value2)){
+                                                // more nested bnode
+                                                // one more level
+                                                let bnodeLvl3 = this.createBnode(value2,key2)
+                                                pLvl3.appendChild(bnodeLvl3)
+                                                bnodeLvl2.appendChild(pLvl3)
+                                                xmlLog.push(`Creating lvl 3 bnode: ${bnodeLvl3.tagName} for ${key2}`)
 
 
-                                                    for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
-                                                        let pLvl4 = this.createElByBestNS(key2)
-                                                        for (let value3 of value2[key3]){
-                                                            if (this.isBnode(value3)){
-                                                                // one more level
-                                                                let bnodeLvl4 = this.createBnode(value3,key3)
-                                                                pLvl4.appendChild(bnodeLvl4)
-                                                                bnodeLvl3.appendChild(pLvl4)
-                                                                xmlLog.push(`Creating lvl 4 bnode: ${bnodeLvl4.tagName} for ${key3}`)
+                                                for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
+                                                    let pLvl4 = this.createElByBestNS(key2)
+                                                    for (let value3 of value2[key3]){
+                                                        if (this.isBnode(value3)){
+                                                            // one more level
+                                                            let bnodeLvl4 = this.createBnode(value3,key3)
+                                                            pLvl4.appendChild(bnodeLvl4)
+                                                            bnodeLvl3.appendChild(pLvl4)
+                                                            xmlLog.push(`Creating lvl 4 bnode: ${bnodeLvl4.tagName} for ${key3}`)
 
 
-                                                                for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
-                                                                    for (let value4 of value3[key4]){
-                                                                        if (this.isBnode(value4)){
-                                                                            console.error("Max hierarchy depth reached, but there are more levels left:", key4, 'in', userValue )
-                                                                            xmlLog.push(`Max hierarchy depth reached, but there are more levels left for ${key4}`)
+                                                            for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
+                                                                for (let value4 of value3[key4]){
+                                                                    if (this.isBnode(value4)){
+                                                                        console.error("Max hierarchy depth reached, but there are more levels left:", key4, 'in', userValue )
+                                                                        xmlLog.push(`Max hierarchy depth reached, but there are more levels left for ${key4}`)
 
-                                                                        }else{
+                                                                    }else{
 
-                                                                            for (let key5 of Object.keys(value4).filter(k => (!k.includes('@') ? true : false ) )){
-                                                                                if (typeof value4[key5] == 'string' || typeof value4[key5] == 'number'){
-                                                                                    // its a label or some other literal
-                                                                                    let p5 = this.createLiteral(key5, value4)
-                                                                                    if (p5!==false) bnodeLvl4.appendChild(p5);
-                                                                                    xmlLog.push(`Added literal ${p5} for ${key5}`)
-                                                                                }else{
-                                                                                    console.error('key5', key5, value4[key5], 'not a literal, should not happen')
-                                                                                    xmlLog.push(`Error not a literal but I thought it was at ${key5}`)
-                                                                                }
+                                                                        for (let key5 of Object.keys(value4).filter(k => (!k.includes('@') ? true : false ) )){
+                                                                            if (typeof value4[key5] == 'string' || typeof value4[key5] == 'number'){
+                                                                                // its a label or some other literal
+                                                                                let p5 = this.createLiteral(key5, value4)
+                                                                                if (p5!==false) bnodeLvl4.appendChild(p5);
+                                                                                xmlLog.push(`Added literal ${p5} for ${key5}`)
+                                                                            }else{
+                                                                                console.error('key5', key5, value4[key5], 'not a literal, should not happen')
+                                                                                xmlLog.push(`Error not a literal but I thought it was at ${key5}`)
                                                                             }
-
                                                                         }
 
                                                                     }
 
                                                                 }
 
+                                                            }
 
-                                                            }else{
-                                                                for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
-                                                                    if (typeof value3[key4] == 'string' || typeof value3[key4] == 'number'){
-                                                                        // its a label or some other literal
-                                                                        let p4 = this.createLiteral(key4, value3)
-                                                                        if (p4!==false) bnodeLvl3.appendChild(p4)
-                                                                        //xmlLog.push(`Added literal ${p4} for ${key4}`)
-                                                                    }else{
-                                                                        console.error('key4', key4, value3[key4], 'not a literal, should not happen')
-                                                                        xmlLog.push(`Error not a literal but I thought it was at ${key4}`)
-                                                                    }
+
+                                                        }else{
+                                                            for (let key4 of Object.keys(value3).filter(k => (!k.includes('@') ? true : false ) )){
+                                                                if (typeof value3[key4] == 'string' || typeof value3[key4] == 'number'){
+                                                                    // its a label or some other literal
+                                                                    let p4 = this.createLiteral(key4, value3)
+                                                                    if (p4!==false) bnodeLvl3.appendChild(p4)
+                                                                    //xmlLog.push(`Added literal ${p4} for ${key4}`)
+                                                                }else{
+                                                                    console.error('key4', key4, value3[key4], 'not a literal, should not happen')
+                                                                    xmlLog.push(`Error not a literal but I thought it was at ${key4}`)
                                                                 }
                                                             }
                                                         }
                                                     }
-                                                }else{
-                                                    for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
-                                                        if (typeof value2[key3] == 'string' || typeof value2[key3] == 'number'){
-                                                            // its a label or some other literal
-                                                            let p3 = this.createLiteral(key3, value2)
-                                                            if (p3!==false) bnodeLvl2.appendChild(p3)
-                                                            xmlLog.push(`Created Literal ${p3.innerHTML} for ${key3}`)
-                                                        }else{
-                                                            console.error('key3', key3, value2[key3], 'not a literal, should not happen')
-                                                            xmlLog.push(`Error not a literal but I thought it was at ${key3}`)
-                                                        }
+                                                }
+                                            }else{
+                                                for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
+                                                    if (typeof value2[key3] == 'string' || typeof value2[key3] == 'number'){
+                                                        // its a label or some other literal
+                                                        let p3 = this.createLiteral(key3, value2)
+                                                        if (p3!==false) bnodeLvl2.appendChild(p3)
+                                                        xmlLog.push(`Created Literal ${p3.innerHTML} for ${key3}`)
+                                                    }else{
+                                                        console.error('key3', key3, value2[key3], 'not a literal, should not happen')
+                                                        xmlLog.push(`Error not a literal but I thought it was at ${key3}`)
                                                     }
                                                 }
                                             }
-                                        // }
+                                        }
 									}
 								}else{
 									xmlLog.push(`It's value at lvl is not a bnode, looping through and adding a literal value`)
@@ -916,15 +908,9 @@ const utilsExport = {
 									if (keys.length>0){
 										for (let key2 of keys){
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
-												// its a label or some other literal
-                                                // if (pLvl1.tagName == "bf:electronicLocator"){  // handle `url of instance` when typing
-                                                     // pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue[key1])
-                                                     // bnodeLvl1.remove()
-                                                // } else {
                                                     let p2 = this.createLiteral(key2, value1)
                                                     xmlLog.push(`Creating literal ${JSON.stringify(value1)}`)
                                                     if (p2!==false) bnodeLvl1.appendChild(p2);
-                                                //}
 											}else if (Array.isArray(value1[key2])){
 												for (let arrayValue of value1[key2]){
 													let keysLevel2 = Object.keys(arrayValue).filter(k => (!k.includes('@') ? true : false ) )

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -796,7 +796,9 @@ const utilsExport = {
 
 							let value1FirstLoop = true
 							// loop through the value array of each of them
+                            console.info("key1", key1)
 							for (let value1 of userValue[key1]){
+                                console.info("value1", value1)
 
 								if (!value1FirstLoop && this.needsNewPredicate(key1)){
 									// we are going to make a new predicate, same type but not the same one as the last one was attached to
@@ -927,13 +929,14 @@ const utilsExport = {
 									}
 									if (keys.length>0){
                                         console.info("####keys", keys)
+                                        console.info("####userValue", userValue)
 										for (let key2 of keys){
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
 												// its a label or some other literal
                                                 if (pLvl1.tagName == "bf:electronicLocator"){  // handle url of instance when typing
-                                                    console.info("##### setting namespace", value1[key2])
+                                                    console.info("##### setting namespace", userValue[key1])
                                                 
-                                                     pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', value1[key2])
+                                                     pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue[key1])
                                                      bnodeLvl1.remove()
                                                 } else {
                                                     let p2 = this.createLiteral(key2, value1)

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -187,13 +187,13 @@ const utilsExport = {
         
         //ignore electronicLocator, after setting the id
         // Otherwise, the "literal," which is really a URI, will update the ID and the value in the tags
-        if (property == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
-            // does it also have a URI?
-            if (userValue['@id']){
-                p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
-            }
-            return p
-        }
+        // if (property == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
+            // //does it also have a URI?
+            // if (userValue['@id']){
+                // p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
+            // }
+            // return p
+        // }
         
 		// it should be stored under the same key
 		if (userValue[property]){
@@ -926,6 +926,7 @@ const utilsExport = {
 										}
 									}
 									if (keys.length>0){
+                                        console.info("####keys", keys)
 										for (let key2 of keys){
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
 												// its a label or some other literal

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -182,7 +182,19 @@ const utilsExport = {
   * @return {boolean}
   */
 	createLiteral: function(property,userValue){
+        console.info("            creating literal", property, "--", userValue)
         let p = this.createElByBestNS(property)
+        
+        //ignore electronicLocator, after setting the id
+        // Otherwise, the "literal," which is really a URI, will update the ID and the value in the tags
+        if (property == "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
+            // does it also have a URI?
+            if (userValue['@id']){
+                p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
+            }
+            return p
+        }
+        
 		// it should be stored under the same key
 		if (userValue[property]){
 			// one last sanity check, don't make empty literals
@@ -195,7 +207,7 @@ const utilsExport = {
 		if (userValue['@id']){
 			p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])
 		}
-
+        
 		if (!this.checkForEDTFDatatype){ this.checkForEDTFDatatype = useConfigStore().checkForEDTFDatatype}
 
 		if (userValue['@datatype']){
@@ -813,6 +825,7 @@ const utilsExport = {
                                             //instead of appending
                                             // do this at lvl1?
                                             
+                                            console.info(">>>>> setting namespace", value1[key2])
                                             //set the rdf:resource at pLvl2
                                             pLvl2.setAttributeNS(this.namespace.rdf, 'rdf:resource', value1[key2])           //here!
                                             
@@ -917,6 +930,8 @@ const utilsExport = {
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
 												// its a label or some other literal
                                                 if (pLvl1.tagName == "bf:electronicLocator"){  // handle url of instance when typing
+                                                    console.info("##### setting namespace", value1[key2])
+                                                
                                                      pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', value1[key2])
                                                      bnodeLvl1.remove()
                                                 } else {

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -160,10 +160,24 @@ const utilsExport = {
 			bnode.appendChild(rdftype)
 			return bnode
 		}else{
-
+            console.info("property", property)
+            console.info("userValue", userValue) //TODO: this is where the extra tag is getting built, where's this getting called?
+            
+            // throw an error, to see what the calling function is
+            // var callerName;
+            // try { throw new Error(); }
+            // catch (e) { 
+                // var re = /(\w+)@|at (\w+) \(/g, st = e.stack, m;
+                // re.exec(st), m = re.exec(st);
+                // callerName = m[1] || m[2];
+                // console.info(e)
+            // }
+            // console.info(callerName);
+    
 			// just normally make it
 			let bnode = this.createElByBestNS(userValue['@type'])
 			if (userValue['@id']){
+                console.info("setting the thing?")
 				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
 			}
 			if (userValue['@parseType']){
@@ -182,7 +196,6 @@ const utilsExport = {
   * @return {boolean}
   */
 	createLiteral: function(property,userValue){
-        console.info("            creating literal", property, "--", userValue)
         let p = this.createElByBestNS(property)
         
         //ignore electronicLocator, after setting the id
@@ -758,7 +771,11 @@ const utilsExport = {
 						xmlLog.push(`Root level bnode: ${ptObj.propertyURI}`)
 
 						let pLvl1 = this.createElByBestNS(ptObj.propertyURI)
+                        
+                        console.info("creating blank node: ", userValue, "--", ptObj.propertyURI)
 						let bnodeLvl1 = this.createBnode(userValue, ptObj.propertyURI)
+                        console.info("pLvl1", pLvl1)
+                        console.info("bnode: 1", bnodeLvl1)
                         
 						xmlLog.push(`Created lvl 1 predicate: ${pLvl1.tagName} and bnode: ${bnodeLvl1.tagName}`)
 
@@ -796,9 +813,7 @@ const utilsExport = {
 
 							let value1FirstLoop = true
 							// loop through the value array of each of them
-                            console.info("key1", key1)
 							for (let value1 of userValue[key1]){
-                                console.info("value1", value1)
 
 								if (!value1FirstLoop && this.needsNewPredicate(key1)){
 									// we are going to make a new predicate, same type but not the same one as the last one was attached to
@@ -810,6 +825,7 @@ const utilsExport = {
 								// is it a bnode?  createElByBestNS
 								if (this.isBnode(value1)){
 									// yes
+                                    console.info("creating bNode: ", value1, "--", key1)
 									let bnodeLvl2 = this.createBnode(value1,key1)
                                     
 									pLvl2.appendChild(bnodeLvl2)
@@ -838,6 +854,7 @@ const utilsExport = {
                                                 if (this.isBnode(value2)){
                                                     // more nested bnode
                                                     // one more level
+                                                    console.info("creating bNode2: ", value2, "--", key2)
                                                     let bnodeLvl3 = this.createBnode(value2,key2)
                                                     pLvl3.appendChild(bnodeLvl3)
                                                     bnodeLvl2.appendChild(pLvl3)
@@ -849,6 +866,7 @@ const utilsExport = {
                                                         for (let value3 of value2[key3]){
                                                             if (this.isBnode(value3)){
                                                                 // one more level
+                                                                console.info("creating bNode3: ", value3, "--", key3)
                                                                 let bnodeLvl4 = this.createBnode(value3,key3)
                                                                 pLvl4.appendChild(bnodeLvl4)
                                                                 bnodeLvl3.appendChild(pLvl4)
@@ -928,14 +946,10 @@ const utilsExport = {
 										}
 									}
 									if (keys.length>0){
-                                        console.info("####keys", keys)
-                                        console.info("####userValue", userValue)
 										for (let key2 of keys){
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
 												// its a label or some other literal
                                                 if (pLvl1.tagName == "bf:electronicLocator"){  // handle url of instance when typing
-                                                    console.info("##### setting namespace", userValue[key1])
-                                                
                                                      pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue[key1])
                                                      bnodeLvl1.remove()
                                                 } else {

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -160,24 +160,9 @@ const utilsExport = {
 			bnode.appendChild(rdftype)
 			return bnode
 		}else{
-            console.info("property", property)
-            console.info("userValue", userValue) //TODO: this is where the extra tag is getting built, where's this getting called?
-            
-            // throw an error, to see what the calling function is
-            // var callerName;
-            // try { throw new Error(); }
-            // catch (e) { 
-                // var re = /(\w+)@|at (\w+) \(/g, st = e.stack, m;
-                // re.exec(st), m = re.exec(st);
-                // callerName = m[1] || m[2];
-                // console.info(e)
-            // }
-            // console.info(callerName);
-    
 			// just normally make it
 			let bnode = this.createElByBestNS(userValue['@type'])
 			if (userValue['@id']){
-                console.info("setting the thing?")
 				bnode.setAttributeNS(this.namespace.rdf, 'rdf:about', userValue['@id'])
 			}
 			if (userValue['@parseType']){
@@ -766,10 +751,7 @@ const utilsExport = {
 
 						let pLvl1 = this.createElByBestNS(ptObj.propertyURI)
                         
-                        console.info("creating blank node: ", userValue, "--", ptObj.propertyURI)
 						let bnodeLvl1 = this.createBnode(userValue, ptObj.propertyURI)
-                        console.info("pLvl1", pLvl1)
-                        console.info("bnode: 1", bnodeLvl1)
                         
 						xmlLog.push(`Created lvl 1 predicate: ${pLvl1.tagName} and bnode: ${bnodeLvl1.tagName}`)
 
@@ -819,7 +801,6 @@ const utilsExport = {
 								// is it a bnode?  createElByBestNS
 								if (this.isBnode(value1)){
 									// yes
-                                    console.info("creating bNode: ", value1, "--", key1)
 									let bnodeLvl2 = this.createBnode(value1,key1)
                                     
 									pLvl2.appendChild(bnodeLvl2)
@@ -843,7 +824,6 @@ const utilsExport = {
                                                 if (this.isBnode(value2)){
                                                     // more nested bnode
                                                     // one more level
-                                                    console.info("creating bNode2: ", value2, "--", key2)
                                                     let bnodeLvl3 = this.createBnode(value2,key2)
                                                     pLvl3.appendChild(bnodeLvl3)
                                                     bnodeLvl2.appendChild(pLvl3)
@@ -855,7 +835,6 @@ const utilsExport = {
                                                         for (let value3 of value2[key3]){
                                                             if (this.isBnode(value3)){
                                                                 // one more level
-                                                                console.info("creating bNode3: ", value3, "--", key3)
                                                                 let bnodeLvl4 = this.createBnode(value3,key3)
                                                                 pLvl4.appendChild(bnodeLvl4)
                                                                 bnodeLvl3.appendChild(pLvl4)

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -441,6 +441,8 @@ const utilsExport = {
     let orginalProfile = profile
 	// cut the ref to the orginal
 	profile = JSON.parse(JSON.stringify(profile))
+    
+    console.info("profile: ", profile)
 
 	let xmlParser = returnDOMParser()
 
@@ -687,9 +689,7 @@ const utilsExport = {
 
 
 				xmlLog.push(['Set userValue to:', JSON.parse(JSON.stringify(userValue)) ])
-
-
-
+                
 				if (this.ignoreProperties.indexOf(ptObj.propertyURI) > -1){
 					xmlLog.push(`Skpping it because it is in the ignoreProperties list`)
 					continue
@@ -733,6 +733,7 @@ const utilsExport = {
 
 
 				// does it even have any userValues?
+                console.info("userValue", JSON.parse(JSON.stringify(userValue)), " -- ", this.hasUserValue(userValue))
 				if (this.hasUserValue(userValue)){
 					// keep track of what resource teplates we used in this record
 					if (xmlVoidDataRtsUsed.indexOf(rt)==-1){
@@ -744,6 +745,7 @@ const utilsExport = {
 
 					// is it a Blank node
 					if (this.isBnode(userValue)){
+                        console.info("isBNode", userValue)
 						// this.debug(ptObj.propertyURI,'root level element, is bnode', userValue)
 						xmlLog.push(`Root level bnode: ${ptObj.propertyURI}`)
 
@@ -785,7 +787,6 @@ const utilsExport = {
 
 
 							let value1FirstLoop = true
-                            console.info("userValue", userValue)
 							// loop through the value array of each of them
 							for (let value1 of userValue[key1]){
 
@@ -999,6 +1000,7 @@ const utilsExport = {
 						componentXmlLookup[`${rt}-${pt}`] = formatXML(pLvl1.outerHTML)
 
 					}else{
+                        console.info("not bNode", userValue)
 						// this.debug(ptObj.propertyURI, 'root level element does not look like a bnode', userValue)
 						xmlLog.push(`Root level does not look like a bnode: ${ptObj.propertyURI}`)
 						let userValueArray = userValue
@@ -1077,7 +1079,7 @@ const utilsExport = {
 
 								console.error("Does not have URI, ERROR")
 							}else if (await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Literal'){
-
+                                    console.info("literal???", ptObj)
 								// console.log("Top level literal HERE!",userValue)
 								// its just a top level literal property
 								// loop through its keys and make the values
@@ -1116,8 +1118,8 @@ const utilsExport = {
 									}
 								}
 								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
-							}else if (await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
-
+							}else if (ptObj.propertyURI != "http://id.loc.gov/ontologies/bibframe/electronicLocator" && await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
+                                    console.info("resource???", ptObj)
 								// if it is a marked in the profile as a literal and has expected value of rdf:Resource flatten it to a string literal
 								let allXMLFragments = ''
 								for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false ) )){
@@ -1141,6 +1143,7 @@ const utilsExport = {
 								}
 								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
 							}else if (userValue['@id']){
+                                console.info("There's a ID")
 								// it has a URI at least, so make that
 								let p = this.createElByBestNS(ptObj.propertyURI)
 								p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -442,8 +442,6 @@ const utilsExport = {
 	// cut the ref to the orginal
 	profile = JSON.parse(JSON.stringify(profile))
     
-    console.info("profile: ", profile)
-
 	let xmlParser = returnDOMParser()
 
     // these will store the top level elements
@@ -733,7 +731,6 @@ const utilsExport = {
 
 
 				// does it even have any userValues?
-                console.info("userValue", JSON.parse(JSON.stringify(userValue)), " -- ", this.hasUserValue(userValue))
 				if (this.hasUserValue(userValue)){
 					// keep track of what resource teplates we used in this record
 					if (xmlVoidDataRtsUsed.indexOf(rt)==-1){
@@ -745,7 +742,6 @@ const utilsExport = {
 
 					// is it a Blank node
 					if (this.isBnode(userValue)){
-                        console.info("isBNode", userValue)
 						// this.debug(ptObj.propertyURI,'root level element, is bnode', userValue)
 						xmlLog.push(`Root level bnode: ${ptObj.propertyURI}`)
 
@@ -799,7 +795,6 @@ const utilsExport = {
 
 								// is it a bnode?  createElByBestNS
 								if (this.isBnode(value1)){
-                                    console.info("isBNode: ", value1)
 									// yes
 									let bnodeLvl2 = this.createBnode(value1,key1)
                                     
@@ -823,12 +818,6 @@ const utilsExport = {
                                             
                                             //delete bnodeLvl2, it's not needed
                                             bnodeLvl2.remove()
-                                            
-                                            // let p3 = this.createLiteral(key2, value1)
-                                            // if (p3!==false) bnodeLvl2.appendChild(p3)
-                                        //handles URL for instnace
-                                        // } else if (Array.isArray(value1[key2] ) && pLvl1.tagName == "bf:electronicLocator"){
-                                            // console.info(">>>>>>>>>>>>>>>>>>>>>>>>")
                                         }else {
                                             for (let value2 of value1[key2]){
                                                 if (this.isBnode(value2)){
@@ -910,7 +899,6 @@ const utilsExport = {
                                         }
 									}
 								}else{
-                                    console.info("else")
 									xmlLog.push(`It's value at lvl is not a bnode, looping through and adding a literal value`)
 									// no it is a literal or something else
 									// loop through its keys and make the values
@@ -929,7 +917,6 @@ const utilsExport = {
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
 												// its a label or some other literal
                                                 if (pLvl1.tagName == "bf:electronicLocator"){  // handle url of instance when typing
-                                                     console.info("   SETTING XML ", value[1], " -- ", key2, "--", value1[key2])
                                                      pLvl1.setAttributeNS(this.namespace.rdf, 'rdf:resource', value1[key2])
                                                      bnodeLvl1.remove()
                                                 } else {
@@ -1000,7 +987,6 @@ const utilsExport = {
 						componentXmlLookup[`${rt}-${pt}`] = formatXML(pLvl1.outerHTML)
 
 					}else{
-                        console.info("not bNode", userValue)
 						// this.debug(ptObj.propertyURI, 'root level element does not look like a bnode', userValue)
 						xmlLog.push(`Root level does not look like a bnode: ${ptObj.propertyURI}`)
 						let userValueArray = userValue
@@ -1079,7 +1065,6 @@ const utilsExport = {
 
 								console.error("Does not have URI, ERROR")
 							}else if (await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Literal'){
-                                    console.info("literal???", ptObj)
 								// console.log("Top level literal HERE!",userValue)
 								// its just a top level literal property
 								// loop through its keys and make the values
@@ -1118,8 +1103,8 @@ const utilsExport = {
 									}
 								}
 								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
+                            //Exception for electronicLocator so it is handled by in the next block
 							}else if (ptObj.propertyURI != "http://id.loc.gov/ontologies/bibframe/electronicLocator" && await utilsRDF.suggestTypeNetwork(ptObj.propertyURI) == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
-                                    console.info("resource???", ptObj)
 								// if it is a marked in the profile as a literal and has expected value of rdf:Resource flatten it to a string literal
 								let allXMLFragments = ''
 								for (let key1 of Object.keys(userValue).filter(k => (!k.includes('@') ? true : false ) )){
@@ -1143,7 +1128,6 @@ const utilsExport = {
 								}
 								componentXmlLookup[`${rt}-${pt}`] = allXMLFragments
 							}else if (userValue['@id']){
-                                console.info("There's a ID")
 								// it has a URI at least, so make that
 								let p = this.createElByBestNS(ptObj.propertyURI)
 								p.setAttributeNS(this.namespace.rdf, 'rdf:resource', userValue['@id'])

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -419,8 +419,16 @@ const utilsProfile = {
 
 
       }
-
-        if (isLocator){ console.info("        returning: ", JSON.parse(JSON.stringify(pointer))) }
+        if (isLocator){ 
+            console.info("        returning: ", JSON.parse(JSON.stringify(pointer))) 
+            // strip out key == "id.loc.gov/ontologies/bibframe/electronicLocator"?
+            //delete pointer[0]["http://id.loc.gov/ontologies/bibframe/electronicLocator"]
+            // pointer[0]["http://id.loc.gov/ontologies/bibframe/electronicLocator"] = ""
+            delete pointer[0]["@type"]
+            
+            console.info("        pointer  with deletions?: ", pointer)
+        }
+        
       return pointer
 
 

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -351,7 +351,9 @@ const utilsProfile = {
   * @return {array} - will return the value array at the end of the property path if it exists
   */
   returnValueFromPropertyPath: function(pt,propertyPath){
-
+        
+         let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator"))
+        
       let deepestLevel
       if (propertyPath[propertyPath.length-1]){
         deepestLevel = propertyPath[propertyPath.length-1].level
@@ -360,6 +362,12 @@ const utilsProfile = {
       }
 
       let pointer = pt.userValue
+      
+      if (isLocator){
+          console.info("    returnValueFromPropertyPath")
+          console.info("        pointer1: ", pointer)
+      }
+      
       for (let p of propertyPath){
 
         // the property path has two parts
@@ -373,6 +381,8 @@ const utilsProfile = {
             if (pointer[p.propertyURI].length === 0){
               console.warn("Expecting there to be at least one value here: ", pt, p, propertyPath)
             }
+            
+            if (isLocator){ console.info("        pointer2: ", pointer) }
 
             // if this is the last level then return the whole array, if we are continuing
             // down the hiearchy then just select the first element, as we don't support multiple values at the early levels

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -352,7 +352,7 @@ const utilsProfile = {
   */
   returnValueFromPropertyPath: function(pt,propertyPath){
         
-         let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator"))
+         let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
         
       let deepestLevel
       if (propertyPath[propertyPath.length-1]){
@@ -365,10 +365,14 @@ const utilsProfile = {
       
       if (isLocator){
           console.info("    returnValueFromPropertyPath")
-          console.info("        pointer1: ", pointer)
+          console.info("        pointer 1: ", pointer)
       }
       
+      // The note in the supplementaryContent is not in the propertyPath
+      //    
       for (let p of propertyPath){
+          
+          if (isLocator){ console.info("        looking at ", p) }
 
         // the property path has two parts
         // {level: 0, propertyURI: 'http://id.loc.gov/ontologies/bibframe/title'}
@@ -382,7 +386,7 @@ const utilsProfile = {
               console.warn("Expecting there to be at least one value here: ", pt, p, propertyPath)
             }
             
-            if (isLocator){ console.info("        pointer2: ", pointer) }
+            if (isLocator){ console.info("        pointer 2: ", pointer) }
 
             // if this is the last level then return the whole array, if we are continuing
             // down the hiearchy then just select the first element, as we don't support multiple values at the early levels
@@ -395,6 +399,7 @@ const utilsProfile = {
           }else{
 
             console.error("Expecting Array in this userValue property:",pt,p,propertyPath)
+            if (isLocator){ console.info("        returning false 1") }
             return false
 
           }
@@ -402,6 +407,7 @@ const utilsProfile = {
         }else{
           // the level doesn't exist here, we were unable to traverse the whole hierachy
           // whihch means the value is not set, so we retun false to say it failed
+          if (isLocator){ console.info("        returning false 2") }
           return false
 
         }
@@ -409,6 +415,7 @@ const utilsProfile = {
 
       }
 
+        if (isLocator){ console.info("        returning: ", JSON.parse(JSON.stringify(pointer))) }
       return pointer
 
 

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -352,7 +352,7 @@ const utilsProfile = {
   */
   returnValueFromPropertyPath: function(pt,propertyPath){
         
-         let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
+      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
         
       let deepestLevel
       if (propertyPath[propertyPath.length-1]){

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -352,29 +352,9 @@ const utilsProfile = {
   */
   returnValueFromPropertyPath: function(pt,propertyPath){
         
-      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") || pp.propertyURI.includes("tableOfContents"))
-      
-      if (isLocator){
-          console.info("====================")
-          console.info("pt", pt)
-          console.info("label", pt.propertyLabel)
-          console.info("propertyPath", propertyPath)
-          
-          for (let pp of propertyPath){
-              if (pp.propertyURI.includes("http://www.w3.org/1999/02/22-rdf-syntax-ns#value")){
-                  pp.propertyURI = "http://id.loc.gov/ontologies/bibframe/electronicLocator"
-              }
-          }
-          
-      } 
-      // else {
-          // console.info("====================")
-          // console.info("label", pt.propertyLabel)
-          // console.info("userValue", pt.userValue)
-          // console.info("propertyPath", propertyPath)
-          // console.info("pt", pt)
-      // }
-      
+      // this needs to include a check for "supplementaryContent", so the note will populate in the form
+      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") )
+            
       let deepestLevel
       if (propertyPath[propertyPath.length-1]){
         deepestLevel = propertyPath[propertyPath.length-1].level
@@ -384,16 +364,9 @@ const utilsProfile = {
 
       let pointer = pt.userValue
       
-      if (isLocator){
-          console.info("pointer", pointer)
-      } 
-      
       // The note in the supplementaryContent is not in the propertyPath
       //    
       for (let p of propertyPath){
-          if (isLocator){
-              console.info("p", p)
-          } 
         // the property path has two parts
         // {level: 0, propertyURI: 'http://id.loc.gov/ontologies/bibframe/title'}
 
@@ -415,12 +388,10 @@ const utilsProfile = {
             }
           } else {
             console.error("Expecting Array in this userValue property:",pt,p,propertyPath)
-            if (isLocator){ console.info("    returning false 1") }
             return false
           }
 
         }else{
-            if (isLocator){ console.info("    returning false 2") }
             return false
         }
       }
@@ -429,7 +400,6 @@ const utilsProfile = {
         delete pointer[0]["@type"]
       }
       
-      if (isLocator){ console.info("    returning ", pointer) }
       return pointer
 
 

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -363,17 +363,9 @@ const utilsProfile = {
 
       let pointer = pt.userValue
       
-      if (isLocator){
-          console.info("    returnValueFromPropertyPath")
-          console.info("        pointer 1: ", pointer)
-      }
-      
       // The note in the supplementaryContent is not in the propertyPath
       //    
       for (let p of propertyPath){
-          
-          if (isLocator){ console.info("        looking at ", p) }
-
         // the property path has two parts
         // {level: 0, propertyURI: 'http://id.loc.gov/ontologies/bibframe/title'}
 
@@ -385,8 +377,6 @@ const utilsProfile = {
             if (pointer[p.propertyURI].length === 0){
               console.warn("Expecting there to be at least one value here: ", pt, p, propertyPath)
             }
-            
-            if (isLocator){ console.info("        pointer 2: ", pointer) }
 
             // if this is the last level then return the whole array, if we are continuing
             // down the hiearchy then just select the first element, as we don't support multiple values at the early levels
@@ -399,20 +389,12 @@ const utilsProfile = {
           }else{
 
             console.error("Expecting Array in this userValue property:",pt,p,propertyPath)
-            if (isLocator){ 
-                console.info("        returning false 1") 
-            }
+
             return false
 
           }
 
         }else{
-          // the level doesn't exist here, we were unable to traverse the whole hierachy
-          // whihch means the value is not set, so we retun false to say it failed
-          if (isLocator){ 
-            console.info("        returning false 2") 
-            console.info("        pointer[", p.propertyURI, "]: ", pointer[p.propertyURI])
-         }
           return false
 
         }
@@ -421,12 +403,7 @@ const utilsProfile = {
       }
         if (isLocator){ 
             console.info("        returning: ", JSON.parse(JSON.stringify(pointer))) 
-            // strip out key == "id.loc.gov/ontologies/bibframe/electronicLocator"?
-            //delete pointer[0]["http://id.loc.gov/ontologies/bibframe/electronicLocator"]
-            // pointer[0]["http://id.loc.gov/ontologies/bibframe/electronicLocator"] = ""
             delete pointer[0]["@type"]
-            
-            console.info("        pointer  with deletions?: ", pointer)
         }
         
       return pointer

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -352,8 +352,29 @@ const utilsProfile = {
   */
   returnValueFromPropertyPath: function(pt,propertyPath){
         
-      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
-        
+      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") || pp.propertyURI.includes("tableOfContents"))
+      
+      if (isLocator){
+          console.info("====================")
+          console.info("pt", pt)
+          console.info("label", pt.propertyLabel)
+          console.info("propertyPath", propertyPath)
+          
+          for (let pp of propertyPath){
+              if (pp.propertyURI.includes("http://www.w3.org/1999/02/22-rdf-syntax-ns#value")){
+                  pp.propertyURI = "http://id.loc.gov/ontologies/bibframe/electronicLocator"
+              }
+          }
+          
+      } 
+      // else {
+          // console.info("====================")
+          // console.info("label", pt.propertyLabel)
+          // console.info("userValue", pt.userValue)
+          // console.info("propertyPath", propertyPath)
+          // console.info("pt", pt)
+      // }
+      
       let deepestLevel
       if (propertyPath[propertyPath.length-1]){
         deepestLevel = propertyPath[propertyPath.length-1].level
@@ -363,9 +384,16 @@ const utilsProfile = {
 
       let pointer = pt.userValue
       
+      if (isLocator){
+          console.info("pointer", pointer)
+      } 
+      
       // The note in the supplementaryContent is not in the propertyPath
       //    
       for (let p of propertyPath){
+          if (isLocator){
+              console.info("p", p)
+          } 
         // the property path has two parts
         // {level: 0, propertyURI: 'http://id.loc.gov/ontologies/bibframe/title'}
 
@@ -387,18 +415,21 @@ const utilsProfile = {
             }
           } else {
             console.error("Expecting Array in this userValue property:",pt,p,propertyPath)
+            if (isLocator){ console.info("    returning false 1") }
             return false
           }
 
         }else{
-          return false
+            if (isLocator){ console.info("    returning false 2") }
+            return false
         }
       }
       
       if (isLocator){ 
         delete pointer[0]["@type"]
       }
-        
+      
+      if (isLocator){ console.info("    returning ", pointer) }
       return pointer
 
 

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -397,6 +397,7 @@ const utilsProfile = {
       }
       
       if (isLocator){ 
+        // deleting this avoids the creation of a "rdf:Resource" tag for "URL of Instance"
         delete pointer[0]["@type"]
       }
       

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -382,29 +382,22 @@ const utilsProfile = {
             // down the hiearchy then just select the first element, as we don't support multiple values at the early levels
             if (p.level !== deepestLevel){
               pointer = pointer[p.propertyURI][0]
-            }else{
+            } else {
               pointer = pointer[p.propertyURI]
             }
-
-          }else{
-
+          } else {
             console.error("Expecting Array in this userValue property:",pt,p,propertyPath)
-
             return false
-
           }
 
         }else{
           return false
-
         }
-
-
       }
-        if (isLocator){ 
-            console.info("        returning: ", JSON.parse(JSON.stringify(pointer))) 
-            delete pointer[0]["@type"]
-        }
+      
+      if (isLocator){ 
+        delete pointer[0]["@type"]
+      }
         
       return pointer
 

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -399,7 +399,9 @@ const utilsProfile = {
           }else{
 
             console.error("Expecting Array in this userValue property:",pt,p,propertyPath)
-            if (isLocator){ console.info("        returning false 1") }
+            if (isLocator){ 
+                console.info("        returning false 1") 
+            }
             return false
 
           }
@@ -407,7 +409,10 @@ const utilsProfile = {
         }else{
           // the level doesn't exist here, we were unable to traverse the whole hierachy
           // whihch means the value is not set, so we retun false to say it failed
-          if (isLocator){ console.info("        returning false 2") }
+          if (isLocator){ 
+            console.info("        returning false 2") 
+            console.info("        pointer[", p.propertyURI, "]: ", pointer[p.propertyURI])
+         }
           return false
 
         }

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 8,
+    versionPatch: 12,
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1610,7 +1610,12 @@ export const useProfileStore = defineStore('profile', {
 
         // and now add in the literal value into the correct property
         blankNode[lastProperty] = value
-        if (isLocator){
+        
+        console.info("blankNode: ", JSON.parse(JSON.stringify(blankNode)))
+        console.info("keys: ", Object.keys(blankNode))
+        console.info("locator?", Object.keys(blankNode).some((key) => key == "http://id.loc.gov/ontologies/bibframe/electronicLocator"))
+        
+        if (isLocator && Object.keys(blankNode).some((key) => key == "http://id.loc.gov/ontologies/bibframe/electronicLocator")){
             blankNode["@id"] = value
         }
 		

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1610,11 +1610,7 @@ export const useProfileStore = defineStore('profile', {
 
         // and now add in the literal value into the correct property
         blankNode[lastProperty] = value
-        
-        console.info("blankNode: ", JSON.parse(JSON.stringify(blankNode)))
-        console.info("keys: ", Object.keys(blankNode))
-        console.info("locator?", Object.keys(blankNode).some((key) => key == "http://id.loc.gov/ontologies/bibframe/electronicLocator"))
-        
+
         if (isLocator && Object.keys(blankNode).some((key) => key == "http://id.loc.gov/ontologies/bibframe/electronicLocator")){
             blankNode["@id"] = value
         }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1677,10 +1677,25 @@ export const useProfileStore = defineStore('profile', {
     * @return {array} - an array of objs representing the literals
     */
     returnLiteralValueFromProfile: function(componentGuid, propertyPath){
+        
+        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator"))
+        if (isLocator){
+            propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
+            
+            console.info("looking at locator")
+            console.info("    componentGuid: ", componentGuid)
+            console.info("    propertyPath: ", propertyPath)
+        }
 
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
       let valueLocation = utilsProfile.returnValueFromPropertyPath(pt,propertyPath)
       let deepestLevelURI = propertyPath[propertyPath.length-1].propertyURI
+      
+      if (isLocator){
+            console.info("    pt: ", pt)
+            console.info("    valueLocation: ", valueLocation)
+            console.info("    deepestLevelURI: ", deepestLevelURI)
+        }
 
       // console.log(propertyPath[0], deepestLevelURI)
       // console.log('pt',pt)
@@ -1700,6 +1715,12 @@ export const useProfileStore = defineStore('profile', {
             values.push({
               '@guid':v['@guid'],
               value: unescape(v[deepestLevelURI]),
+              '@language' : (v['@language']) ? v['@language'] : null,
+            })
+          } else if (isLocator){
+              values.push({
+              '@guid':v['@guid'],
+              value: unescape(v["@id"]),
               '@language' : (v['@language']) ? v['@language'] : null,
             })
           }else{

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1467,9 +1467,25 @@ export const useProfileStore = defineStore('profile', {
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
         
         //TODO: get the electronic locator fields working when entering data
+        console.info("  literal: ")
+        console.info("  literal: componentGuid", componentGuid)
+        console.info("  literal: fieldGuid", fieldGuid)
+        console.info("  literal: propertyPath", propertyPath)
+        console.info("  literal: value", value)
+        console.info("  literal: lang", lang)
+        console.info("  literal: repeatedLiteral", repeatedLiteral)
         
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
+      
+      
+      //The propertyPath for supplementaryContent's note is missing the note. It jumps straight to the label
+        if (propertyPath.some((pp) => pp.propertyURI.includes("supplementaryContent")) && propertyPath.at(-1).propertyURI == "http://www.w3.org/2000/01/rdf-schema#label"){
+            propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
+            propertyPath.at(-1).level = 2
+
+        }
+
 
       let lastProperty = propertyPath.at(-1).propertyURI
       // locate the correct pt to work on in the activeProfile

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1466,6 +1466,8 @@ export const useProfileStore = defineStore('profile', {
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
         
+        
+        
         //TODO: get the electronic locator fields working when entering data
         console.info("  literal: ")
         console.info("  literal: componentGuid", componentGuid)
@@ -1483,8 +1485,14 @@ export const useProfileStore = defineStore('profile', {
         if (propertyPath.some((pp) => pp.propertyURI.includes("supplementaryContent")) && propertyPath.at(-1).propertyURI == "http://www.w3.org/2000/01/rdf-schema#label"){
             propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
             propertyPath.at(-1).level = 2
-
         }
+        
+        // for the electronic locator, the path ends with `sameAs`, but it just gets in the way
+        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
+        if (isLocator){
+            propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
+        }
+        
 
 
       let lastProperty = propertyPath.at(-1).propertyURI
@@ -1602,6 +1610,9 @@ export const useProfileStore = defineStore('profile', {
 
         // and now add in the literal value into the correct property
         blankNode[lastProperty] = value
+        if (isLocator){
+            blankNode["@id"] = value
+        }
 		
         // if we just set an empty value, remove the value property, and if there are no other values, remvoe the entire property
         if (value.trim() === ''){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1465,14 +1465,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
-        console.info("setValueLiteral")
-        console.info("componentGuid: ", componentGuid)
-        console.info("fieldGuid: ", fieldGuid)
-        console.info("propertyPath: ", propertyPath)
-        console.info("value: ", value)
-        console.info("lang: ", lang)
-        console.info("repeatedLiteral: ", repeatedLiteral)
-      
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
       
@@ -1484,8 +1476,10 @@ export const useProfileStore = defineStore('profile', {
           propertyPath.at(-1).level = 2
       }
         
+      // this needs to include a check for "supplementaryContent", so the note will populate in the form
+      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
+      
       // for the electronic locator, the path ends with `sameAs`, but it just gets in the way, toss it
-      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") || pp.propertyURI.includes("tableOfContents"))
       if (isLocator){
           propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
       }
@@ -1704,7 +1698,9 @@ export const useProfileStore = defineStore('profile', {
     */
     returnLiteralValueFromProfile: function(componentGuid, propertyPath){
         
-        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") || pp.propertyURI.includes("tableOfContents") )
+        // for the electronic locator, the path ends with `sameAs`, but it just gets in the way, toss it
+        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") )
+        
         if (isLocator){
             // `sameAs` gets in the way for the electronicLocator, toss it
             propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1678,9 +1678,16 @@ export const useProfileStore = defineStore('profile', {
     */
     returnLiteralValueFromProfile: function(componentGuid, propertyPath){
         
-        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator"))
+        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
         if (isLocator){
             propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
+            
+            //The propertyPath for supplementaryContent's note is missing the note. It jumps straight to the label
+            if (propertyPath.some((pp) => pp.propertyURI.includes("supplementaryContent")) && propertyPath.at(-1).propertyURI == "http://www.w3.org/2000/01/rdf-schema#label"){
+                propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
+                propertyPath.at(-1).level = 2
+                
+            }
             
             console.info("looking at locator")
             console.info("    componentGuid: ", componentGuid)
@@ -1695,7 +1702,7 @@ export const useProfileStore = defineStore('profile', {
             console.info("    pt: ", pt)
             console.info("    valueLocation: ", valueLocation)
             console.info("    deepestLevelURI: ", deepestLevelURI)
-        }
+      }
 
       // console.log(propertyPath[0], deepestLevelURI)
       // console.log('pt',pt)

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1468,8 +1468,6 @@ export const useProfileStore = defineStore('profile', {
         
         
         
-        //TODO: get the electronic locator fields working when entering data
-        // for supplementary content note, it updates the URI, but also populates the <bf:electronicLocator>...</...>
         console.info("  literal: ")
         console.info("  literal: componentGuid", componentGuid)
         console.info("  literal: fieldGuid", fieldGuid)
@@ -1477,24 +1475,23 @@ export const useProfileStore = defineStore('profile', {
         console.info("  literal: value", value)
         console.info("  literal: lang", lang)
         console.info("  literal: repeatedLiteral", repeatedLiteral)
-        
+
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
       
       
       //The propertyPath for supplementaryContent's note is missing the note. It jumps straight to the label
-        if (propertyPath.some((pp) => pp.propertyURI.includes("supplementaryContent")) && propertyPath.at(-1).propertyURI == "http://www.w3.org/2000/01/rdf-schema#label"){
-            propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
-            propertyPath.at(-1).level = 2
-        }
+      // so insert it so XML can get built
+      if (propertyPath.some((pp) => pp.propertyURI.includes("supplementaryContent")) && propertyPath.at(-1).propertyURI == "http://www.w3.org/2000/01/rdf-schema#label"){
+          propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
+          propertyPath.at(-1).level = 2
+      }
         
-        // for the electronic locator, the path ends with `sameAs`, but it just gets in the way
-        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
-        if (isLocator){
-            propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
-        }
-        
-
+      // for the electronic locator, the path ends with `sameAs`, but it just gets in the way, toss it
+      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
+      if (isLocator){
+          propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
+      }
 
       let lastProperty = propertyPath.at(-1).propertyURI
       // locate the correct pt to work on in the activeProfile
@@ -1611,7 +1608,7 @@ export const useProfileStore = defineStore('profile', {
 
         // and now add in the literal value into the correct property
         blankNode[lastProperty] = value
-
+        // for electronicLocators, update the ID, so the XML can get built correctly
         if (isLocator && Object.keys(blankNode).some((key) => key == "http://id.loc.gov/ontologies/bibframe/electronicLocator")){
             blankNode["@id"] = value
         }
@@ -1712,13 +1709,14 @@ export const useProfileStore = defineStore('profile', {
         
         let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
         if (isLocator){
+            // `sameAs` gets in the way for the electronicLocator, toss it
             propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
             
             //The propertyPath for supplementaryContent's note is missing the note. It jumps straight to the label
+            //  fix the propertyPath so the XML can get built correctly
             if (propertyPath.some((pp) => pp.propertyURI.includes("supplementaryContent")) && propertyPath.at(-1).propertyURI == "http://www.w3.org/2000/01/rdf-schema#label"){
                 propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
                 propertyPath.at(-1).level = 2
-                
             }
             
             console.info("looking at locator")
@@ -1756,7 +1754,7 @@ export const useProfileStore = defineStore('profile', {
               value: unescape(v[deepestLevelURI]),
               '@language' : (v['@language']) ? v['@language'] : null,
             })
-          } else if (isLocator){
+          } else if (isLocator){ //for electronicLocator, incoming records have the value in `@id`
               values.push({
               '@guid':v['@guid'],
               value: unescape(v["@id"]),
@@ -4343,6 +4341,8 @@ export const useProfileStore = defineStore('profile', {
               if (!key.startsWith("@")){
                   let result = false
                   try{
+                      // this makes sure that the propertiesPanel will have the correct symbol when the incoming data
+                      //  has an populate electronicLocator
                       if (component.propertyURI != "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
                           result = Object.keys(userValue[key][0]).every((childKey) => childKey.startsWith("@"))
                       } else {

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1466,16 +1466,6 @@ export const useProfileStore = defineStore('profile', {
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
         
-        
-        
-        console.info("  literal: ")
-        console.info("  literal: componentGuid", componentGuid)
-        console.info("  literal: fieldGuid", fieldGuid)
-        console.info("  literal: propertyPath", propertyPath)
-        console.info("  literal: value", value)
-        console.info("  literal: lang", lang)
-        console.info("  literal: repeatedLiteral", repeatedLiteral)
-
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
       
@@ -1718,21 +1708,11 @@ export const useProfileStore = defineStore('profile', {
                 propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
                 propertyPath.at(-1).level = 2
             }
-            
-            console.info("looking at locator")
-            console.info("    componentGuid: ", componentGuid)
-            console.info("    propertyPath: ", propertyPath)
         }
 
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
       let valueLocation = utilsProfile.returnValueFromPropertyPath(pt,propertyPath)
       let deepestLevelURI = propertyPath[propertyPath.length-1].propertyURI
-      
-      if (isLocator){
-            console.info("    pt: ", pt)
-            console.info("    valueLocation: ", valueLocation)
-            console.info("    deepestLevelURI: ", deepestLevelURI)
-      }
 
       // console.log(propertyPath[0], deepestLevelURI)
       // console.log('pt',pt)
@@ -3401,9 +3381,6 @@ export const useProfileStore = defineStore('profile', {
       */
 
   insertDefaultValuesComponent: async function(componentGuid, structure){
-      console.info("inserting defaults")
-      console.info("componentGuid: ", componentGuid)
-      console.info("structure: ", structure)
     // console.log(componentGuid)
     // console.log("structure",structure)
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4289,7 +4289,6 @@ export const useProfileStore = defineStore('profile', {
     
     //Check if the component's userValue is empty
     isEmptyComponent: function(component){
-      
       let emptyArray = new Array("@root")
       let userValue = component.userValue
       
@@ -4302,12 +4301,16 @@ export const useProfileStore = defineStore('profile', {
               if (!key.startsWith("@")){
                   let result = false
                   try{
-                      result = Object.keys(userValue[key][0]).every((childKey) => childKey.startsWith("@"))
+                      if (component.propertyURI != "http://id.loc.gov/ontologies/bibframe/electronicLocator"){
+                          result = Object.keys(userValue[key][0]).every((childKey) => childKey.startsWith("@"))
+                      } else {
+                          result = !Object.keys(userValue[key][0]).some((childKey) => childKey.startsWith("@id"))
+                      }
                   } catch(err) {
                       console.error("error: Checking if component is empty")
                   }
-                  return result
                   
+                  return result
               }
           }
       }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3402,6 +3402,9 @@ export const useProfileStore = defineStore('profile', {
       */
 
   insertDefaultValuesComponent: async function(componentGuid, structure){
+      console.info("inserting defaults")
+      console.info("componentGuid: ", componentGuid)
+      console.info("structure: ", structure)
     // console.log(componentGuid)
     // console.log("structure",structure)
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1711,11 +1711,6 @@ export const useProfileStore = defineStore('profile', {
                 propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
                 propertyPath.at(-1).level = 2
             }
-            // For table of contents, there's also an intermediate piece missing?
-            // if (propertyPath.some((pp) => pp.propertyURI.includes("tableOfContents"))){
-                // propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/TableOfContents" })
-                // propertyPath.at(-1).level = 2
-            // }
         }
 
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1469,6 +1469,7 @@ export const useProfileStore = defineStore('profile', {
         
         
         //TODO: get the electronic locator fields working when entering data
+        // for supplementary content note, it updates the URI, but also populates the <bf:electronicLocator>...</...>
         console.info("  literal: ")
         console.info("  literal: componentGuid", componentGuid)
         console.info("  literal: fieldGuid", fieldGuid)

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1465,6 +1465,9 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
+        
+        //TODO: get the electronic locator fields working when entering data
+        
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1465,7 +1465,14 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
-        
+        console.info("setValueLiteral")
+        console.info("componentGuid: ", componentGuid)
+        console.info("fieldGuid: ", fieldGuid)
+        console.info("propertyPath: ", propertyPath)
+        console.info("value: ", value)
+        console.info("lang: ", lang)
+        console.info("repeatedLiteral: ", repeatedLiteral)
+      
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
       
@@ -1478,7 +1485,7 @@ export const useProfileStore = defineStore('profile', {
       }
         
       // for the electronic locator, the path ends with `sameAs`, but it just gets in the way, toss it
-      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
+      let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") || pp.propertyURI.includes("tableOfContents"))
       if (isLocator){
           propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
       }
@@ -1697,7 +1704,7 @@ export const useProfileStore = defineStore('profile', {
     */
     returnLiteralValueFromProfile: function(componentGuid, propertyPath){
         
-        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent"))
+        let isLocator = propertyPath.some((pp) => pp.propertyURI.includes("electronicLocator") || pp.propertyURI.includes("supplementaryContent") || pp.propertyURI.includes("tableOfContents") )
         if (isLocator){
             // `sameAs` gets in the way for the electronicLocator, toss it
             propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -1708,6 +1715,11 @@ export const useProfileStore = defineStore('profile', {
                 propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/note" })
                 propertyPath.at(-1).level = 2
             }
+            // For table of contents, there's also an intermediate piece missing?
+            // if (propertyPath.some((pp) => pp.propertyURI.includes("tableOfContents"))){
+                // propertyPath.splice(1, 0, { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/TableOfContents" })
+                // propertyPath.at(-1).level = 2
+            // }
         }
 
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)


### PR DESCRIPTION
This updates Marva to work with `electronicLocators`. If incoming data had these fields, they were not being populated in Marva. Likewise, if the user updated or created values for this field, they wouldn't appear in the XML.

The difficulty is that these are defined and treated as literals, but should exist in the XML as attribute values. There's new logic to get everything from the right place and into the right place.

There are 3 places that this field can appear:
1) In Works, the table of contents
2) In the Instance's `SupplementaryContentNote`
3) In the Instances "URL of Instance"