### PR TITLE
add diacritic code from literals to complex serach modal input

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 7,
+    versionPatch: 8,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3006,7 +3006,7 @@ export const useProfileStore = defineStore('profile', {
           if (work){ break }
         }
       }
-      console.log("work",work)
+      // console.log("work",work)
       if (work){
 
         for (let ptId in work.pt){
@@ -3073,7 +3073,7 @@ export const useProfileStore = defineStore('profile', {
                         {
                         let agent = contributorUserValue['http://id.loc.gov/ontologies/bibframe/agent'][0]
                         if (agent && agent['http://www.w3.org/2000/01/rdf-schema#label'] && agent['http://www.w3.org/2000/01/rdf-schema#label'].length > 0 && agent['http://www.w3.org/2000/01/rdf-schema#label'][0] && agent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']){
-                          console.log("agentagentagentagent",agent)
+                          // console.log("agentagentagentagent",agent)
                           let agentData = {type:type,label:agent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']}
                           if (agent['@id']){
                             agentData['@id'] = agent['@id']


### PR DESCRIPTION
This adds the diacritic features found in the literal field to the search input in the complex search modal:

![image](https://github.com/user-attachments/assets/332e8db4-d02e-4ba3-919b-3f2043e819ab)

You can do the CTRL+ALT+... to do the macro express macros
Or the CTRL+E then ... to do the voyager macros
or you can setup a text macro and invoke it here as well.