### PR TITLE
if the bf:relation has a URI then don't mark it as a deepHierarchy

### DIFF
--- a/public/test_files/2018340701.xml
+++ b/public/test_files/2018340701.xml
@@ -1,0 +1,622 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
+    xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+    xmlns:lclocal="http://id.loc.gov/ontologies/lclocal/"
+    xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:pmo="http://performedmusicontology.org/ontology/"
+    xmlns:streams="info:lc/streams#"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/">
+    <bf:Work rdf:about="http://id.loc.gov/resources/works/20481788">
+        <bflc:aap>United Arab Emirates Qānūn al-ijrāʼāt al-jazāʼīyah</bflc:aap>
+        <bflc:aap-normalized>unitedarabemiratesqānūnalijrāʼātaljazāʼīyah</bflc:aap-normalized>
+        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Text"/>
+        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Monograph"/>
+        <bf:language>
+            <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/ara">
+                <rdfs:label xml:lang="en">Arabic</rdfs:label>
+                <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ara</bf:code>
+            </bf:Language>
+        </bf:language>
+        <bf:supplementaryContent>
+            <bf:SupplementaryContent rdf:about="http://id.loc.gov/vocabulary/msupplcont/bibliography">
+                <rdfs:label>bibliography</rdfs:label>
+                <bf:code>bibliography</bf:code>
+            </bf:SupplementaryContent>
+        </bf:supplementaryContent>
+        <bf:geographicCoverage>
+            <bf:GeographicCoverage rdf:about="http://id.loc.gov/vocabulary/geographicAreas/a-ts">
+                <rdfs:label xml:lang="en">United Arab Emirates</rdfs:label>
+                <bf:code rdf:datatype="http://id.loc.gov/datatypes/codes/gac">a-ts---</bf:code>
+            </bf:GeographicCoverage>
+        </bf:geographicCoverage>
+        <bf:classification>
+            <bf:ClassificationLcc>
+                <bf:classificationPortion>KMV4604.51992</bf:classificationPortion>
+                <bf:itemPortion>.A4 2017</bf:itemPortion>
+                <bf:assigner>
+                    <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Organization>
+                </bf:assigner>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/uba">
+                        <rdfs:label>used by assigner</rdfs:label>
+                        <bf:code>uba</bf:code>
+                    </bf:Status>
+                </bf:status>
+            </bf:ClassificationLcc>
+        </bf:classification>
+        <bf:contribution>
+            <bf:Contribution>
+                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/PrimaryContribution"/>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/rwo/agents/n79086806">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Place"/>
+                        <rdfs:label>United Arab Emirates</rdfs:label>
+                        <bflc:marcKey>151  $aUnited Arab Emirates</bflc:marcKey>
+                        <rdfs:label xml:lang="zxx-Arab">اتحاد إمارات الخليج العربي</rdfs:label>
+                        <bflc:marcKey xml:lang="zxx-Arab">451  $aاتحاد إمارات الخليج العربي</bflc:marcKey>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/codes/gac">a-ts---</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/enj">
+                        <rdfs:label>enacting jurisdiction</rdfs:label>
+                        <bf:code>enj</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+        <bf:title>
+            <bf:Title>
+                <bf:mainTitle>Qānūn al-ijrāʼāt al-jazāʼīyah</bf:mainTitle>
+                <bf:mainTitle xml:lang="ar-arab">قانون الإجراءات الجزائية</bf:mainTitle>
+            </bf:Title>
+        </bf:title>
+        <bf:content>
+            <bf:Content rdf:about="http://id.loc.gov/vocabulary/contentTypes/txt">
+                <rdfs:label>text</rdfs:label>
+                <bf:code>txt</bf:code>
+            </bf:Content>
+        </bf:content>
+        <bf:subject>
+            <bf:Topic>
+                <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+                <rdfs:label>Criminal procedure--United Arab Emirates</rdfs:label>
+                <madsrdf:authoritativeLabel>Criminal procedure--United Arab Emirates</madsrdf:authoritativeLabel>
+                <madsrdf:isMemberOfMADSScheme>
+                    <madsrdf:MADSScheme rdf:about="http://id.loc.gov/authorities/subjects">
+                        <rdfs:label xml:lang="en">Library of Congress Subject Headings</rdfs:label>
+                    </madsrdf:MADSScheme>
+                </madsrdf:isMemberOfMADSScheme>
+                <madsrdf:componentList rdf:parseType="Collection">
+                    <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh85034086">
+                        <rdfs:label xml:lang="en">Criminal procedure</rdfs:label>
+                        <bflc:marcKey>150  $aCriminal procedure</bflc:marcKey>
+                    </madsrdf:Topic>
+                    <madsrdf:Geographic rdf:about="http://id.loc.gov/rwo/agents/n79086806-781">
+                        <rdfs:label>United Arab Emirates</rdfs:label>
+                        <bflc:marcKey>181  $zUnited Arab Emirates</bflc:marcKey>
+                        <rdfs:label xml:lang="zxx-arab">دولة الإمارات العربية المتحدة</rdfs:label>
+                        <bflc:marcKey xml:lang="zxx-arab">4102 $aدولة الإمارات العربية المتحدة</bflc:marcKey>
+                    </madsrdf:Geographic>
+                </madsrdf:componentList>
+                <bflc:aap-normalized>criminalprocedureunitedarabemirates</bflc:aap-normalized>
+                <bf:source>
+                    <bf:Source rdf:about="http://id.loc.gov/authorities/subjects">
+                        <rdfs:label xml:lang="en">Library of Congress Subject Headings</rdfs:label>
+                    </bf:Source>
+                </bf:source>
+            </bf:Topic>
+        </bf:subject>
+        <bf:subject>
+            <bf:Topic>
+                <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#ComplexSubject"/>
+                <rdfs:label>Rehabilitation--Law and legislation--United Arab Emirates</rdfs:label>
+                <madsrdf:authoritativeLabel>Rehabilitation--Law and legislation--United Arab Emirates</madsrdf:authoritativeLabel>
+                <madsrdf:isMemberOfMADSScheme>
+                    <madsrdf:MADSScheme rdf:about="http://id.loc.gov/authorities/subjects">
+                        <rdfs:label xml:lang="en">Library of Congress Subject Headings</rdfs:label>
+                    </madsrdf:MADSScheme>
+                </madsrdf:isMemberOfMADSScheme>
+                <madsrdf:componentList rdf:parseType="Collection">
+                    <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh85112401">
+                        <rdfs:label xml:lang="en">Rehabilitation</rdfs:label>
+                        <bflc:marcKey>150  $aRehabilitation</bflc:marcKey>
+                    </madsrdf:Topic>
+                    <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh99004848">
+                        <rdfs:label xml:lang="en">Law and legislation</rdfs:label>
+                        <bflc:marcKey>180  $xLaw and legislation</bflc:marcKey>
+                    </madsrdf:Topic>
+                    <madsrdf:Geographic rdf:about="http://id.loc.gov/rwo/agents/n79086806-781">
+                        <rdfs:label>United Arab Emirates</rdfs:label>
+                        <bflc:marcKey>181  $zUnited Arab Emirates</bflc:marcKey>
+                        <rdfs:label xml:lang="zxx-arab">دولة الإمارات العربية المتحدة</rdfs:label>
+                        <bflc:marcKey xml:lang="zxx-arab">4102 $aدولة الإمارات العربية المتحدة</bflc:marcKey>
+                    </madsrdf:Geographic>
+                </madsrdf:componentList>
+                <bflc:aap-normalized>rehabilitationlawandlegislationunitedarabemirates</bflc:aap-normalized>
+                <bf:source>
+                    <bf:Source rdf:about="http://id.loc.gov/authorities/subjects">
+                        <rdfs:label xml:lang="en">Library of Congress Subject Headings</rdfs:label>
+                    </bf:Source>
+                </bf:source>
+            </bf:Topic>
+        </bf:subject>
+        <dcterms:isPartOf rdf:resource="http://id.loc.gov/resources/works"/>
+        <bf:relation>
+            <bf:Relation>
+                <bf:relationship rdf:resource="http://id.loc.gov/ontologies/bibframe/hasSeries"/>
+                <bf:seriesEnumeration>2</bf:seriesEnumeration>
+                <bf:seriesEnumeration xml:lang="ar-arab">2</bf:seriesEnumeration>
+                <bf:associatedResource>
+                    <bf:Series>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bflc/Uncontrolled"/>
+                        <bf:status>
+                            <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/t">
+                                <rdfs:label>transcribed</rdfs:label>
+                                <bf:code>t</bf:code>
+                            </bf:Status>
+                        </bf:status>
+                        <bf:title>
+                            <bf:Title>
+                                <bf:mainTitle>Silsilat al-tashrīʻāt al-ittiḥādīyah</bf:mainTitle>
+                                <bf:mainTitle xml:lang="ar-arab">سلسلة التشريعات الإتحادية ؛</bf:mainTitle>
+                            </bf:Title>
+                        </bf:title>
+                    </bf:Series>
+                </bf:associatedResource>
+            </bf:Relation>
+        </bf:relation>
+        <bf:relation>
+            <bf:Relation>
+                <bf:relationship rdf:resource="http://id.loc.gov/ontologies/bibframe/hasSeries"/>
+                <bf:seriesEnumeration>2</bf:seriesEnumeration>
+                <bf:seriesEnumeration xml:lang="ar-arab">2</bf:seriesEnumeration>
+                <bf:associatedResource>
+                    <bf:Series>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bflc/Uncontrolled"/>
+                        <bf:status>
+                            <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/t">
+                                <rdfs:label>transcribed</rdfs:label>
+                                <bf:code>t</bf:code>
+                            </bf:Status>
+                        </bf:status>
+                        <bf:title>
+                            <bf:Title>
+                                <bf:mainTitle>Silsilat al-tashrīʻāt wa-al-qawānīn al-ittiḥādīyah fī dawlat al-Imārāt al-ʻArabīyah al-Muttaḥidah</bf:mainTitle>
+                                <bf:mainTitle xml:lang="ar-arab">سلسلة التشريعات والقوانين الإتحادية في دولة الإمارات العربية المتحدة ؛</bf:mainTitle>
+                            </bf:Title>
+                        </bf:title>
+                    </bf:Series>
+                </bf:associatedResource>
+            </bf:Relation>
+        </bf:relation>
+        <bf:relation>
+            <bf:Relation>
+                <bf:relationship>
+                    <bf:Relationship rdf:about="http://id.loc.gov/vocabulary/relationship/relatedwork">
+                        <rdfs:label>related work</rdfs:label>
+                        <bf:code>relatedwork</bf:code>
+                    </bf:Relationship>
+                </bf:relationship>
+                <bf:associatedResource>
+                    <bf:Hub rdf:about="http://id.loc.gov/resources/hubs/f083b14e-5566-c810-7fad-4304efafa05e">
+                        <rdfs:label>United Arab Emirates Qānūn al-Ijrāʼāt al-Jazāʼīyah (1992)</rdfs:label>
+                        <bf:contribution>
+                            <bf:Contribution>
+                                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/PrimaryContribution"/>
+                                <bf:agent>
+                                    <bf:Agent rdf:about="http://id.loc.gov/rwo/agents/n79086806">
+                                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Place"/>
+                                        <rdfs:label>United Arab Emirates</rdfs:label>
+                                        <bflc:marcKey>151  $aUnited Arab Emirates</bflc:marcKey>
+                                        <rdfs:label xml:lang="zxx-Arab">اتحاد إمارات الخليج العربي</rdfs:label>
+                                        <bflc:marcKey xml:lang="zxx-Arab">451  $aاتحاد إمارات الخليج العربي</bflc:marcKey>
+                                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/codes/gac">a-ts---</bf:code>
+                                    </bf:Agent>
+                                </bf:agent>
+                                <bf:role>
+                                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/ctb">
+                                        <rdfs:label>contributor</rdfs:label>
+                                        <bf:code>ctb</bf:code>
+                                    </bf:Role>
+                                </bf:role>
+                            </bf:Contribution>
+                        </bf:contribution>
+                        <bf:title>
+                            <bf:Title>
+                                <bf:mainTitle>Qānūn al-Ijrāʼāt al-Jazāʼīyah (1992)</bf:mainTitle>
+                            </bf:Title>
+                        </bf:title>
+                        <bf:title>
+                            <bf:VariantTitle>
+                                <bf:mainTitle>Qānūn Ittiḥādī raqm 35 (1992)</bf:mainTitle>
+                            </bf:VariantTitle>
+                        </bf:title>
+                    </bf:Hub>
+                </bf:associatedResource>
+            </bf:Relation>
+        </bf:relation>
+        <bf:relation>
+            <bf:Relation>
+                <bf:relationship>
+                    <bf:Relationship rdf:about="http://id.loc.gov/vocabulary/relationship/relatedwork">
+                        <rdfs:label>related work</rdfs:label>
+                        <bf:code>relatedwork</bf:code>
+                    </bf:Relationship>
+                </bf:relationship>
+                <bf:associatedResource>
+                    <bf:Hub rdf:about="http://id.loc.gov/resources/hubs/29c0449e-33a4-0ad7-6366-68e01fc8c9f7">
+                        <rdfs:label>United Arab Emirates Qānūn Radd al-Iʻtibār (1992)</rdfs:label>
+                        <bf:contribution>
+                            <bf:Contribution>
+                                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/PrimaryContribution"/>
+                                <bf:agent>
+                                    <bf:Agent>
+                                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Jurisdiction"/>
+                                        <rdfs:label>United Arab Emirates</rdfs:label>
+                                        <bflc:marcKey>1101 $aUnited Arab Emirates.</bflc:marcKey>
+                                    </bf:Agent>
+                                </bf:agent>
+                                <bf:role>
+                                    <madsrdf:Authority rdf:about="http://id.loc.gov/vocabulary/relators/ctb">
+                                        <rdfs:label>contributor</rdfs:label>
+                                        <bf:code>ctb</bf:code>
+                                    </madsrdf:Authority>
+                                </bf:role>
+                            </bf:Contribution>
+                        </bf:contribution>
+                        <bf:title>
+                            <bf:Title>
+                                <bf:mainTitle>Qānūn Radd al-Iʻtibār (1992)</bf:mainTitle>
+                            </bf:Title>
+                        </bf:title>
+                        <bf:title>
+                            <bf:VariantTitle>
+                                <bf:mainTitle>Qānūn Ittiḥādī raqm 36 (1992)</bf:mainTitle>
+                            </bf:VariantTitle>
+                        </bf:title>
+                    </bf:Hub>
+                </bf:associatedResource>
+            </bf:Relation>
+        </bf:relation>
+        <bf:hasInstance rdf:resource="http://id.loc.gov/resources/instances/20481788"/>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/n">
+                        <rdfs:label>new</rdfs:label>
+                        <bf:code>n</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-05-03</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-12-12T07:48:54</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlcmrc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress, Network Development and MARC Standards Office</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC-MRC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlcmrc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlcmrc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:generationProcess rdf:resource="https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.8.0"/>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-12-16T09:40:27.434778-05:00</bf:date>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:descriptionLevel rdf:resource="http://id.loc.gov/ontologies/bibframe-2-4-0/"/>
+                <bflc:encodingLevel>
+                    <bflc:EncodingLevel rdf:about="http://id.loc.gov/vocabulary/menclvl/f">
+                        <rdfs:label>full</rdfs:label>
+                        <bf:code>f</bf:code>
+                    </bflc:EncodingLevel>
+                </bflc:encodingLevel>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/isbd">
+                        <rdfs:label>ISBD: International standard bibliographic description</rdfs:label>
+                        <bf:code>isbd</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:identifiedBy>
+                    <bf:Local>
+                        <rdf:value>20481788</rdf:value>
+                        <bf:assigner>
+                            <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                                <rdfs:label>United States, Library of Congress</rdfs:label>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                            </bf:Organization>
+                        </bf:assigner>
+                    </bf:Local>
+                </bf:identifiedBy>
+                <lclocal:d906>=906     $a 7 $b cbc $c origode $d 2 $e ncip $f 20 $g y-nonroman</lclocal:d906>
+                <lclocal:d925>=925  0  $a acquire $b 1 shelf copy $x policy default</lclocal:d925>
+                <lclocal:d955>=955     $b we52 2018-05-12; $i we52 2024-11-20 to LL</lclocal:d955>
+                <bf:descriptionLanguage>
+                    <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/eng">
+                        <rdfs:label xml:lang="en">English</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eng</bf:code>
+                    </bf:Language>
+                </bf:descriptionLanguage>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/rda">
+                        <rdfs:label>Resource description and access</rdfs:label>
+                        <bf:code>rda</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:note>
+                    <bf:Note>
+                        <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/internal"/>
+                        <rdfs:label>040  $aDLC$beng$erda$cDLC</rdfs:label>
+                    </bf:Note>
+                </bf:note>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/pcc">
+                        <rdfs:label>Program for Cooperative Cataloging</rdfs:label>
+                        <bf:code>pcc</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/lcode">
+                        <rdfs:label>LC Overseas Data Entry</rdfs:label>
+                        <bf:code>lcode</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+                <lclocal:d985>=985     $e ODE-ca</lclocal:d985>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+    </bf:Work>
+    <bf:Instance rdf:about="http://id.loc.gov/resources/instances/20481788">
+        <bf:issuance>
+            <bf:Issuance rdf:about="http://id.loc.gov/vocabulary/issuance/mono">
+                <rdfs:label>single unit</rdfs:label>
+                <bf:code>mono</bf:code>
+            </bf:Issuance>
+        </bf:issuance>
+        <bf:provisionActivity>
+            <bf:ProvisionActivity>
+                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Publication"/>
+                <bf:date rdf:datatype="http://id.loc.gov/datatypes/edtf">2017</bf:date>
+                <bf:place>
+                    <bf:Place rdf:about="http://id.loc.gov/vocabulary/countries/ts">
+                        <rdfs:label xml:lang="en">United Arab Emirates</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ts</bf:code>
+                    </bf:Place>
+                </bf:place>
+                <bflc:simplePlace>al-Shāriqah</bflc:simplePlace>
+                <bflc:simplePlace xml:lang="ar-arab">الشارقة</bflc:simplePlace>
+                <bflc:simpleAgent>Jamʻīyat al-Imārāt lil-Muḥāmīn wa-al-Qānūnīyīn</bflc:simpleAgent>
+                <bflc:simpleAgent xml:lang="ar-arab">جمعية الإمارات للمحامين والقانونيين،</bflc:simpleAgent>
+                <bflc:simpleDate>2017</bflc:simpleDate>
+                <bflc:simpleDate xml:lang="ar-arab">2017</bflc:simpleDate>
+            </bf:ProvisionActivity>
+        </bf:provisionActivity>
+        <bf:publicationStatement>al-Shāriqah: Jamʻīyat al-Imārāt lil-Muḥāmīn wa-al-Qānūnīyīn, 2017</bf:publicationStatement>
+        <bf:publicationStatement xml:lang="ar-arab">الشارقة: جمعية الإمارات للمحامين والقانونيين،, 2017</bf:publicationStatement>
+        <bf:identifiedBy>
+            <bf:Lccn>
+                <rdf:value>  2018340701</rdf:value>
+            </bf:Lccn>
+        </bf:identifiedBy>
+        <bf:identifiedBy>
+            <bf:Isbn>
+                <rdf:value>9789948237792</rdf:value>
+            </bf:Isbn>
+        </bf:identifiedBy>
+        <bf:title>
+            <bf:Title>
+                <bf:mainTitle>Qānūn al-ijrāʼāt al-jazāʼīyah</bf:mainTitle>
+                <bf:subtitle>al-Qānūn al-Ittiḥādī raqm 35 li-sanat 1992 M ; Qānūn Radd al-Iʻtibār, al-Qānūn al-Ittiḥādī raqm 36 li-sanat 1992 M.</bf:subtitle>
+                <bf:mainTitle xml:lang="ar-arab">قانون الإجراءات الجزائية</bf:mainTitle>
+                <bf:subtitle xml:lang="ar-arab">القانون الإتحادي رقم ٣٥ لسنة ١٩٩٢ م ؛ قانون رد الإعتبار، القانون الإتحادي رقم ٣٦ لسنة ١٩٩٢ م</bf:subtitle>
+            </bf:Title>
+        </bf:title>
+        <bf:editionStatement>al-Ṭabʻah al-ūlá</bf:editionStatement>
+        <bf:editionStatement xml:lang="ar-arab">الطبعة الأولى</bf:editionStatement>
+        <bf:extent>
+            <bf:Extent>
+                <rdfs:label>108 pages</rdfs:label>
+            </bf:Extent>
+        </bf:extent>
+        <bf:dimensions>21 cm</bf:dimensions>
+        <bf:media>
+            <bf:Media rdf:about="http://id.loc.gov/vocabulary/mediaTypes/n">
+                <rdfs:label>unmediated</rdfs:label>
+                <bf:code>n</bf:code>
+            </bf:Media>
+        </bf:media>
+        <bf:carrier>
+            <bf:Carrier rdf:about="http://id.loc.gov/vocabulary/carriers/nc">
+                <rdfs:label>volume</rdfs:label>
+                <bf:code>nc</bf:code>
+            </bf:Carrier>
+        </bf:carrier>
+        <bf:note>
+            <bf:Note>
+                <rdfs:label>"Aḥdath al-taʻdīlāt li-ʻām, 2017"--cover.</rdfs:label>
+            </bf:Note>
+        </bf:note>
+        <bf:note>
+            <bf:Note>
+                <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/biblio"/>
+                <rdfs:label>Includes bibliographical references.</rdfs:label>
+            </bf:Note>
+        </bf:note>
+        <dcterms:isPartOf rdf:resource="http://id.loc.gov/resources/instances"/>
+        <bf:instanceOf rdf:resource="http://id.loc.gov/resources/works/20481788"/>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/n">
+                        <rdfs:label>new</rdfs:label>
+                        <bf:code>n</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2018-05-03</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-12-12T07:48:54</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlcmrc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress, Network Development and MARC Standards Office</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC-MRC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlcmrc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlcmrc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:generationProcess rdf:resource="https://github.com/lcnetdev/marc2bibframe2/releases/tag/v2.8.0"/>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-12-16T09:40:27.434778-05:00</bf:date>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:descriptionLevel rdf:resource="http://id.loc.gov/ontologies/bibframe-2-4-0/"/>
+                <bflc:encodingLevel>
+                    <bflc:EncodingLevel rdf:about="http://id.loc.gov/vocabulary/menclvl/f">
+                        <rdfs:label>full</rdfs:label>
+                        <bf:code>f</bf:code>
+                    </bflc:EncodingLevel>
+                </bflc:encodingLevel>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/isbd">
+                        <rdfs:label>ISBD: International standard bibliographic description</rdfs:label>
+                        <bf:code>isbd</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:identifiedBy>
+                    <bf:Local>
+                        <rdf:value>20481788</rdf:value>
+                        <bf:assigner>
+                            <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                                <rdfs:label>United States, Library of Congress</rdfs:label>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                            </bf:Organization>
+                        </bf:assigner>
+                    </bf:Local>
+                </bf:identifiedBy>
+                <lclocal:d906>=906     $a 7 $b cbc $c origode $d 2 $e ncip $f 20 $g y-nonroman</lclocal:d906>
+                <lclocal:d925>=925  0  $a acquire $b 1 shelf copy $x policy default</lclocal:d925>
+                <lclocal:d955>=955     $b we52 2018-05-12; $i we52 2024-11-20 to LL</lclocal:d955>
+                <bf:descriptionLanguage>
+                    <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/eng">
+                        <rdfs:label xml:lang="en">English</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eng</bf:code>
+                    </bf:Language>
+                </bf:descriptionLanguage>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/rda">
+                        <rdfs:label>Resource description and access</rdfs:label>
+                        <bf:code>rda</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:note>
+                    <bf:Note>
+                        <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/internal"/>
+                        <rdfs:label>040  $aDLC$beng$erda$cDLC</rdfs:label>
+                    </bf:Note>
+                </bf:note>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/pcc">
+                        <rdfs:label>Program for Cooperative Cataloging</rdfs:label>
+                        <bf:code>pcc</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/lcode">
+                        <rdfs:label>LC Overseas Data Entry</rdfs:label>
+                        <bf:code>lcode</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+                <lclocal:d985>=985     $e ODE-ca</lclocal:d985>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+    </bf:Instance>
+</rdf:RDF>

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1614,6 +1614,19 @@ const utilsParse = {
 
             sucessfulElements.push(e.outerHTML)
 
+
+            // check if we marked this component deepHierarchy
+            if (populateData.deepHierarchy){
+              // check if it is a relation with a URI, if so it is okay
+              if (populateData.userValue['http://id.loc.gov/ontologies/bibframe/relation'] && populateData.userValue['http://id.loc.gov/ontologies/bibframe/relation'][0]){
+                if (populateData.userValue['http://id.loc.gov/ontologies/bibframe/relation'][0]['http://id.loc.gov/ontologies/bibframe/associatedResource'] && populateData.userValue['http://id.loc.gov/ontologies/bibframe/relation'][0]['http://id.loc.gov/ontologies/bibframe/associatedResource'][0]){
+                  if (populateData.userValue['http://id.loc.gov/ontologies/bibframe/relation'][0]['http://id.loc.gov/ontologies/bibframe/associatedResource'][0]['@id']){
+                    delete populateData.deepHierarchy
+                  }
+                }
+              }
+            }
+
             // since we created a brand new populateData we either need to
             // replace the orginal in the profile or if there is more than one we
             // need to make a new one and add it to the resource template list

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -277,6 +277,10 @@ export const useConfigStore = defineStore('config', {
     {lccn:'2023920086',label:"The Serby saga (IBC)", idUrl:'https://id.loc.gov/resources/instances/23354934.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
     {lccn:'2024398050',label:"Wehasŭ sonyŏn (Compilation)", idUrl:'https://id.loc.gov/resources/instances/23799873.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
+    {lccn:'2018340701',label:"Qānūn al-ijrāʼāt al-jazāʼīyah", idUrl:'https://id.loc.gov/resources/instances/2018340701.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
+
+
+
     {lccn:'2007052988',label:"A journey to the Western Islands of Scotland", idUrl:'https://id.loc.gov/resources/instances/15146892.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
     {lccn:'2023546355',label:"'P'osŭt'ŭ cheguk' ŭi Tong Asia", idUrl:'https://id.loc.gov/resources/instances/23591130.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
@@ -301,6 +305,8 @@ export const useConfigStore = defineStore('config', {
 
 
 
+
+    
 
 
 


### PR DESCRIPTION
More logic to label bf:relations as deepHierarchy better.