### PR TITLE
Preference export import

### DIFF
--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -448,9 +448,14 @@
         if (window.localStorage.getItem('marva-preferences')){
           let prefs = JSON.parse(window.localStorage.getItem('marva-preferences'))
 
+          let today = new Date()
+          let dd = String(today.getDate()).padStart(2, '0')
+          let mm = String(today.getMonth() + 1).padStart(2, '0')
+          let yyyy = today.getFullYear()
+
           var temp = document.createElement('a')
           temp.setAttribute('href', 'data:text/plain; characterset=utf-8,' + encodeURIComponent(JSON.stringify(prefs)))
-          temp.setAttribute('download', "MarvaPreferences.json")
+          temp.setAttribute('download', "MarvaPreferences_" + yyyy + mm + dd + ".json")
           temp.style.display = 'none'
           document.body.appendChild(temp)
           temp.click()
@@ -463,7 +468,6 @@
       importPreferences: function(){
         const that = this
 
-        let data = null
         var temp = document.createElement("input")
         temp.type = "file"
         temp.id = "file-input"

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -112,13 +112,13 @@
         //       //     <span style="font-size:2em; font-weight:bold; position: absolute; width: 100px; left:0;">M</span>
         //       //     `,
         //   })
-        // }  
+        // }
 
 
 
 
 
-        let menuButtonSubMenu = [  
+        let menuButtonSubMenu = [
           { text: "Load Resource", click: () => {
             try{
               this.$nextTick(()=>{
@@ -132,7 +132,7 @@
 
 
         if (this.$route.path.startsWith('/edit/')){
-          menuButtonSubMenu.push({ is: 'separator'})            
+          menuButtonSubMenu.push({ is: 'separator'})
           menuButtonSubMenu.push(
             {
               text: 'Add Additional Instance',
@@ -156,7 +156,7 @@
 
         if (!this.disable.includes('Tools')){
           menu.push(
-          { text: "Tools",  
+          { text: "Tools",
             menu: [
             { text: "Shelf Listing Browser", click: () => {
               this.activeShelfListData = {}
@@ -174,7 +174,7 @@
               // active: this.happy,
               click: () => { this.showNonLatinAgentModal = true }
             },
-            
+
             { is: 'separator'},
             {
               text: 'Copy Mode [' + (this.preferenceStore.copyMode ? "on" : "off") + ']',
@@ -192,7 +192,7 @@
             }
           ] }
           )
-          
+
 
 
         }
@@ -230,7 +230,7 @@
               { text: 'Field Colors', click: () => this.showFieldColorsModal = true, icon: '🌈' },
 
 
-              
+
 
 
 
@@ -247,9 +247,10 @@
               { text: 'Sidebars - Property', click: () => this.preferenceStore.togglePrefModal('Sidebars - Property')},
               { text: 'Shelflisting', click: () => this.preferenceStore.togglePrefModal('Shelflisting')},
 
-
               { is: 'separator'},
-
+              { text: 'Export Prefs', click: () => this.exportPreferences(), icon: 'download' },
+              { text: 'Import Prefs', click: () => this.importPreferences(), icon: 'upload' },
+              { is: 'separator'},
               { text: 'Reset Prefs', click: () => this.preferenceStore.resetPreferences(), icon: 'restart_alt' },
 
 
@@ -260,7 +261,7 @@
         }
         if (this.$route.path.startsWith('/edit/')){
           menu.push({ is: "separator" })
-          
+
           menu.push(
             {
               text: "",
@@ -273,14 +274,14 @@
                 this.layoutActiveFilter=null
               }
             }
-          )            
+          )
 
            let layoutsMenu = []
-           
+
            for (let l in this.layouts.all ){
 
             layoutsMenu.push({
-              text: this.layouts.all[l].label,              
+              text: this.layouts.all[l].label,
               click: () => {
                 this.activateLayout(this.layouts.all[l])
               }
@@ -293,7 +294,7 @@
             )
 
         }
-        
+
 
         if (this.$route.path.startsWith('/edit/')){
           menu.push({ is: "separator" })
@@ -338,7 +339,7 @@
               }
             }
           )
-          
+
           if (this.preferenceStore.copyMode){
               menu.push({ is: "separator" })
               menu.push(
@@ -353,7 +354,7 @@
                   }
                 }
               )
-              
+
               menu.push(
                 {
                   text: "Paste Content",
@@ -365,7 +366,7 @@
                   }
                 }
               )
-          
+
               menu.push(
                 {
                   text: !this.allSelected ? "Select All" : "Deselect All",
@@ -382,8 +383,8 @@
 
 
 
-        
-          
+
+
 
         menu.push(
 
@@ -426,19 +427,14 @@
       },
 
       activateLayout(layout){
-
-
-        
         this.layoutActive = true
         this.layoutActiveFilter = layout
-
-
       },
-      
+
       selectAll: function(){
           let checkBoxes = document.getElementsByClassName("copy-selection")
           this.allSelected = !this.allSelected
-          
+
           checkBoxes.forEach((el) => {
               if (this.allSelected){
                   el.checked = true
@@ -447,7 +443,48 @@
               }
           })
       },
-      
+
+      exportPreferences: function(){
+        if (window.localStorage.getItem('marva-preferences')){
+          let prefs = JSON.parse(window.localStorage.getItem('marva-preferences'))
+
+          var temp = document.createElement('a')
+          temp.setAttribute('href', 'data:text/plain; characterset=utf-8,' + encodeURIComponent(JSON.stringify(prefs)))
+          temp.setAttribute('download', "MarvaPreferences.json")
+          temp.style.display = 'none'
+          document.body.appendChild(temp)
+          temp.click()
+          document.body.removeChild(temp)
+        } else {
+          alert("Couldn't find preferences to export. :(")
+        }
+      },
+
+      importPreferences: function(){
+        const that = this
+
+        let data = null
+        var temp = document.createElement("input")
+        temp.type = "file"
+        temp.id = "file-input"
+        temp.addEventListener('change', function(e){
+          var file = e.target.files[0]
+          if (!file){ return }
+          let reader = new FileReader()
+
+          reader.onload = function(e){
+            var contents = e.target.result
+            that.preferenceStore.loadPreferences(contents)
+            that.preferenceStore.buildDiacriticSettings()
+          }
+
+          reader.readAsText(file)
+        }, false)
+        document.body.appendChild(temp)
+        temp.click()
+        document.body.removeChild(temp)
+      },
+
     },
 
     created() {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 24,
+    versionPatch: 25,
 
     regionUrls: {
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -55,7 +55,7 @@ export const usePreferenceStore = defineStore('preference', {
     // keeps a copy of the orginal values to be able to reset
     styleDefaultOrginal: {},
     panelDisplayOrginal: {},
-    
+
     copyMode: false,
 
     panelDisplay:{
@@ -900,7 +900,7 @@ export const usePreferenceStore = defineStore('preference', {
       this.loadPreferences()
 
       this.buildDiacriticSettings()
-      
+
       //set copyMode from preferences
       this.copyMode = this.styleDefault['--c-general-copy-mode'].value
 
@@ -953,11 +953,19 @@ export const usePreferenceStore = defineStore('preference', {
     },
     /**
     * Loads the saved preferences into the current preferences
+    * @param {obj} data - preference data from a file
+    *
     * @return {void}
     */
-    loadPreferences: function(){
-      if (window.localStorage.getItem('marva-preferences')){
-        let prefs = JSON.parse(window.localStorage.getItem('marva-preferences'))
+    loadPreferences: function(data=null){
+      if (window.localStorage.getItem('marva-preferences') || data){
+        let prefs = null
+
+        if (!data){
+          prefs = JSON.parse(window.localStorage.getItem('marva-preferences'))
+        } else {
+          prefs = JSON.parse(data)
+        }
 
         // TEMP - 10/24 remove eventually
         for (let k in prefs.styleDefault){
@@ -1122,11 +1130,11 @@ export const usePreferenceStore = defineStore('preference', {
 
 
     },
-    
+
     // turn copy mode on/off
     toggleCopyMode: function(){
         this.copyMode = !this.copyMode
-    }
+    },
 
     /**
     * Take a url and rewrites it to match the url pattern of the current enviornment
@@ -1143,10 +1151,6 @@ export const usePreferenceStore = defineStore('preference', {
 
 
   },
-
-
-
-
 
 })
 


### PR DESCRIPTION
Add the ability for users to export and import their preferences. There's a ticket to add preferences to the Backend DB. This is an intermediate step because that's likely to be more work, but should help avoid anyone losing their preferences.

Export will generate a file called "MarvaPreferences_<today's day>.json." 

Import will prompt the user to select a file with preferences to import. Import calls `store.preference.loadPreferences()`, which has a small update of a new parameter, and `store.preference.buildDiacriticSettings()`.

![image](https://github.com/user-attachments/assets/09e5abfc-8c8f-4b50-9c30-bfc420301bb8)
