### PR TITLE
Instance deletion buttons

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -272,8 +272,8 @@
 
         //only able to delete the instances they create
         showDeleteInstanceButton: function(profileName){
-            //return this.activeProfile.rt[profileName].deletable // this property is removed when the record is saved
-            return true
+          //return this.activeProfile.rt[profileName].deletable // this property is removed when the record is saved
+          return true
         },
         
         showDeleteInstanceModal: function(profileName){

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -272,7 +272,8 @@
 
         //only able to delete the instances they create
         showDeleteInstanceButton: function(profileName){
-            return this.activeProfile.rt[profileName].deletable
+            //return this.activeProfile.rt[profileName].deletable // this property is removed when the record is saved
+            return true
         },
         
         showDeleteInstanceModal: function(profileName){

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 20,
+    versionPatch: 21,
 
     regionUrls: {
 


### PR DESCRIPTION
The button wouldn't appear after the record had been saved. When the new instance is created, it gets a property `deletable = true` but this disappears, when Marva is saved. 

The button will appear as part of all instances.