### PR TITLE
the /edit/ mount action clears the component cache

### DIFF
--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -173,6 +173,13 @@ export const useProfileStore = defineStore('profile', {
   actions: {
 
 
+    resetLocalComponentCache(){
+      cachePt = {}
+      cacheGuid = {}
+      dataChangedTimeout = null
+    },
+
+
     /**
     * The main first process that takes the raw profiles and processes them for use
     *

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -180,6 +180,7 @@
 
       console.log("Mounted called", this.$route.params.action, this.$route.params.recordId )
       console.log(this.$route.params)
+      this.profileStore.resetLocalComponentCache()      
       if (this.profilesLoaded && this.activeProfile){
 
         if (this.activeProfile.neweId){
@@ -194,11 +195,10 @@
           // otherwise they just got kicked over to the edit screen with an existing record id, load it from the back end to edit
           this.profileStore.loadRecordFromBackend(this.$route.params.recordId)
         }
-
-
-
-
       }
+
+
+      
 
 
 


### PR DESCRIPTION
Adds a new method that cleans up the component cache and uses it every time the edit screen is invoked.