### PR TITLE
[BFP 128] language lookups

### DIFF
--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -357,7 +357,6 @@ export default {
 
     simpleLookupValues(){
       // profileStore.setActiveField()
-      console.info("getting values")
       let values = this.profileStore.returnSimpleLookupValueFromProfile(this.guid, this.propertyPath)
       if (this.readOnly && values.length==0){
         this.showField=false
@@ -480,9 +479,7 @@ export default {
       if (!this.uri.includes("suggest2")){
         utilsNetwork.loadSimpleLookup(this.uri)
       } else {
-        console.info("doing the thing")
         let uriParts = this.uri.split("/suggest2?q=")
-        console.info(uriParts)
         let results = await utilsNetwork.loadSimpleLookupKeyword(uriParts[0], uriParts[1])
         utilsNetwork.lookupLibrary[this.uri] = results
       }
@@ -546,14 +543,7 @@ export default {
         }
 
       }
-      console.info("utilsNetwork.lookupLibrary", utilsNetwork.lookupLibrary)
-      console.info("this.uri: ", this.uri)
-      console.info("addKeyword: ", addKeyword)
-      console.info("!!!", utilsNetwork.lookupLibrary[this.uri+addKeyword])
-      console.info("???", Object.keys(utilsNetwork.lookupLibrary[this.uri+addKeyword]))
-
       Object.keys(utilsNetwork.lookupLibrary[this.uri+addKeyword]).forEach((v)=>{
-        console.info("v: ", v)
         // the list has a special key metdata that contains more info
         if (v==='metadata'){return false}
         // no filter yet show first 25

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -473,9 +473,6 @@ export default {
       }
       this.uri = this.structure.valueConstraint.useValuesFrom[0]
 
-      if (this.uri == "http://id.loc.gov/vocabulary/resourceComponents"){
-        this.uri = "https://id.loc.gov/vocabulary/suggest2?q=*&memberOf=http://id.loc.gov/vocabulary/resourceComponents/collection_LanguageResource"
-      }
       if (!this.uri.includes("suggest2")){
         utilsNetwork.loadSimpleLookup(this.uri)
       } else {

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -357,6 +357,7 @@ export default {
 
     simpleLookupValues(){
       // profileStore.setActiveField()
+      console.info("getting values")
       let values = this.profileStore.returnSimpleLookupValueFromProfile(this.guid, this.propertyPath)
       if (this.readOnly && values.length==0){
         this.showField=false
@@ -459,7 +460,7 @@ export default {
 
     },
 
-    focused: function(){
+    focused: async function(){
 
       // set the state active field
       this.activeField = this.myGuid
@@ -473,14 +474,22 @@ export default {
       }
       this.uri = this.structure.valueConstraint.useValuesFrom[0]
 
-      utilsNetwork.loadSimpleLookup(this.uri)
-
-
+      if (this.uri == "http://id.loc.gov/vocabulary/resourceComponents"){
+        this.uri = "https://id.loc.gov/vocabulary/suggest2?q=*&memberOf=http://id.loc.gov/vocabulary/resourceComponents/collection_LanguageResource"
+      }
+      if (!this.uri.includes("suggest2")){
+        utilsNetwork.loadSimpleLookup(this.uri)
+      } else {
+        console.info("doing the thing")
+        let uriParts = this.uri.split("/suggest2?q=")
+        console.info(uriParts)
+        let results = await utilsNetwork.loadSimpleLookupKeyword(uriParts[0], uriParts[1])
+        utilsNetwork.lookupLibrary[this.uri] = results
+      }
     },
 
     actionButtonCommand: function(cmd){
       this.$refs.input.focus()
-
     },
 
     // Takes the list of values from this lookup uri and filters it based on the input
@@ -537,8 +546,14 @@ export default {
         }
 
       }
-      Object.keys(utilsNetwork.lookupLibrary[this.uri+addKeyword]).forEach((v)=>{
+      console.info("utilsNetwork.lookupLibrary", utilsNetwork.lookupLibrary)
+      console.info("this.uri: ", this.uri)
+      console.info("addKeyword: ", addKeyword)
+      console.info("!!!", utilsNetwork.lookupLibrary[this.uri+addKeyword])
+      console.info("???", Object.keys(utilsNetwork.lookupLibrary[this.uri+addKeyword]))
 
+      Object.keys(utilsNetwork.lookupLibrary[this.uri+addKeyword]).forEach((v)=>{
+        console.info("v: ", v)
         // the list has a special key metdata that contains more info
         if (v==='metadata'){return false}
         // no filter yet show first 25
@@ -594,9 +609,6 @@ export default {
 
 
         if (!recursive){
-
-
-
           if (this.uri.includes('id.loc.gov/vocabulary/')){
 
             if (this.activeFilter.length>2){
@@ -712,8 +724,6 @@ export default {
 
     },
     keyDownEvent: function(event, reposLeft){
-
-
       if (event && event.keyCode == 220 && event.ctrlKey == true){
         let id = `action-button-${event.target.dataset.guid}`
         document.getElementById(id).click()
@@ -727,24 +737,14 @@ export default {
 
 
       if (reposLeft){
-
         this.findSelectListTime = window.setInterval(()=>{
-
           if (this.$refs.selectlist && this.$refs.selectlist.style){
             window.clearTimeout(this.findSelectListTime)
             var rect = event.target.getBoundingClientRect();
             this.$refs.selectlist.style.left = rect.left + 'px'
-
           }
-
-
-
-
         },100)
-
-
       }
-
 
       this.activeValue = event.target.value
 
@@ -876,18 +876,12 @@ export default {
         event.preventDefault()
 
 
-      }else if (event.target.value == ''){
-
-
+      } else if (event.target.value == '') {
             this.activeFilter = ''
             this.activeValue = ''
             this.activeSelect = ''
             this.displayAutocomplete=false
-
-
-
       }
-
 
       if (this.displayAutocomplete){
         // this.$store.dispatch("disableMacroNav")

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -48,7 +48,6 @@ const utilsNetwork = {
     * @return {object} - returns the results processing
     */
     loadSimpleLookup: async function(uris){
-        console.info("loadSimpleLookup")
         // TODO make this better for multuple lookup list (might not be needed)
         if (!Array.isArray(uris)){
           uris=[uris]
@@ -84,8 +83,6 @@ const utilsNetwork = {
     */
 
     simpleLookupProcess: function(data,parentURI){
-        console.info("parentURI: ", parentURI)
-        console.info("processing the data", data)
         let dataProcessed = {
 
             // all the URIs will live here but also the metadata obj about the uris
@@ -102,7 +99,6 @@ const utilsNetwork = {
             // something that has the parent URI
 
             data.forEach((d)=>{
-                  console.info("d: ", d)
                 let label = null
                 let labelData = null                // it has a URI and that URI is not the parent uri
                 // assume it is one of the values we want
@@ -191,7 +187,6 @@ const utilsNetwork = {
     */
 
     loadSimpleLookupKeyword: async function(uris,keyword){
-      console.info("loadSimpleLookupKeyword")
       if (!Array.isArray(uris)){
         uris=[uris]
       }
@@ -209,10 +204,8 @@ const utilsNetwork = {
 
 
         let url = `${uri}/suggest2/?q=${keyword}&count=25`
-        console.info("url: ", url)
 
         let r = await this.fetchSimpleLookup(url)
-        console.info("r", r)
 
         if (r.hits && r.hits.length==0){
           url = `${uri}/suggest2/?q=${keyword}&count=25&searchtype=keyword`
@@ -222,7 +215,6 @@ const utilsNetwork = {
 
         if (r.hits && r.hits.length>0){
           for (let hit of r.hits){
-            console.info("hit: ", hit)
             results.metadata.values[hit.uri] = {uri:hit.uri, label: [hit.suggestLabel], authLabel:hit.aLabel, code: [], displayLabel: [hit.suggestLabel] }
             results[hit.uri] = [hit.suggestLabel]
           }
@@ -232,8 +224,6 @@ const utilsNetwork = {
       }
 
       this.lookupLibrary[uris[0]+'KEYWORD'] = results
-
-      console.info("results: ", results)
 
       return results
     },

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 16,
-    versionPatch: 28,
+    versionPatch: 29,
 
     regionUrls: {
 


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-128

This is the Marva component of the update to language related lookups. It reuses the `loadSimpleLookupKeyword()` function which parses the results of a `/suggest2` query for a simple lookup. This function is doing the heavy lifting the other changes exist to support it and call it when needed. It should start working once the profiles are updated, and will continue to work as is until then.