### PR TITLE
Fix edit error after copy/paste

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -607,7 +607,7 @@ export default {
               this.marcDeliminatedLCSHMode = true
 
               //Get the type of search
-              let selection = document.getElementById(this.guid)
+              let selection = document.getElementById(this.guid+"-select")
               let selected = selection.options[selection.selectedIndex].value
               this.searchType = selected
 
@@ -671,7 +671,7 @@ export default {
 
             this.authorityLookup = this.searchValue.trim()
             this.searchValue = this.searchValue.trim()
-            let selection = document.getElementById(this.guid)
+            let selection = document.getElementById(this.guid+"-select")
             let selected = selection.options[selection.selectedIndex].value
             this.searchType = selected
             this.displaySubjectModal=true
@@ -737,12 +737,9 @@ export default {
     // Open the authority `panel` for an given authority
     openAuthority: function() {
       //Get the type of search
-      console.info("guid", this.guid)
-      try {
-        let selection = document.getElementById(this.guid)
-        let selected = selection.options[selection.selectedIndex].value
-        this.searchType = selected
-      } catch {}
+      let selection = document.getElementById(this.guid+"-select")
+      let selected = selection.options[selection.selectedIndex].value
+      this.searchType = selected
 
       let label = this.$refs.el[0].innerHTML
       this.profileData = this.profileStore.returnStructureByGUID(this.guid)

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -764,9 +764,13 @@ export default {
         this.marcDeliminatedLCSHModeTimeout = null
         this.marcDeliminatedLCSHModeResults = []
 
-        let selection = document.getElementById(this.guid)
-        let selected = selection.options[selection.selectedIndex].value
-        this.searchType = selected
+        try {
+          let selection = document.getElementById(this.guid)
+          let selected = selection.options[selection.selectedIndex].value
+          this.searchType = selected
+        } catch{
+
+        }
 
         this.displaySubjectModal = true
       }

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -737,9 +737,12 @@ export default {
     // Open the authority `panel` for an given authority
     openAuthority: function() {
       //Get the type of search
-      let selection = document.getElementById(this.guid)
-      let selected = selection.options[selection.selectedIndex].value
-      this.searchType = selected
+      console.info("guid", this.guid)
+      try {
+        let selection = document.getElementById(this.guid)
+        let selected = selection.options[selection.selectedIndex].value
+        this.searchType = selected
+      } catch {}
 
       let label = this.$refs.el[0].innerHTML
       this.profileData = this.profileStore.returnStructureByGUID(this.guid)
@@ -764,13 +767,13 @@ export default {
         this.marcDeliminatedLCSHModeTimeout = null
         this.marcDeliminatedLCSHModeResults = []
 
-        try {
-          let selection = document.getElementById(this.guid)
-          let selected = selection.options[selection.selectedIndex].value
-          this.searchType = selected
-        } catch{
+        // try {
+        //   let selection = document.getElementById(this.guid)
+        //   let selected = selection.options[selection.selectedIndex].value
+        //   this.searchType = selected
+        // } catch{
 
-        }
+        // }
 
         this.displaySubjectModal = true
       }

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -12,7 +12,7 @@
 
     </template>
     <template v-else>
-      <select :id="structure['@guid']" @change="templateChange($event)" style=" background-color: transparent;">
+      <select :id="structure['@guid']+'-select'" @change="templateChange($event)" style=" background-color: transparent;">
           <option v-for="rt in allRtTemplate" :value="rt.id" :selected="(rt.id === thisRtTemplate.id)">{{rt.resourceLabel}}</option>
       </select>
     </template>

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 4,
+    versionPatch: 5,
 
     regionUrls: {
 


### PR DESCRIPTION
Copy/paste IDs match the IDs of the subject selection drop down. The latter now has `-select` appended to them to avoid the conflict.