### PR TITLE
[BFP 268] Auto Dewey 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@ import HubStubCreateModal from "@/components/panels/edit/modals/HubStubCreateMod
 
 
 import ShelfListingModal from "@/components/panels/edit/modals/ShelfListing.vue";
-
+import AutoDeweyModal from "./components/panels/edit/modals/AutoDeweyModal.vue";
 import UpdateAvailableModal from "@/components/general/UpdateAvailableModal.vue";
 
 
@@ -41,6 +41,7 @@ export default {
     ShelfListingModal,
     DiacriticsConfigModal,
     UpdateAvailableModal,
+    AutoDeweyModal,
     TextMacroModal,
     NonLatinBulkModal,
     NonLatinAgentModal,
@@ -60,7 +61,7 @@ export default {
     ...mapStores(useConfigStore, useProfileStore, usePreferenceStore),
     // // gives read access to this.count and this.double
     ...mapState(useProfileStore, ['profilesLoaded', 'showValidateModal','profilesLoaded', 'showPostModal']),
-    ...mapWritableState(useProfileStore, ['showShelfListingModal','showHubStubCreateModal']),
+    ...mapWritableState(useProfileStore, ['showShelfListingModal','showHubStubCreateModal', 'showAutoDeweyModal']),
 
     ...mapState(usePreferenceStore, ['showPrefModal','catCode']),
     ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal','showFieldColorsModal']),
@@ -86,10 +87,10 @@ export default {
     }
   },
 
-  async mounted() {    
-    console.log(this.configStore.versionMajor)    
+  async mounted() {
+    console.log(this.configStore.versionMajor)
 //     const configStore = useConfigStore()
-// const profileStore = useProfileStore()   
+// const profileStore = useProfileStore()
 
     this.preferenceStore.initalize()
     // this.profileStore.buildProfiles()
@@ -141,7 +142,7 @@ export default {
     <DiacriticsConfigModal v-model="showDiacriticConfigModal" />
   </template>
 
-  
+
   <template v-if="showShelfListingModal==true">
     <ShelfListingModal v-model="showShelfListingModal"  />
   </template>
@@ -151,7 +152,7 @@ export default {
   <template v-if="showTextMacroModal==true">
     <TextMacroModal v-model="showTextMacroModal"  />
   </template>
-  
+
   <template v-if="showNonLatinBulkModal==true">
     <NonLatinBulkModal v-model="showNonLatinBulkModal"  />
   </template>
@@ -159,16 +160,20 @@ export default {
   <template v-if="showNonLatinAgentModal==true">
     <NonLatinAgentModal v-model="showNonLatinAgentModal"  />
   </template>
-  
+
   <template v-if="showFieldColorsModal==true">
     <FieldColorsModal v-model="showFieldColorsModal"  />
   </template>
   <template v-if="showHubStubCreateModal==true">
     <HubStubCreateModal v-model="showHubStubCreateModal"  />
   </template>
-  
-  
-  
+
+  ??
+  <template v-if="showAutoDeweyModal==true">
+    <AutoDeweyModal v-model="showAutoDeweyModal"  />
+  </template>
+  !!
+
 </template>
 
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -168,11 +168,9 @@ export default {
     <HubStubCreateModal v-model="showHubStubCreateModal"  />
   </template>
 
-  ??
   <template v-if="showAutoDeweyModal==true">
     <AutoDeweyModal v-model="showAutoDeweyModal"  />
   </template>
-  !!
 
 </template>
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -116,7 +116,6 @@
 
       </div>
 
-
       <div v-if="structure.propertyURI=='http://id.loc.gov/ontologies/bibframe/itemPortion'">
         <!-- { "title": "knitter's handy book of patterns", "classNumber": "TT820", "cutterNumber": ".B877 2002", "titleNonSort": 4, "contributors": [ { "type": "PrimaryContribution", "label": "Budd, Ann, 1956-" } ], "firstSubject": "Knitting--Patterns" } -->
         <div style="display: flex;">

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -31,7 +31,7 @@
 
   </template>
 
-  <template v-else>    
+  <template v-else>
     <div class="lookup-fake-input" v-if="showField" >
       <div class="literal-holder" @click="focusClick(lValue)" v-for="lValue in literalValues">
         <!-- <div>Literal ({{propertyPath.map((x)=>{return x.propertyURI}).join('>')}})</div> -->
@@ -783,7 +783,7 @@ export default {
         let data = this.profileStore.returnLccInfo(this.guid, this.structure)
         if (data.contributors && data.contributors.length>0){
           data.contributors[0].secondLetterLabel = data.contributors[0].label.substring(1)
-        }        
+        }
         return data
       }
       return false
@@ -824,7 +824,7 @@ export default {
     //     this.lccFeatureData = this.profileStore.returnLccInfo(this.guid, this.structure)
     //   }
     // }
-    dataChangedTimestamp(newVal, oldVal) {      
+    dataChangedTimestamp(newVal, oldVal) {
       this.lccFeatureDataCounter++
     }
 
@@ -1010,8 +1010,8 @@ textarea{
 .lookup-fake-input{
   min-height: 2em;
   background-color: transparent;
-  
-  
+
+
 }
 
 textarea:focus-within{

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -166,7 +166,8 @@
 
   import { mapStores, mapState, mapWritableState } from 'pinia'
 
-  import { LcCallToDewey } from '@/lib/auto_dewey'
+  import utilsNetwork from '@/lib/utils_network'
+  import LcCallToDewey from '@/lib/auto_dewey' //TODO: get this working
 
 
   export default {

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -14,7 +14,7 @@
  <VMenu ref="action-button-menu" :triggers="useOpenModes" @show="shortCutPressed" v-model:shown="isMenuShown"  @hide="menuClosed">
     <button tabindex="-1" :id="`action-button-${fieldGuid}`" :class="{'action-button':true,'small-mode': small }"><span class="material-icons action-button-icon">{{preferenceStore.returnValue('--s-edit-general-action-button-icon')}}</span></button>
 
-    <AutoDewey ref="autoDeweyModal" @hideDeweyModal="hideDeweyModal()" v-model="displayDewey" :lcCall="lcCall" @addDdc="addDdc" />
+    <!-- <AutoDewey ref="autoDeweyModal" @hideDeweyModal="hideDeweyModal()" v-model="displayDewey" :lcCall="lcCall" @addDdc="addDdc" /> -->
 
     <template #popper>
 
@@ -252,77 +252,6 @@
     methods: {
       hideDeweyModal:function (){
         this.displayDewey = false
-      },
-
-      addDdc: async function(deweyInfo){
-        console.info("Add DDC: ", deweyInfo)
-        //Look to see if there is a DDC component
-        let activeProfile = this.profileStore.activeProfile
-        console.info(activeProfile)
-        let hasEmptyDDC = false
-        let ddcComponent = null
-        let lastClassifiction = null
-        for (let pt in activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt){
-          if (pt.includes("id_loc_gov_ontologies_bibframe_classification__classification_numbers")){
-            const target = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[pt]
-            console.info("target: ", target)
-            const userValue = target.userValue
-            console.info("userValue: ", userValue)
-            const classification = userValue["http://id.loc.gov/ontologies/bibframe/classification"][0]
-            const type = classification["@type"]
-            console.info("component: ", classification)
-            if (!pt.deleted){
-              lastClassifiction = pt
-              //type == "http://id.loc.gov/ontologies/bibframe/ClassificationDdc" &&
-              if (!Object.keys(classification).includes("http://id.loc.gov/ontologies/bibframe/classificationPortion")){
-                hasEmptyDDC = true
-                ddcComponent = classification
-              }
-            }
-          }
-        }
-        let newDDC
-        // if no empty ddc, create one
-        if (!hasEmptyDDC){
-          console.info("Creating component")
-          newDDC = await this.profileStore.duplicateComponentGetId(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'], this.structure, "lc:RT:bf2:Monograph:Work", lastClassifiction)
-          ddcComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
-        }
-
-        //add information to component
-        console.info("ddcComponent", ddcComponent)
-        let userValue = null
-        try{
-          userValue = ddcComponent.userValue["http://id.loc.gov/ontologies/bibframe/classification"][0]
-        } catch {
-          userValue = ddcComponent
-        }
-
-        let dewey = null
-        if (Object.keys(deweyInfo).includes("DDC")){
-          dewey = deweyInfo.DDC
-        } else {
-          dewey = deweyInfo.dewey
-        }
-
-        const newGuid = short.generate()
-        console.info("userValue: ", userValue)
-        userValue["@type"] = "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
-        userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(dewey) }]
-
-        //Add the defaults:
-        // console.info("profile: ", this.profileStore.activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt)
-        // const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
-        // const newStructure = this.profileStore.returnStructureByGUID(newComponent["@guid"])
-
-        // console.info("newComponent['@guid']: ", newComponent['@guid'])
-        // console.info("newStructure: ", newStructure)
-        // console.info("ddcComponent: ", ddcComponent)
-
-        // console.info("*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*")
-
-        // this.profileStore.insertDefaultValuesComponent(newComponent['@guid'], ddcComponent)
-
       },
 
       showBuildHubStub(){
@@ -698,7 +627,13 @@
         }
         this.lcCall = lccn
         console.info("lccn: ", lccn)
-        this.displayDewey = true
+        this.deweyData = {
+          lcc: lcc,
+          guid: this.guid,
+          strcuture: this.structure
+        }
+
+        this.showAutoDeweyModal = true
       },
 
     },

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -631,7 +631,7 @@
         this.deweyData = {
           lcc: lccn,
           guid: this.guid,
-          strcuture: this.structure
+          structure: this.structure
         }
 
         console.info("!!", this.deweyData)

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -275,7 +275,8 @@
             console.info("component: ", classification)
             if (!pt.deleted){
               lastClassifiction = pt
-              if (type == "http://id.loc.gov/ontologies/bibframe/ClassificationDdc" && !Object.keys(classification).includes("http://id.loc.gov/ontologies/bibframe/classificationPortion")){
+              //type == "http://id.loc.gov/ontologies/bibframe/ClassificationDdc" &&
+              if (!Object.keys(classification).includes("http://id.loc.gov/ontologies/bibframe/classificationPortion")){
                 hasEmptyDDC = true
                 ddcComponent = classification
               }
@@ -298,18 +299,23 @@
         } catch {
           userValue = ddcComponent
         }
+        const newGuid = short.generate()
         console.info("userValue: ", userValue)
         userValue["@type"] = "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
-        userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": short.generate(), "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(deweyInfo.DDC) }]
+        userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(deweyInfo.DDC) }]
+
         //Add the defaults:
+        console.info("profile: ", this.profileStore.activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt)
+        const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
+        const newStructure = this.profileStore.returnStructureByGUID(newComponent["@guid"])
 
-        // const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
-        // const newStructure = this.profileStore.returnStructureByGUID(newComponent["@guid"])
+        console.info("newComponent['@guid']: ", newComponent['@guid'])
+        console.info("newStructure: ", newStructure)
+        console.info("ddcComponent: ", ddcComponent)
 
-        // console.info("newComponent['@guid']: ", newComponent['@guid'])
-        // console.info("newStructure: ", newStructure)
+        console.info("*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*")
 
-        // this.profileStore.insertDefaultValuesComponent(newComponent['@guid'], newStructure)
+        // this.profileStore.insertDefaultValuesComponent(newComponent['@guid'], ddcComponent)
 
       },
 

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -98,10 +98,11 @@
               </button>
         </template>
 
-        <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="convertLcc2Dewey()">
-          <span class="button-shortcut-label">0</span>
-          AutoDewey
-        </button>
+        <template v-if="this.structure.parentId == 'lc:RT:bf2:LCC'">
+          <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="convertLcc2Dewey()">
+            <span class="">🤖</span>AutoDewey
+          </button>
+        </template>
 
         <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="showDebug()">
           <span class="button-shortcut-label">0</span>

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -96,6 +96,10 @@
               </button>
         </template>
 
+        <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="convertLcc2Dewey()">
+          <span class="button-shortcut-label">0</span>
+          AutoDewey
+        </button>
 
         <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="showDebug()">
           <span class="button-shortcut-label">0</span>
@@ -161,6 +165,8 @@
 
 
   import { mapStores, mapState, mapWritableState } from 'pinia'
+
+  import { LcCallToDewey } from '@/lib/auto_dewey'
 
 
   export default {
@@ -593,6 +599,24 @@
       //     this.$emit('actionButtonCommand', cmd)
       //     this.showActionButtonMenu=false
       // }
+
+      convertLcc2Dewey: function(){
+        // TODO: can a lcc be valid with only a class portion?
+        console.info("Dewing the conversion")
+
+        const parent = this.profileStore.returnStructureByComponentGuid(this.guid)
+        let lccn = null
+        try{
+          const data = parent.userValue["http://id.loc.gov/ontologies/bibframe/classification"][0]
+          const classPortion = data["http://id.loc.gov/ontologies/bibframe/classificationPortion"][0]["http://id.loc.gov/ontologies/bibframe/classificationPortion"]
+          const itemPortion = data["http://id.loc.gov/ontologies/bibframe/itemPortion"][0]["http://id.loc.gov/ontologies/bibframe/itemPortion"]
+          lccn = classPortion + itemPortion
+        } catch(e) {
+          alert("Couldn't generate an LC class number for auto dewey. Make sure all the pieces are present.")
+          console.error("AutoDewey Error", e)
+        }
+        console.info("lccn: ", lccn)
+      },
 
     },
     watch: {

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -207,6 +207,7 @@
 
 
       ...mapWritableState(usePreferenceStore, ['debugModalData','showDebugModal']),
+      ...mapWritableState(useProfileStore, ['showAutoDeweyModal', 'deweyData']),
 
       scriptShifterOptionsForMenu(){
 
@@ -628,11 +629,12 @@
         this.lcCall = lccn
         console.info("lccn: ", lccn)
         this.deweyData = {
-          lcc: lcc,
+          lcc: lccn,
           guid: this.guid,
           strcuture: this.structure
         }
 
+        console.info("!!", this.deweyData)
         this.showAutoDeweyModal = true
       },
 

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -359,7 +359,6 @@
         if (this.structure.parentId.includes("lc:RT:bf2:SeriesHub")){
           return false
         }
-        console.info("this.structure", this.structure.parentId)
         //does this have defaults, or are the defaults higher up?
         let defaults = this.structure.valueConstraint.defaults
 
@@ -612,7 +611,6 @@
 
       convertLcc2Dewey: function(){
         // TODO: can a lcc be valid with only a class portion?
-        console.info("Dewing the conversion")
 
         const parent = this.profileStore.returnStructureByComponentGuid(this.guid)
         let lccn = null
@@ -627,14 +625,12 @@
           return
         }
         this.lcCall = lccn
-        console.info("lccn: ", lccn)
         this.deweyData = {
           lcc: lccn,
           guid: this.guid,
           structure: this.structure
         }
 
-        console.info("!!", this.deweyData)
         this.showAutoDeweyModal = true
       },
 

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -617,12 +617,14 @@
         try{
           const data = parent.userValue["http://id.loc.gov/ontologies/bibframe/classification"][0]
           const classPortion = data["http://id.loc.gov/ontologies/bibframe/classificationPortion"][0]["http://id.loc.gov/ontologies/bibframe/classificationPortion"]
-          const itemPortion = data["http://id.loc.gov/ontologies/bibframe/itemPortion"][0]["http://id.loc.gov/ontologies/bibframe/itemPortion"]
-          lccn = classPortion + itemPortion
+          lccn = classPortion
+          try {
+            const itemPortion = data["http://id.loc.gov/ontologies/bibframe/itemPortion"][0]["http://id.loc.gov/ontologies/bibframe/itemPortion"]
+            lccn += itemPortion
+          } catch {}
         } catch(e) {
-          alert("Couldn't generate an LC class number for auto dewey. Make sure all the pieces are present.")
+          // alert("Couldn't generate an LC class number for auto dewey. Make sure all the pieces are present.")
           console.error("AutoDewey Error", e)
-          return
         }
         this.lcCall = lccn
         this.deweyData = {

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -14,8 +14,6 @@
  <VMenu ref="action-button-menu" :triggers="useOpenModes" @show="shortCutPressed" v-model:shown="isMenuShown"  @hide="menuClosed">
     <button tabindex="-1" :id="`action-button-${fieldGuid}`" :class="{'action-button':true,'small-mode': small }"><span class="material-icons action-button-icon">{{preferenceStore.returnValue('--s-edit-general-action-button-icon')}}</span></button>
 
-    <!-- <AutoDewey ref="autoDeweyModal" @hideDeweyModal="hideDeweyModal()" v-model="displayDewey" :lcCall="lcCall" @addDdc="addDdc" /> -->
-
     <template #popper>
 
       <div style="width: 250px;">
@@ -608,8 +606,6 @@
       // }
 
       convertLcc2Dewey: function(){
-        // TODO: can a lcc be valid with only a class portion?
-
         const parent = this.profileStore.returnStructureByComponentGuid(this.guid)
         let lccn = null
         try{

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -296,10 +296,18 @@
         } catch {
           userValue = ddcComponent
         }
+
+        let dewey = null
+        if (Object.keys(deweyInfo).includes("DDC")){
+          dewey = deweyInfo.DDC
+        } else {
+          dewey = deweyInfo.dewey
+        }
+
         const newGuid = short.generate()
         console.info("userValue: ", userValue)
         userValue["@type"] = "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
-        userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(deweyInfo.dewey) }]
+        userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(dewey) }]
 
         //Add the defaults:
         // console.info("profile: ", this.profileStore.activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt)

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -302,7 +302,7 @@
         const newGuid = short.generate()
         console.info("userValue: ", userValue)
         userValue["@type"] = "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
-        userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(deweyInfo.DDC) }]
+        userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(deweyInfo.dewey) }]
 
         //Add the defaults:
         // console.info("profile: ", this.profileStore.activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt)
@@ -693,8 +693,6 @@
         this.lcCall = lccn
         console.info("lccn: ", lccn)
         this.displayDewey = true
-        //const ddc = LcCallToDewey(lccn)
-        //console.info("ddc: ", ddc)
       },
 
     },

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -170,9 +170,6 @@
 
   import { mapStores, mapState, mapWritableState } from 'pinia'
 
-  import utilsNetwork from '@/lib/utils_network'
-  import LcCallToDewey from '@/lib/auto_dewey'
-
   export default {
     components: {
     AutoDewey

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -305,15 +305,15 @@
         userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(deweyInfo.DDC) }]
 
         //Add the defaults:
-        console.info("profile: ", this.profileStore.activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt)
-        const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
-        const newStructure = this.profileStore.returnStructureByGUID(newComponent["@guid"])
+        // console.info("profile: ", this.profileStore.activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt)
+        // const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
+        // const newStructure = this.profileStore.returnStructureByGUID(newComponent["@guid"])
 
-        console.info("newComponent['@guid']: ", newComponent['@guid'])
-        console.info("newStructure: ", newStructure)
-        console.info("ddcComponent: ", ddcComponent)
+        // console.info("newComponent['@guid']: ", newComponent['@guid'])
+        // console.info("newStructure: ", newStructure)
+        // console.info("ddcComponent: ", ddcComponent)
 
-        console.info("*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*")
+        // console.info("*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*")
 
         // this.profileStore.insertDefaultValuesComponent(newComponent['@guid'], ddcComponent)
 
@@ -676,7 +676,6 @@
 
       convertLcc2Dewey: function(){
         // TODO: can a lcc be valid with only a class portion?
-        this.displayDewey = true
         console.info("Dewing the conversion")
 
         const parent = this.profileStore.returnStructureByComponentGuid(this.guid)
@@ -689,9 +688,11 @@
         } catch(e) {
           alert("Couldn't generate an LC class number for auto dewey. Make sure all the pieces are present.")
           console.error("AutoDewey Error", e)
+          return
         }
         this.lcCall = lccn
         console.info("lccn: ", lccn)
+        this.displayDewey = true
         //const ddc = LcCallToDewey(lccn)
         //console.info("ddc: ", ddc)
       },

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -256,8 +256,6 @@
       },
 
       showBuildHubStub(){
-
-
         console.log("this.propertyPath",this.propertyPath)
 
         if (!this.propertyPath) return false;

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -9,7 +9,7 @@
             :is-active="true"
             :w="850"
             :h="400"
-            :x="initalLeft"
+            :x="200"
             :y="50"
             :class="ddc-modal"
             @resizing="dragResize"
@@ -20,9 +20,9 @@
             >
 
             <div class="dewey-modal" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
-                <div style="position: relative;">
+                <div>
                     <div class="dewey-menu-button">
-                        <button @click="closeModal()">Close</button>
+                        <button @click="closeModal()" class="close-button">Close</button>
                     </div>
                 </div>
                 <div ref="autoDeweyModalContainer" class="auto-dewey-modal-container">
@@ -68,8 +68,7 @@
                                 <dt>LCC Caption</dt>
                                 <dd>{{ deweyInfo['LCC Caption'] }}</dd> -->
                             </dl>
-
-                            <button @click="add()" v-if="deweyInfo && (deweyInfo.DDC || deweyInfo.dewey) && this.$route.path.includes('/edit/')">Add to record</button>
+                            <button @click="add()" v-if="deweyInfo && deweyData.lcc && this.$route.path.includes('/edit/')">Add to record</button>
                         </div>
                     </div>
                 </div>
@@ -100,6 +99,10 @@
 
     .auto-dewey-container {
         display: flex;
+    }
+
+    .auto-dewey-modal-container{
+        height: 400px;
     }
 
     .input-panel{
@@ -185,6 +188,17 @@
         max-width: 100%;
     }
 
+    .close-button{
+        position: absolute;
+        right: 5px;
+        top: 5px;
+        background-color: white;
+        border-radius: 5px;
+        border: solid 1px black;
+        cursor: pointer;
+        z-index: 100;
+    }
+
   </style>
 
   <script>
@@ -205,8 +219,8 @@
 
     data: function() {
         return {
-            autoDeweyGenres: ['fiction', 'poetry', 'drama', 'none'],
-            autoDeweyGenre: null,
+            autoDeweyGenres: ['none', 'fiction', 'poetry', 'drama'],
+            autoDeweyGenre: 'none',
             lcCall: null,
             deweyInfo: null,
             deweyPeriod: 0,

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -31,18 +31,24 @@
                             <label for="LcCall">LC Call Number: </label>
                             <input class="lcCallInput" name="LcCall" v-model="lcCallLocal" ref="inputLookup" type="text" @click="inputFocus" />
 
-                            <div class="dewey-toggle-btn-grp cssonly">
+                            <div class="dewey-toggle-btn-grp cssonly" style="margin-bottom: 8px;">
                                 <div v-for="opt in autoDeweyGenres">
                                     <input type="radio" :id="opt" :value="opt" class="genre-type-radio" v-model="autoDeweyGenre" name="genre-selection" />
                                     <label onclick="" :for="opt" class="dewey-toggle-btn">{{opt}}</label>
                                 </div>
                             </div>
 
-                            <div v-if="deweyInfo && deweyInfo.periods && deweyInfo.periods.length > 0">
-                                ???
-                            </div>
-
                             <button @click="dewIt()">Create DDC</button>
+
+                            <div v-if="deweyInfo && deweyInfo.periods && deweyInfo.periods.length > 0" style="margin-top: 10px;">
+                                Select a period to complete the DDC creation.
+                                <div class="dewey-toggle-btn-grp cssonly">
+                                    <div v-for="(per, indx) in deweyInfo.periods">
+                                        <input type="radio" :id="per" :value="per" class="period-type-radio" v-model="deweyPeriod" name="period-selection" @click="setPeriod(idx)" />
+                                        <label onclick="" :for="per" class="dewey-toggle-btn">{{per}}</label>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
 
                         <div class="auto-dewey-results">
@@ -106,7 +112,7 @@
         padding: 5px;
     }
     .dewey-toggle-btn-grp.cssonly{
-        width: 110px;
+        width: 500px;
         height: 30px;
         line-height: 30px;
     }
@@ -127,12 +133,12 @@
         width: fit-content;
     }
 
+    .period-type-radio,
     .genre-type-radio {
         position: absolute;
         z-index: 100;
         cursor: pointer;
         opacity: 0;
-
     }
 
     .dewey-toggle-btn-grp.cssonly div input{
@@ -169,7 +175,7 @@
   <script>
     import { VueFinalModal } from 'vue-final-modal'
     import VueDragResize from 'vue3-drag-resize'
-    import LcCallToDewey from '@/lib/auto_dewey'
+    import {LcCallToDewey, onPeriodClicked} from '@/lib/auto_dewey'
 
     export default {
     name: "AutoDewey",
@@ -216,6 +222,12 @@
             console.info("adding to record")
             this.$emit('addDdc', this.deweyInfo)
             this.closeModal()
+        },
+
+        setPeriod: function(idx){
+            console.info("setting period: ", e.target.value)
+            let result = onPeriodClicked(idx+1, this.deweyInfo.dewey, this.deweyInfo.genre, this.deweyInfo.country) //periodNumber, sDewey$, sGenre$, sCountry$
+            console.info("result", result)
         }
     },
 

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -16,6 +16,7 @@
             @dragging="dragResize"
             :sticks="['br']"
             :stickSize="22"
+            style="background-color: whitesmoke"
             >
 
             <div class="dewey-modal" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
@@ -32,6 +33,7 @@
                             <input class="lcCallInput" name="LcCall" v-model="lcCall" ref="inputLookup" type="text" @click="inputFocus" />
 
                             <div class="dewey-toggle-btn-grp cssonly" style="margin-bottom: 8px;">
+                                <div><span class="dewey-genre">Genre:</span></div>
                                 <div v-for="opt in autoDeweyGenres">
                                     <input type="radio" :id="opt" :value="opt" class="genre-type-radio" v-model="autoDeweyGenre" name="genre-selection" />
                                     <label onclick="" :for="opt" class="dewey-toggle-btn">{{opt}}</label>
@@ -92,7 +94,7 @@
         margin-left: 2em;
     }
 
-    .ddc-modal{
+    .dewey-modal{
         background-color: whitesmoke;
     }
 
@@ -111,6 +113,11 @@
         margin: 5px;
         padding: 5px;
     }
+
+    .dewey-genre {
+        line-height: 30px;
+    }
+
     .dewey-toggle-btn-grp.cssonly{
         width: 100%;
         height: 30px;
@@ -198,7 +205,7 @@
 
     data: function() {
         return {
-            autoDeweyGenres: ['fiction', 'poetry', 'drama'],
+            autoDeweyGenres: ['fiction', 'poetry', 'drama', 'none'],
             autoDeweyGenre: null,
             lcCall: null,
             deweyInfo: null,

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -20,7 +20,7 @@
 
             <div class="complex-lookup-modal">
                 <div style="position: relative;">
-                    <div class="dewey-menu-buttons">
+                    <div class="dewey-menu-button">
                         <button @click="closeModal()">Close</button>
                     </div>
                 </div>
@@ -29,7 +29,7 @@
                     <div class="auto-dewey-container">
                         <div class="input-panel">
                             <label for="LcCall">LC Call Number: </label>
-                            <input class="lcCallInput" name="LcCall" v-model="lcCallLocal" ref="inputLookup" type="text" />
+                            <input class="lcCallInput" name="LcCall" v-model="lcCallLocal" ref="inputLookup" type="text" @click="inputFocus" />
 
                             <div class="dewey-toggle-btn-grp cssonly">
                                 <div v-for="opt in autoDeweyGenres">
@@ -38,22 +38,30 @@
                                 </div>
                             </div>
 
+                            <div v-if="deweyInfo && deweyInfo.periods && deweyInfo.periods.length > 0">
+                                ???
+                            </div>
+
                             <button @click="dewIt()">Create DDC</button>
                         </div>
 
-                        <div class="auto-dewey-results" v-if="deweyInfo">
+                        <div class="auto-dewey-results">
                             <h2>Results</h2>
-                            <dl>
-                                <dt>DDC</dt>
-                                <dd>{{ deweyInfo.DDC }}</dd>
+                            <dl v-if="deweyInfo">
+                                <div v-for="(value, name, indx) in deweyInfo">
+                                    <dt v-if="value">{{ name }}</dt>
+                                    <dd v-if="value">{{ value }}</dd>
+                                </div>
+                                <!--
 
                                 <dt>DDC Caption</dt>
                                 <dd>{{ deweyInfo['DDC Caption'] }}</dd>
 
                                 <dt>LCC Caption</dt>
-                                <dd>{{ deweyInfo['LCC Caption'] }}</dd>
+                                <dd>{{ deweyInfo['LCC Caption'] }}</dd> -->
                             </dl>
-                            <button @click="add()">Add</button>
+
+                            <button @click="add()" v-if="deweyInfo">Add to record</button>
                         </div>
                     </div>
                 </div>
@@ -75,6 +83,7 @@
 
     dd {
         margin-bottom: 1em;
+        margin-left: 2em;
     }
 
     .auto-dewey-modal-container{
@@ -94,6 +103,7 @@
         width: 50%;
         background-color: lightgrey;
         margin: 5px;
+        padding: 5px;
     }
     .dewey-toggle-btn-grp.cssonly{
         width: 110px;
@@ -184,6 +194,9 @@
 
     computed: {},
     methods: {
+        inputFocus: function(){
+            this.$refs.inputLookup.focus()
+        },
         closeModal: function(){
             this.autoDeweyGenre = null
             this.lcCallLocal = null

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -1,0 +1,138 @@
+<template>
+    <VueFinalModal
+        display-directive="show"
+        :hide-overlay="false"
+        :overlay-transition="'vfm-fade'"
+        @closed="closeModal()"
+      >
+        <VueDragResize
+            :is-active="true"
+            :w="850"
+            :h="initalHeight"
+            :x="initalLeft"
+            :y="50"
+            class="debug-modal"
+            @resizing="dragResize"
+            @dragging="dragResize"
+            :sticks="['br']"
+            :stickSize="22"
+            >
+
+            <div ref="autoDeweyModalContainer" class="complex-lookup-modal-container">
+                <div style="position: relative;">
+                    <div class="menu-buttons">
+                        <button @click="closeModal()">Close</button>
+                    </div>
+
+                    <div class="input-panel">
+                        <p>Hello?</p>
+
+                        <label for="LcCall">LC Call Number: </label>
+                        <input class="lcCallInput" name="LcCall" v-model="lcCallLocal" ref="inputLookup" type="text" />
+
+                        <div v-for="opt in autoDeweyGenres">
+                            <input type="radio" :value="opt" class="genre-type-radio" v-model="autoDeweyGenre" name="GenreType"/>
+                            <label onclick="" class="toggle-btn">{{opt}}</label>
+                        </div>
+
+                        <button @click="dewIt()">Dew It</button>
+                    </div>
+                    <div class="results" v-if="deweyInfo">
+                        <h2>Results</h2>
+                        <dl>
+                            <dt>DDC</dt>
+                            <dd>{{ deweyInfo.DDC }}</dd>
+
+                            <dt>DDC Caption</dt>
+                            <dd>{{ deweyInfo['DDC Caption'] }}</dd>
+
+                            <dt>LCC Caption</dt>
+                            <dd>{{ deweyInfo['LCC Caption'] }}</dd>
+                        </dl>
+                        <button @click="add()">Add</button>
+                    </div>
+                </div>
+
+            </div>
+        </VueDragResize>
+    </VueFinalModal>
+  </template>
+
+
+  <style type="text/css" scoped>
+    dt {
+        font-weight: bold;
+    }
+
+    dl,
+    dd {
+        font-size: 0.9rem;
+    }
+
+    dd {
+        margin-bottom: 1em;
+    }
+  </style>
+
+  <script>
+    import { VueFinalModal } from 'vue-final-modal'
+    import VueDragResize from 'vue3-drag-resize'
+    import LcCallToDewey from '@/lib/auto_dewey'
+
+    export default {
+    name: "AutoDewey",
+    components: {
+        VueFinalModal,
+        VueDragResize,
+    },
+    props: {
+        lcCall: String,
+    },
+
+    watch: {},
+
+    data: function() {
+        return {
+            autoDeweyGenres: ['fiction', 'poetry', 'drama'],
+            autoDeweyGenre: null,
+            lcCallLocal: null,
+            deweyInfo: null
+        }
+    },
+
+    computed: {},
+    methods: {
+        closeModal: function(){
+            this.autoDeweyGenre = null
+            this.lcCallLocal = null
+            this.deweyInfo = null
+            this.$emit('hideDeweyModal', true)
+        },
+
+        dewIt: function(){
+            console.info("Dewing the thing")
+            console.info("genre: ", this.autoDeweyGenre)
+            console.info("lcCall: ", this.lcCallLocal)
+            this.deweyInfo = LcCallToDewey(this.lcCallLocal, this.autoDeweyGenre)
+            console.info(">>> deweyInfo", this.deweyInfo)
+        },
+
+        add: function(){
+            console.info("adding to record")
+            this.$emit('addDdc', this.deweyInfo)
+            this.closeModal()
+        }
+    },
+
+    created: function () {},
+    before: function () {},
+    mounted: function(){},
+
+
+    updated: function() {
+        //update local value from prop
+        this.lcCallLocal = this.lcCall
+    }
+  };
+
+  </script>

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -8,7 +8,7 @@
         <VueDragResize
             :is-active="true"
             :w="850"
-            :h="initalHeight"
+            :h="250"
             :x="initalLeft"
             :y="50"
             class="debug-modal"
@@ -18,41 +18,45 @@
             :stickSize="22"
             >
 
-            <div ref="autoDeweyModalContainer" class="complex-lookup-modal-container">
+            <div class="complex-lookup-modal">
                 <div style="position: relative;">
-                    <div class="menu-buttons">
+                    <div class="dewey-menu-buttons">
                         <button @click="closeModal()">Close</button>
                     </div>
+                </div>
+                <div ref="autoDeweyModalContainer" class="auto-dewey-modal-container">
+                    <h1 style="margin-left: 5px">AutoDewey 🤖</h1>
+                    <div class="auto-dewey-container">
+                        <div class="input-panel">
+                            <label for="LcCall">LC Call Number: </label>
+                            <input class="lcCallInput" name="LcCall" v-model="lcCallLocal" ref="inputLookup" type="text" />
 
-                    <div class="input-panel">
-                        <p>Hello?</p>
+                            <div class="dewey-toggle-btn-grp cssonly">
+                                <div v-for="opt in autoDeweyGenres">
+                                    <input type="radio" :id="opt" :value="opt" class="genre-type-radio" v-model="autoDeweyGenre" name="genre-selection" />
+                                    <label onclick="" :for="opt" class="dewey-toggle-btn">{{opt}}</label>
+                                </div>
+                            </div>
 
-                        <label for="LcCall">LC Call Number: </label>
-                        <input class="lcCallInput" name="LcCall" v-model="lcCallLocal" ref="inputLookup" type="text" />
-
-                        <div v-for="opt in autoDeweyGenres">
-                            <input type="radio" :value="opt" class="genre-type-radio" v-model="autoDeweyGenre" name="GenreType"/>
-                            <label onclick="" class="toggle-btn">{{opt}}</label>
+                            <button @click="dewIt()">Create DDC</button>
                         </div>
 
-                        <button @click="dewIt()">Dew It</button>
-                    </div>
-                    <div class="results" v-if="deweyInfo">
-                        <h2>Results</h2>
-                        <dl>
-                            <dt>DDC</dt>
-                            <dd>{{ deweyInfo.DDC }}</dd>
+                        <div class="auto-dewey-results" v-if="deweyInfo">
+                            <h2>Results</h2>
+                            <dl>
+                                <dt>DDC</dt>
+                                <dd>{{ deweyInfo.DDC }}</dd>
 
-                            <dt>DDC Caption</dt>
-                            <dd>{{ deweyInfo['DDC Caption'] }}</dd>
+                                <dt>DDC Caption</dt>
+                                <dd>{{ deweyInfo['DDC Caption'] }}</dd>
 
-                            <dt>LCC Caption</dt>
-                            <dd>{{ deweyInfo['LCC Caption'] }}</dd>
-                        </dl>
-                        <button @click="add()">Add</button>
+                                <dt>LCC Caption</dt>
+                                <dd>{{ deweyInfo['LCC Caption'] }}</dd>
+                            </dl>
+                            <button @click="add()">Add</button>
+                        </div>
                     </div>
                 </div>
-
             </div>
         </VueDragResize>
     </VueFinalModal>
@@ -72,6 +76,84 @@
     dd {
         margin-bottom: 1em;
     }
+
+    .auto-dewey-modal-container{
+
+    }
+
+    .auto-dewey-container {
+        display: flex;
+    }
+
+    .input-panel{
+        width:50%;
+        padding: 10px;
+    }
+
+    .auto-dewey-results {
+        width: 50%;
+        background-color: lightgrey;
+        margin: 5px;
+    }
+    .dewey-toggle-btn-grp.cssonly{
+        width: 110px;
+        height: 30px;
+        line-height: 30px;
+    }
+    .dewey-toggle-btn-grp.cssonly div {
+        display: initial;
+        position: relative;
+        margin: 5px 2px;
+    }
+    /* .dewey-toggle-btn-grp {
+        display: flex;
+        position: relative;
+        margin: 5px 2px;
+    } */
+
+    .dewey-toggle-btn-grp div {
+        margin: 5px;
+        padding: 5px;
+        width: fit-content;
+    }
+
+    .genre-type-radio {
+        position: absolute;
+        z-index: 100;
+        cursor: pointer;
+        opacity: 0;
+
+    }
+
+    .dewey-toggle-btn-grp.cssonly div input{
+        padding: 5px;
+    }
+
+    .dewey-toggle-btn-grp.cssonly div label:hover {
+        border: solid 1px #a0d5dc !important;
+    }
+
+    .dewey-toggle-btn-grp.cssonly div input + label{
+        border: solid 1px black;
+        border-radius: 5px;
+        padding: 5px;
+    }
+
+    .dewey-toggle-btn-grp.cssonly div input:checked + label{
+        background-color: lightblue;
+        border: solid 1px blue;
+        border-radius: 5px;
+    }
+
+    .dewey-toggle-btn {
+        cursor: pointer;
+    }
+
+    .dewey-menu-buttons{
+        float: right;
+        margin: 5px;
+    }
+
   </style>
 
   <script>

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -1,31 +1,31 @@
 <template>
     <VueFinalModal
         display-directive="show"
-        :hide-overlay="false"
+        :hide-overlay="true"
         :overlay-transition="'vfm-fade'"
         @closed="closeModal()"
       >
         <VueDragResize
             :is-active="true"
             :w="850"
-            :h="300"
+            :h="400"
             :x="initalLeft"
             :y="50"
-            class="debug-modal"
+            class="ddc-modal"
             @resizing="dragResize"
             @dragging="dragResize"
             :sticks="['br']"
             :stickSize="22"
             >
 
-            <div class="complex-lookup-modal">
+            <div class="complex-lookup-modal" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
                 <div style="position: relative;">
                     <div class="dewey-menu-button">
                         <button @click="closeModal()">Close</button>
                     </div>
                 </div>
                 <div ref="autoDeweyModalContainer" class="auto-dewey-modal-container">
-                    <h1 style="margin-left: 5px">AutoDewey 🤖</h1>
+                    <h1 style="margin-left: 5px">LC to DDC</h1>
                     <div class="auto-dewey-container">
                         <div class="input-panel">
                             <label for="LcCall">LC Call Number: </label>
@@ -246,7 +246,15 @@
             console.info("result: ", result)
 
             this.deweyInfo.dewey = result
-        }
+        },
+
+        onSelectElement (event) {
+          const tagName = event.target.tagName
+
+          if (tagName === 'INPUT' || tagName === 'TD' || tagName === 'BUTTON'  || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+            event.stopPropagation()
+          }
+        },
     },
 
     created: function () {},

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -11,14 +11,14 @@
             :h="400"
             :x="initalLeft"
             :y="50"
-            class="ddc-modal"
+            :class="ddc-modal"
             @resizing="dragResize"
             @dragging="dragResize"
             :sticks="['br']"
             :stickSize="22"
             >
 
-            <div class="complex-lookup-modal" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
+            <div class="dewey-modal" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
                 <div style="position: relative;">
                     <div class="dewey-menu-button">
                         <button @click="closeModal()">Close</button>
@@ -67,7 +67,7 @@
                                 <dd>{{ deweyInfo['LCC Caption'] }}</dd> -->
                             </dl>
 
-                            <button @click="add()" v-if="deweyInfo && this.$route.path.includes('/edit/')">Add to record</button>
+                            <button @click="add()" v-if="deweyInfo && (deweyInfo.DDC || deweyInfo.dewey) && this.$route.path.includes('/edit/')">Add to record</button>
                         </div>
                     </div>
                 </div>
@@ -92,8 +92,8 @@
         margin-left: 2em;
     }
 
-    .auto-dewey-modal-container{
-
+    .ddc-modal{
+        background-color: whitesmoke;
     }
 
     .auto-dewey-container {
@@ -220,25 +220,21 @@
             this.autoDeweyGenre = null
             this.lcCall = null
             this.deweyInfo = null
+            this.deweyData.guid = null
+            this.deweyData.structure = null
             this.showAutoDeweyModal = false
         },
 
         dewIt: function(){
-            console.info("Dewing the thing")
-            console.info("genre: ", this.autoDeweyGenre)
-            console.info("lcCall: ", this.lcCall)
             this.deweyInfo = LcCallToDewey(this.lcCall, this.autoDeweyGenre)
-            console.info(">>> deweyInfo", this.deweyInfo)
         },
 
         add: function(){
-            console.info("adding to record", this.deweyInfo)
             this.profileStore.addDdc(this.deweyInfo, this.deweyData.guid, this.deweyData.structure)
             this.closeModal()
         },
 
         setPeriod: function(e, idx){
-            console.info("setting period: ", this.deweyInfo, "--", idx)
             //e.target.checked = true
             const period = this.deweyInfo.dewey
             if (period.startsWith("Period")){
@@ -247,7 +243,6 @@
             const genre = this.deweyInfo.genre
             const country = this.deweyInfo.country
             let result = onPeriodClicked(idx+1, this.savedPeriod, genre, country) //periodNumber, sDewey$, sGenre$, sCountry$
-            console.info("result: ", result)
 
             this.deweyInfo.dewey = result
         },
@@ -270,13 +265,7 @@
     },
 
 
-    updated: function() {
-        // console.info("update")
-        // //update local value from prop
-        // this.lcCall = this.deweyData.lcc
-        // this.guid = this.deweyData.guid
-        // this.structure = this.deweyData.structure
-    }
+    updated: function() {}
   };
 
   </script>

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -8,7 +8,7 @@
         <VueDragResize
             :is-active="true"
             :w="850"
-            :h="250"
+            :h="300"
             :x="initalLeft"
             :y="50"
             class="debug-modal"
@@ -38,9 +38,9 @@
                                 </div>
                             </div>
 
-                            <button @click="dewIt()">Create DDC</button>
+                            <button @click="dewIt()" style="margin-top: 8px;">Create DDC</button>
 
-                            <div v-if="deweyInfo && deweyInfo.periods && deweyInfo.periods.length > 0" style="margin-top: 10px;">
+                            <div v-if="deweyInfo && deweyInfo.periods && deweyInfo.periods.length > 0" style="margin-top: 10px;" class="dewey-period-selection">
                                 Select a period to complete the DDC creation.
                                 <div class="dewey-toggle-btn-grp cssonly">
                                     <div v-for="(per, idx) in deweyInfo.periods">
@@ -112,9 +112,13 @@
         padding: 5px;
     }
     .dewey-toggle-btn-grp.cssonly{
-        width: 500px;
+        width: 100%;
         height: 30px;
         line-height: 30px;
+
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap
     }
     .dewey-toggle-btn-grp.cssonly div {
         display: initial;
@@ -170,6 +174,10 @@
         margin: 5px;
     }
 
+    .dewey-period-selection{
+        max-width: 100%;
+    }
+
   </style>
 
   <script>
@@ -220,7 +228,7 @@
         },
 
         add: function(){
-            console.info("adding to record")
+            console.info("adding to record", this.deweyInfo)
             this.$emit('addDdc', this.deweyInfo)
             this.closeModal()
         },

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -233,7 +233,7 @@
 
         add: function(){
             console.info("adding to record", this.deweyInfo)
-            this.profileStore.addDdc(this.deweyData.lcc, this.deweyData.guid, this.deweyData.structure)
+            this.profileStore.addDdc(this.deweyInfo, this.deweyData.guid, this.deweyData.structure)
             this.closeModal()
         },
 

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -19,7 +19,7 @@
             style="background-color: whitesmoke"
             >
 
-            <div class="dewey-modal" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
+            <div class="dewey-modal" ref="autoDeweyContent" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
                 <div>
                     <div class="dewey-menu-button">
                         <button @click="closeModal()" class="close-button">Close</button>
@@ -239,7 +239,7 @@
             this.height = newRect.height
             this.top = newRect.top
             this.left = newRect.left
-            this.$refs.shelfListingContent.style.height = newRect.height + 'px'
+            this.$refs.autoDeweyContent.style.height = newRect.height + 'px'
         },
         inputFocus: function(){
             this.$refs.inputLookup.focus()

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -263,14 +263,19 @@
 
     created: function () {},
     before: function () {},
-    mounted: function(){},
-
-
-    updated: function() {
-        //update local value from prop
+    mounted: function(){
         this.lcCall = this.deweyData.lcc
         this.guid = this.deweyData.guid
         this.structure = this.deweyData.structure
+    },
+
+
+    updated: function() {
+        // console.info("update")
+        // //update local value from prop
+        // this.lcCall = this.deweyData.lcc
+        // this.guid = this.deweyData.guid
+        // this.structure = this.deweyData.structure
     }
   };
 

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -256,7 +256,6 @@
         },
 
         setPeriod: function(e, idx){
-            //e.target.checked = true
             const period = this.deweyInfo.dewey
             if (period.startsWith("Period")){
                 this.savedPeriod = period

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -234,6 +234,13 @@
         ...mapWritableState(useProfileStore, ['showAutoDeweyModal','deweyData']),
     },
     methods: {
+        dragResize: function(newRect) {
+            this.width = newRect.width
+            this.height = newRect.height
+            this.top = newRect.top
+            this.left = newRect.left
+            this.$refs.shelfListingContent.style.height = newRect.height + 'px'
+        },
         inputFocus: function(){
             this.$refs.inputLookup.focus()
         },

--- a/src/components/panels/edit/modals/AutoDeweyModal.vue
+++ b/src/components/panels/edit/modals/AutoDeweyModal.vue
@@ -43,8 +43,8 @@
                             <div v-if="deweyInfo && deweyInfo.periods && deweyInfo.periods.length > 0" style="margin-top: 10px;">
                                 Select a period to complete the DDC creation.
                                 <div class="dewey-toggle-btn-grp cssonly">
-                                    <div v-for="(per, indx) in deweyInfo.periods">
-                                        <input type="radio" :id="per" :value="per" class="period-type-radio" v-model="deweyPeriod" name="period-selection" @click="setPeriod(idx)" />
+                                    <div v-for="(per, idx) in deweyInfo.periods">
+                                        <input type="radio" :id="per" :value="per" class="period-type-radio" v-model="deweyPeriod" name="period-selection" @click="setPeriod($event, idx)" />
                                         <label onclick="" :for="per" class="dewey-toggle-btn">{{per}}</label>
                                     </div>
                                 </div>
@@ -175,7 +175,7 @@
   <script>
     import { VueFinalModal } from 'vue-final-modal'
     import VueDragResize from 'vue3-drag-resize'
-    import {LcCallToDewey, onPeriodClicked} from '@/lib/auto_dewey'
+    import { onPeriodClicked, LcCallToDewey } from '@/lib/auto_dewey'
 
     export default {
     name: "AutoDewey",
@@ -194,7 +194,8 @@
             autoDeweyGenres: ['fiction', 'poetry', 'drama'],
             autoDeweyGenre: null,
             lcCallLocal: null,
-            deweyInfo: null
+            deweyInfo: null,
+            deweyPeriod: 0,
         }
     },
 
@@ -224,10 +225,19 @@
             this.closeModal()
         },
 
-        setPeriod: function(idx){
-            console.info("setting period: ", e.target.value)
-            let result = onPeriodClicked(idx+1, this.deweyInfo.dewey, this.deweyInfo.genre, this.deweyInfo.country) //periodNumber, sDewey$, sGenre$, sCountry$
-            console.info("result", result)
+        setPeriod: function(e, idx){
+            console.info("setting period: ", this.deweyInfo, "--", idx)
+            //e.target.checked = true
+            const period = this.deweyInfo.dewey
+            if (period.startsWith("Period")){
+                this.savedPeriod = period
+            }
+            const genre = this.deweyInfo.genre
+            const country = this.deweyInfo.country
+            let result = onPeriodClicked(idx+1, this.savedPeriod, genre, country) //periodNumber, sDewey$, sGenre$, sCountry$
+            console.info("result: ", result)
+
+            this.deweyInfo.dewey = result
         }
     },
 

--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -255,7 +255,6 @@
             <div class="shelf-listing-work-area">
               <input v-model="classNumber" class="number-input" placeholder="Class" @keyup="hitCount=10; search()" type="text" />
               <input v-model="cutterNumber" class="number-input" @keyup="hitCount=10; search()" placeholder="Cutter" type="text" />
-              {{ activeShelfListData }}
               <button class="number-input" @click="save" :disabled="(!activeShelfListData.componentGuid)">Save</button>
 
               <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>

--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -255,6 +255,7 @@
             <div class="shelf-listing-work-area">
               <input v-model="classNumber" class="number-input" placeholder="Class" @keyup="hitCount=10; search()" type="text" />
               <input v-model="cutterNumber" class="number-input" @keyup="hitCount=10; search()" placeholder="Cutter" type="text" />
+              {{ activeShelfListData }}
               <button class="number-input" @click="save" :disabled="(!activeShelfListData.componentGuid)">Save</button>
 
               <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -18,9 +18,9 @@
     <div ref="complexLookupModalContainer" class="complex-lookup-modal-container">
       <div style="position: relative;">
           <div style="position:absolute; right:2em; top:  0.25em; z-index: 100;">
-			  <div class="menu-buttons">
-				<button @click="closeEditor()">Close</button>
-			  </div>
+			      <div class="menu-buttons">
+				    <button @click="closeEditor()">Close</button>
+			    </div>
             <button @click="editorModeSwitch('build')" data-tooltip="Build LCSH headings using a lookup list" class="subjectEditorModeButtons simptip-position-left" style="margin-right: 1em; background-color: black; height: 2em; display: inline-flex;">
       <!--         <svg fill="#F2F2F2" width="20px" height="20px" version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                <g>
@@ -416,17 +416,12 @@
     /*font-size: 1em;*/
   }
 
-
-
   .subject-editor-container-left-lowres{
-
     font-size: 0.75em !important;
     height: 352px;
     max-height: 352px;
 
   }
-
-
 
   .subject-editor-container-right{
     flex:1;
@@ -455,7 +450,6 @@
 
 
   .color-holder{
-
     font-size: 1.5em;
     position: absolute;
     padding-top: 0.3em;

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -166,7 +166,7 @@
             { text: "AutoDewey", click: () => {
               this.deweyData = {}
               this.showAutoDeweyModal = true
-            }, icon:"" },
+            }, icon:"smart_toy" },
 
             { is: 'separator'},
             {

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -57,7 +57,7 @@
       ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay']),
       ...mapState(useConfigStore, ['layouts']),
       ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal','layoutActiveFilter','layoutActive','showFieldColorsModal']),
-      ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal']),
+      ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal', 'showAutoDeweyModal']),
       ...mapWritableState(useConfigStore, ['showNonLatinBulkModal','showNonLatinAgentModal']),
 
 
@@ -162,6 +162,11 @@
               this.activeShelfListData = {}
               this.showShelfListingModal = true
             }, icon:"🗄️" },
+
+            { text: "AutoDewey", click: () => {
+              this.deweyData = {}
+              this.showAutoDeweyModal = true
+            }, icon:"" },
 
             { is: 'separator'},
             {

--- a/src/lib/LCCtoDewey.json
+++ b/src/lib/LCCtoDewey.json
@@ -1,0 +1,8871 @@
+[
+    {
+      "LCC": "AC",
+      "LCC Range": "AC",
+      "LCC Caption": "Collections. Series. Collected works",
+      "DDC": "081 - 089",
+      "DDC Caption": "General collections in specific languages"
+    },
+    {
+      "LCC": "AE",
+      "LCC Range": "AE",
+      "LCC Caption": "Encyclopedias",
+      "DDC": "031 - 039",
+      "DDC Caption": "Encyclopedias & books of facts"
+    },
+    {
+      "LCC": "AG",
+      "LCC Range": "AG",
+      "LCC Caption": "Dictionaries and other general reference works",
+      "DDC": 30,
+      "DDC Caption": "Encyclopedias & books of facts"
+    },
+    {
+      "LCC": "AI",
+      "LCC Range": "AI",
+      "LCC Caption": "Newspapers--Indexes",
+      "DDC": "071 - 079",
+      "DDC Caption": "Geographic treatment of journalism & newspapers"
+    },
+    {
+      "LCC": "AI",
+      "LCC Range": "AI",
+      "LCC Caption": "Periodicals--Indexes",
+      "DDC": 50,
+      "DDC Caption": "Magazines, journals & serials"
+    },
+    {
+      "LCC": "AM",
+      "LCC Range": "AM",
+      "LCC Caption": "Museums. Collectors and collecting",
+      "DDC": 69,
+      "DDC Caption": "Associations, organizations & museums"
+    },
+    {
+      "LCC": "AN",
+      "LCC Range": "AN",
+      "LCC Caption": "Newspapers",
+      "DDC": "071 - 079",
+      "DDC Caption": "Geographic treatment of journalism & newspapers"
+    },
+    {
+      "LCC": "AP",
+      "LCC Range": "AP",
+      "LCC Caption": "General periodicals",
+      "DDC": 50,
+      "DDC Caption": "Magazines, journals & serials"
+    },
+    {
+      "LCC": "AS",
+      "LCC Range": "AS",
+      "LCC Caption": "Academies and learned societies",
+      "DDC": "060 - 068",
+      "DDC Caption": "Associations, organizations & museums"
+    },
+    {
+      "LCC": "AY",
+      "LCC Range": "AY",
+      "LCC Caption": "Yearbooks. Almanacs. Directories",
+      "DDC": 30,
+      "DDC Caption": "Encyclopedias & books of facts"
+    },
+    {
+      "LCC": "AZ",
+      "LCC Range": "AZ",
+      "LCC Caption": "History of scholarship and learning. The humanities",
+      "DDC": 1,
+      "DDC Caption": "Knowledge"
+    },
+    {
+      "LCC": "AZ",
+      "LCC Range": "AZ",
+      "LCC Caption": "History of scholarship and learning. The humanities",
+      "DDC": 1.1,
+      "DDC Caption": "Intellectual life"
+    },
+    {
+      "LCC": "AZ",
+      "LCC Range": "AZ",
+      "LCC Caption": "History of scholarship and learning. The humanities",
+      "DDC": 1.2,
+      "DDC Caption": "Scholarship & learning"
+    },
+    {
+      "LCC": "AZ",
+      "LCC Range": "AZ",
+      "LCC Caption": "History of scholarship and learning. The humanities",
+      "DDC": 1.3,
+      "DDC Caption": "Humanities"
+    },
+    {
+      "LCC": "B",
+      "LCC Range": "B",
+      "LCC Caption": "Philosophy",
+      "DDC": "100 - 109",
+      "DDC Caption": "Philosophy"
+    },
+    {
+      "LCC": "B",
+      "LCC Range": "B",
+      "LCC Caption": "Philosophy",
+      "DDC": 180,
+      "DDC Caption": "Ancient, medieval & Eastern philosophy"
+    },
+    {
+      "LCC": "B",
+      "LCC Range": "B",
+      "LCC Caption": "Philosophy",
+      "DDC": 190,
+      "DDC Caption": "Modern western philosophy"
+    },
+    {
+      "LCC": "BC",
+      "LCC Range": "BC",
+      "LCC Caption": "Logic",
+      "DDC": 160,
+      "DDC Caption": "Logic"
+    },
+    {
+      "LCC": "BD",
+      "LCC Range": "BD",
+      "LCC Caption": "Speculative philosophy",
+      "DDC": 110,
+      "DDC Caption": "Metaphysics"
+    },
+    {
+      "LCC": "BD",
+      "LCC Range": "BD",
+      "LCC Caption": "Speculative philosophy",
+      "DDC": 120,
+      "DDC Caption": "Epistemology"
+    },
+    {
+      "LCC": "BD",
+      "LCC Range": "BD",
+      "LCC Caption": "Speculative philosophy",
+      "DDC": 140,
+      "DDC Caption": "Philosophical schools of thought"
+    },
+    {
+      "LCC": "BF",
+      "LCC Range": "BF",
+      "LCC Caption": "Psychology",
+      "DDC": 150,
+      "DDC Caption": "Psychology"
+    },
+    {
+      "LCC": "BF",
+      "LCC Range": "BF 1001+",
+      "LCC Caption": "Parapsychology",
+      "DDC": 130,
+      "DDC Caption": "Astrology, parapsychology & the occult"
+    },
+    {
+      "LCC": "BH",
+      "LCC Range": "BH",
+      "LCC Caption": "Aesthetics",
+      "DDC": 111.85,
+      "DDC Caption": "Aesthetics--philosophy"
+    },
+    {
+      "LCC": "BJ",
+      "LCC Range": "BJ 1-1725",
+      "LCC Caption": "Ethics",
+      "DDC": 170,
+      "DDC Caption": "Ethics"
+    },
+    {
+      "LCC": "BJ",
+      "LCC Range": "BJ 1801-2195",
+      "LCC Caption": "Social usages. Etiquette",
+      "DDC": 395,
+      "DDC Caption": "Etiquette (Manners)"
+    },
+    {
+      "LCC": "BL",
+      "LCC Range": "BL",
+      "LCC Caption": "Religions. Mythology.",
+      "DDC": 200,
+      "DDC Caption": "Religion"
+    },
+    {
+      "LCC": "BL",
+      "LCC Range": "BL",
+      "LCC Caption": "Religions. Mythology.",
+      "DDC": 210,
+      "DDC Caption": "Philosophy & theory of religion"
+    },
+    {
+      "LCC": "BL",
+      "LCC Range": "BL",
+      "LCC Caption": "Religions. Mythology.",
+      "DDC": "291 - 295",
+      "DDC Caption": "Comparative religion; Religions other than Christianity"
+    },
+    {
+      "LCC": "BL",
+      "LCC Range": "BL",
+      "LCC Caption": "Religions. Mythology.",
+      "DDC": 299,
+      "DDC Caption": "Other religions"
+    },
+    {
+      "LCC": "BM",
+      "LCC Range": "BM",
+      "LCC Caption": "Judaism",
+      "DDC": 296,
+      "DDC Caption": "Judaism"
+    },
+    {
+      "LCC": "BP",
+      "LCC Range": "BP",
+      "LCC Caption": "Islam. Bahaism. Theosophy, etc.",
+      "DDC": 297,
+      "DDC Caption": "Islam, Babism, Bahai Faith"
+    },
+    {
+      "LCC": "BQ",
+      "LCC Range": "BQ",
+      "LCC Caption": "Buddhism",
+      "DDC": 294.3,
+      "DDC Caption": "Buddhism"
+    },
+    {
+      "LCC": "BR",
+      "LCC Range": "BR",
+      "LCC Caption": "Christianity",
+      "DDC": "230 - 230.7",
+      "DDC Caption": "Christianity & Christian theology"
+    },
+    {
+      "LCC": "BR",
+      "LCC Range": "BR",
+      "LCC Caption": "Christianity",
+      "DDC": 270,
+      "DDC Caption": "History of Christianity"
+    },
+    {
+      "LCC": "BS",
+      "LCC Range": "BS",
+      "LCC Caption": "Bible",
+      "DDC": 220,
+      "DDC Caption": "The Bible"
+    },
+    {
+      "LCC": "BT",
+      "LCC Range": "BT",
+      "LCC Caption": "Christian doctrinal theology",
+      "DDC": "231 - 239",
+      "DDC Caption": "Christianity & Christian theology"
+    },
+    {
+      "LCC": "BV",
+      "LCC Range": "BV",
+      "LCC Caption": "Practical Theology",
+      "DDC": 240,
+      "DDC Caption": "Christian practice & observance"
+    },
+    {
+      "LCC": "BV",
+      "LCC Range": "BV",
+      "LCC Caption": "Practical Theology",
+      "DDC": 250,
+      "DDC Caption": "Christian pastoral practice & religious orders"
+    },
+    {
+      "LCC": "BV",
+      "LCC Range": "BV",
+      "LCC Caption": "Practical Theology",
+      "DDC": 260,
+      "DDC Caption": "Church organization, social work & worship"
+    },
+    {
+      "LCC": "BX",
+      "LCC Range": "BX",
+      "LCC Caption": "Christian Denominations",
+      "DDC": 280,
+      "DDC Caption": "Christian denominations"
+    },
+    {
+      "LCC": "BX",
+      "LCC Range": "BX",
+      "LCC Caption": "Christian Denominations",
+      "DDC": 305.6,
+      "DDC Caption": "Religious groups"
+    },
+    {
+      "LCC": "BX",
+      "LCC Range": "BX",
+      "LCC Caption": "Christian Denominations",
+      "DDC": 322.1,
+      "DDC Caption": "Religious organizations & groups"
+    },
+    {
+      "LCC": "C",
+      "LCC Range": "C",
+      "LCC Caption": "Auxiliary sciences of history (General)",
+      "DDC": "na",
+      "DDC Caption": "na"
+    },
+    {
+      "LCC": "CB",
+      "LCC Range": "CB",
+      "LCC Caption": "History of civilization",
+      "DDC": 909,
+      "DDC Caption": "World history"
+    },
+    {
+      "LCC": "CC",
+      "LCC Range": "CC",
+      "LCC Caption": "Archaeology",
+      "DDC": 930.1,
+      "DDC Caption": "Archaeology"
+    },
+    {
+      "LCC": "CD",
+      "LCC Range": "CD",
+      "LCC Caption": "Diplomatics. Archives. Seals",
+      "DDC": "929.1 - 929.3",
+      "DDC Caption": "Genealogy; Family histories; Genealogical sources"
+    },
+    {
+      "LCC": "CD",
+      "LCC Range": "CD 5001-6471",
+      "LCC Caption": "Diplomatics. Archives. Seals",
+      "DDC": 737.6,
+      "DDC Caption": "Engraved seals, signets, stamps"
+    },
+    {
+      "LCC": "CE",
+      "LCC Range": "CE",
+      "LCC Caption": "Technical chronology. Calendar",
+      "DDC": "529 - 529.5",
+      "DDC Caption": "Chronology"
+    },
+    {
+      "LCC": "CJ",
+      "LCC Range": "CJ",
+      "LCC Caption": "Numismatics",
+      "DDC": 737,
+      "DDC Caption": "Numismatics & sigillography"
+    },
+    {
+      "LCC": "CN",
+      "LCC Range": "CN",
+      "LCC Caption": "Inscriptions. Epigraphy",
+      "DDC": 411.7,
+      "DDC Caption": "Paleography"
+    },
+    {
+      "LCC": "CR",
+      "LCC Range": "CR",
+      "LCC Caption": "Heraldry",
+      "DDC": 929.6,
+      "DDC Caption": "Heraldry"
+    },
+    {
+      "LCC": "CR",
+      "LCC Range": "CR",
+      "LCC Caption": "Heraldry",
+      "DDC": 929.7,
+      "DDC Caption": "Royal houses, peerage, gentry, orders of knighthood"
+    },
+    {
+      "LCC": "CS",
+      "LCC Range": "CS",
+      "LCC Caption": "Genealogy",
+      "DDC": "929.1 - 929.4",
+      "DDC Caption": "Genealogy; Family histories; Genealogical sources"
+    },
+    {
+      "LCC": "CT",
+      "LCC Range": "CT",
+      "LCC Caption": "Biography (General)",
+      "DDC": 920,
+      "DDC Caption": "Biography & genealogy"
+    },
+    {
+      "LCC": "CT",
+      "LCC Range": "CT",
+      "LCC Caption": "Biography (General)",
+      "DDC": "920.1 - 920.7",
+      "DDC Caption": "Biography of specific classes of persons"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 125",
+      "LCC Caption": "Australian aborigines",
+      "DDC": 305.89915,
+      "DDC Caption": "Australian aborigines"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 125",
+      "LCC Caption": "Australian aborigines",
+      "DDC": 994.0049915,
+      "DDC Caption": "Australian aborigines--History"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 145",
+      "LCC Caption": "Australian Capital Territory. Canberra",
+      "DDC": 994.7,
+      "DDC Caption": "Australian Capital Territory"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 150-180",
+      "LCC Caption": "New South Wales",
+      "DDC": 994.4,
+      "DDC Caption": "New South Wales--History"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 182-198",
+      "LCC Caption": "Tasmania. Van Diemen's Land",
+      "DDC": 994.6,
+      "DDC Caption": "Tasmania--History"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 1-950",
+      "LCC Caption": "Oceania (South Seas), History of",
+      "DDC": "919 - 919.8",
+      "DDC Caption": "Oceania--Description & travel; Oceania--Geography"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 1-950",
+      "LCC Caption": "Oceania (South Seas), History of",
+      "DDC": "990 - 998",
+      "DDC Caption": "Islands of the Pacific"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 200-230",
+      "LCC Caption": "Victoria",
+      "DDC": 994.5,
+      "DDC Caption": "Victoria"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 250-280",
+      "LCC Caption": "Queensland",
+      "DDC": 994.3,
+      "DDC Caption": "Queensland"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 300-330",
+      "LCC Caption": "South Australia",
+      "DDC": 994.23,
+      "DDC Caption": "South Australia"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 350-380",
+      "LCC Caption": "Western Australia",
+      "DDC": 994.1,
+      "DDC Caption": "Western Australia"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 390",
+      "LCC Caption": "Central Australia",
+      "DDC": 994.2,
+      "DDC Caption": "Central Australia"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 391",
+      "LCC Caption": "Northern Australia",
+      "DDC": 994.29,
+      "DDC Caption": "Northern Australia"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 392-398",
+      "LCC Caption": "Northern Territory of Australia",
+      "DDC": 994.29,
+      "DDC Caption": "Northern Territory"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 400-430",
+      "LCC Caption": "New Zealand",
+      "DDC": 993,
+      "DDC Caption": "New Zealand"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 422.8-424",
+      "LCC Caption": "Maoris",
+      "DDC": 305.899442,
+      "DDC Caption": "Maori (New Zealand people)"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 422.8-424",
+      "LCC Caption": "Maoris",
+      "DDC": 993.0049944,
+      "DDC Caption": "Maori (New Zealand people)"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 490",
+      "LCC Caption": "Melanesia (General)",
+      "DDC": "919.5 - 919.509",
+      "DDC Caption": "Oceania--Description & travel; Oceania--Geography"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 490",
+      "LCC Caption": "Melanesia (General)",
+      "DDC": "995 - 995.009",
+      "DDC Caption": "Oceania--History"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 500",
+      "LCC Caption": "Micronesia (General)",
+      "DDC": 996.5,
+      "DDC Caption": "Pacific Islands (Trust Territory)"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 620-629",
+      "LCC Caption": "Hawaiian Islands. Hawaii",
+      "DDC": 996.9,
+      "DDC Caption": "Hawaii"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 739-747",
+      "LCC Caption": "New Guinea",
+      "DDC": "995 - 995.7",
+      "DDC Caption": "New Guinea"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 80-398",
+      "LCC Caption": "Australia",
+      "DDC": 919.4,
+      "DDC Caption": "Australia--Description & travel"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 80-398",
+      "LCC Caption": "Australia",
+      "DDC": 994,
+      "DDC Caption": "Australia"
+    },
+    {
+      "LCC": "DU",
+      "LCC Range": "DU 810-819",
+      "LCC Caption": "Samoan Islands",
+      "DDC": 996.13,
+      "DDC Caption": "American Samoa"
+    },
+    {
+      "LCC": "DX",
+      "LCC Range": "DX 101-301",
+      "LCC Caption": "Gypsies, History of",
+      "DDC": 305.891497,
+      "DDC Caption": "Romanies--social aspects"
+    },
+    {
+      "LCC": "DX",
+      "LCC Range": "DX 101-301",
+      "LCC Caption": "Gypsies, History of",
+      "DDC": 909.0491497,
+      "DDC Caption": "Romanies"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E",
+      "LCC Caption": "America",
+      "DDC": 917.3,
+      "DDC Caption": "United States--description and travel"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E",
+      "LCC Caption": "America",
+      "DDC": "917-917.09",
+      "DDC Caption": "Geography of and travel in North America"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E",
+      "LCC Caption": "America",
+      "DDC": "970-970.05",
+      "DDC Caption": "General history of North America"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E",
+      "LCC Caption": "America",
+      "DDC": 973,
+      "DDC Caption": "United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 11-143",
+      "LCC Caption": "America",
+      "DDC": "917-917.09",
+      "DDC Caption": "Geography of and travel in North America"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 11-143",
+      "LCC Caption": "America",
+      "DDC": "970-970.05",
+      "DDC Caption": "General history of North America"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 31-49.2",
+      "LCC Caption": "North America",
+      "DDC": "917-917.09",
+      "DDC Caption": "Geography of and travel in North America"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 31-49.2",
+      "LCC Caption": "North America",
+      "DDC": "970-970.05",
+      "DDC Caption": "General history of North America"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 51-73",
+      "LCC Caption": "Pre-Columbian America. The Indians",
+      "DDC": 970.00497,
+      "DDC Caption": "American native peoples"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 51-73",
+      "LCC Caption": "Pre-Columbian America. The Indians",
+      "DDC": 970.011,
+      "DDC Caption": "Earliest history to 1492"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 75-99",
+      "LCC Caption": "Indians of North America",
+      "DDC": 305.897,
+      "DDC Caption": "American native peoples--social aspects"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 75-99",
+      "LCC Caption": "Indians of North America",
+      "DDC": 970.00497,
+      "DDC Caption": "American native peoples"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 81-83",
+      "LCC Caption": "Indian wars",
+      "DDC": "973-973.08",
+      "DDC Caption": "United States--History"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 99",
+      "LCC Caption": "Indian tribes and cultures",
+      "DDC": 305.897,
+      "DDC Caption": "American native peoples--social aspects"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 99",
+      "LCC Caption": "Indian tribes and cultures",
+      "DDC": 970.00497,
+      "DDC Caption": "American native peoples"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 101-135",
+      "LCC Caption": "Discovery of America and early explorations",
+      "DDC": 970.01,
+      "DDC Caption": "Early history to 1599"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 103-110",
+      "LCC Caption": "Pre-Columbian period",
+      "DDC": 970.011,
+      "DDC Caption": "Earliest history to 1492"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 111-120",
+      "LCC Caption": "Columbus",
+      "DDC": 970.015,
+      "DDC Caption": "Columbus, Christopher--North American history"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 121-135",
+      "LCC Caption": "Post-Columbian period. El Dorado",
+      "DDC": 970.01,
+      "DDC Caption": "Early history to 1599"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 141-143",
+      "LCC Caption": "Descriptive accounts of America. Earliest to 1810",
+      "DDC": 917,
+      "DDC Caption": "Geography of and travel in North America"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 151-887",
+      "LCC Caption": "United States",
+      "DDC": 917.3,
+      "DDC Caption": "United States--description and travel"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 151-887",
+      "LCC Caption": "United States",
+      "DDC": 973,
+      "DDC Caption": "United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 183.7-183.9",
+      "LCC Caption": "Diplomatic history. Foreign and general relations",
+      "DDC": 327.73,
+      "DDC Caption": "Foreign relations--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 184.5-185.98",
+      "LCC Caption": "Afro-Americans",
+      "DDC": 305.896073,
+      "DDC Caption": "African Americans--social aspects"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 184.5-185.98",
+      "LCC Caption": "Afro-Americans",
+      "DDC": 973.0496073,
+      "DDC Caption": "African Americans"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 186+",
+      "LCC Caption": "Thirteen North American Colonies before 1776,",
+      "DDC": 973.2,
+      "DDC Caption": "Colonial period, 1607-1775"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 186-199",
+      "LCC Caption": "Colonial history (1607-1775)",
+      "DDC": 973.2,
+      "DDC Caption": "Colonial period, 1607-1775"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 196",
+      "LCC Caption": "King William's War, 1689-1697",
+      "DDC": 973.25,
+      "DDC Caption": "Colonial period, 1689-1732"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 197",
+      "LCC Caption": "Queen Anne's War, 1702-1713",
+      "DDC": 973.25,
+      "DDC Caption": "Colonial period, 1689-1732"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 198",
+      "LCC Caption": "King George's War, 1744-1748",
+      "DDC": 973.26,
+      "DDC Caption": "Period of extension of English rule, 1732-1763"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 199",
+      "LCC Caption": "French and Indian War, 1755-1763",
+      "DDC": 973.26,
+      "DDC Caption": "Period of extension of English rule, 1732-1763"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 201-298",
+      "LCC Caption": "The Revolution, 1775-1783",
+      "DDC": 973.3,
+      "DDC Caption": "Periods of Revolution and Confederation, 1775-1789"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 300-453",
+      "LCC Caption": "Revolution to the Civil War, 1775/1783-1861",
+      "DDC": "973.4-973.6",
+      "DDC Caption": "Constitutional period, 1789-1809, 1809-1861"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 302.5-302.6",
+      "LCC Caption": "Biography (Late eighteenth century)",
+      "DDC": 973.3092,
+      "DDC Caption": "United States--History--Revolution, 1775-1783 --Personal narratives"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 303-309",
+      "LCC Caption": "Confederation, 1783-1789",
+      "DDC": 973.318,
+      "DDC Caption": "Period of confederation, 1783-1789"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 310-337",
+      "LCC Caption": "Constitutional period, 1789-1809",
+      "DDC": 973.4,
+      "DDC Caption": "Constitutional period, 1789-1809"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 311-320",
+      "LCC Caption": "Washington's administrations, 1789-1797",
+      "DDC": "973.41-973.43",
+      "DDC Caption": "Administration of George Washington, 1789-1797"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 321-330",
+      "LCC Caption": "John Adams' administration, 1797-1801",
+      "DDC": 973.44,
+      "DDC Caption": "Administration of John Adams, 1797-1801"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 323",
+      "LCC Caption": "Troubles with France, 1796-1800",
+      "DDC": 327.73,
+      "DDC Caption": "Foreign relations--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 323",
+      "LCC Caption": "Troubles with France, 1796-1800",
+      "DDC": 973.44,
+      "DDC Caption": "Administration of John Adams, 1797-1801"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 331-337",
+      "LCC Caption": "Jefferson's administrations, 1801-1809",
+      "DDC": "973.46-973.48",
+      "DDC Caption": "Administration of Thomas Jefferson, 1801-1809"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 333",
+      "LCC Caption": "Purchase of Louisiana, 1803",
+      "DDC": 327.73,
+      "DDC Caption": "Foreign relations--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 333",
+      "LCC Caption": "Purchase of Louisiana, 1803",
+      "DDC": 973.46,
+      "DDC Caption": "Administration of Thomas Jefferson, 1801-1809"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 335",
+      "LCC Caption": "War with Tripoli, 1801-1805",
+      "DDC": 973.47,
+      "DDC Caption": "Tripolitan War, 1801-1805"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 337.5",
+      "LCC Caption": "Nineteenth century (General)",
+      "DDC": "973.5-973.509",
+      "DDC Caption": "United States--Civilization--19th century"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 341-370",
+      "LCC Caption": "Madison's administrations, 1809-1817",
+      "DDC": "973.51-973.53",
+      "DDC Caption": "Administration of James Madison, 1809-1817"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 351.5-364.9",
+      "LCC Caption": "War of 1812",
+      "DDC": 973.52,
+      "DDC Caption": "War of 1812, 1812-1815"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 365",
+      "LCC Caption": "War with Algeria, 1815",
+      "DDC": 973.53,
+      "DDC Caption": "War with Algiers, 1815"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 371-375",
+      "LCC Caption": "Monroe's administrations, 1817-1825",
+      "DDC": 973.54,
+      "DDC Caption": "Administration of James Monroe, 1817-1825"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 373",
+      "LCC Caption": "Missouri Compromise, 1820",
+      "DDC": 326.0973,
+      "DDC Caption": "Slavery and emancipation--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 373",
+      "LCC Caption": "Missouri Compromise, 1820",
+      "DDC": 973.7113,
+      "DDC Caption": "Wilmot Proviso, 1847, and compromises"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 376-380",
+      "LCC Caption": "John Quincy Adams' administration, 1825-1829",
+      "DDC": 973.55,
+      "DDC Caption": "Administration of John Quincy Adams, 1825-1829"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 381-385",
+      "LCC Caption": "Jackson's administrations, 1829-1837",
+      "DDC": 973.56,
+      "DDC Caption": "Administration of Andrew Jackson, 1829-1837"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 386-390",
+      "LCC Caption": "Van Buren's administration, 1837-1841",
+      "DDC": 973.57,
+      "DDC Caption": "Administration of Martin Van Buren, 1837-1841"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 391-392",
+      "LCC Caption": "Harrison's (W. H.) administration, March 4-April 4, 1841",
+      "DDC": 973.58,
+      "DDC Caption": "Administrations of William Henry Harrison and John Tyler, 1841-1845"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 396-400",
+      "LCC Caption": "Tyler's administration, April 4, 1841-1845",
+      "DDC": 973.58,
+      "DDC Caption": "Administrations of William Henry Harrison and John Tyler, 1841-1845"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 398",
+      "LCC Caption": "Northeastern boundary disputes, 1783-1845",
+      "DDC": 327.73,
+      "DDC Caption": "Foreign relations--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 401-415.2",
+      "LCC Caption": "Mexican War, 1846-1848",
+      "DDC": 973.62,
+      "DDC Caption": "Mexican War, 1845-1848"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 415.6-440.5",
+      "LCC Caption": "Middle nineteenth century, 1845/1848-1861",
+      "DDC": 973.6,
+      "DDC Caption": "United States--Politics and government--1845-1861"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 416-420",
+      "LCC Caption": "Polk's administration, 1856-1849",
+      "DDC": 973.61,
+      "DDC Caption": "Administration of James Knox Polk, 1845-1849"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 421-423",
+      "LCC Caption": "Taylor's administration, 1849-July 9, 1850",
+      "DDC": 973.63,
+      "DDC Caption": "Administration of Zachary Taylor, 1849-1850"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 423",
+      "LCC Caption": "Slavery question, 1849-1853",
+      "DDC": 306.3620973,
+      "DDC Caption": "Slavery--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 423",
+      "LCC Caption": "Slavery question, 1849-1853",
+      "DDC": 326.0973,
+      "DDC Caption": "Slavery and emancipation--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 426-430",
+      "LCC Caption": "Fillmore's administration, July 9, 1850-1853",
+      "DDC": 973.64,
+      "DDC Caption": "Administration of Millard Fillmore, 1850-1853"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 431-435",
+      "LCC Caption": "Pierce's administration, 1853-1857",
+      "DDC": 973.66,
+      "DDC Caption": "Administration of Franklin Pierce, 1853-1857"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 433",
+      "LCC Caption": "Slavery question, 1853-1857",
+      "DDC": 306.3620973,
+      "DDC Caption": "Slavery--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 433",
+      "LCC Caption": "Slavery question, 1853-1857",
+      "DDC": 326.0973,
+      "DDC Caption": "Slavery and emancipation--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 436-440.5",
+      "LCC Caption": "Buchanan's administration, 1857-1861",
+      "DDC": 973.68,
+      "DDC Caption": "Administration of James Buchanan, 1857-1861"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 438",
+      "LCC Caption": "Slavery question, 1557-1861",
+      "DDC": 306.3620973,
+      "DDC Caption": "Slavery--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 438",
+      "LCC Caption": "Slavery question, 1557-1861",
+      "DDC": 326.0973,
+      "DDC Caption": "Slavery and emancipation--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 441-453",
+      "LCC Caption": "Slavery in the United States. Antislavery movements",
+      "DDC": 306.3620973,
+      "DDC Caption": "Slavery--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 441-453",
+      "LCC Caption": "Slavery in the United States. Antislavery movements",
+      "DDC": 326.0973,
+      "DDC Caption": "Slavery and emancipation--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 441-453",
+      "LCC Caption": "Slavery in the United States. Antislavery movements",
+      "DDC": 973.7114,
+      "DDC Caption": "Abolition movement"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 456-459",
+      "LCC Caption": "Lincoln's administrations, 1861-April 15, 1865",
+      "DDC": "973.7-973.7109",
+      "DDC Caption": "Administration of Abraham Lincoln, 1861-1865"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 456-655",
+      "LCC Caption": "Civil War period, 1861-1865",
+      "DDC": 973.7,
+      "DDC Caption": "Administration of Abraham Lincoln, 1861-1865; Civil War"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 461-655",
+      "LCC Caption": "Civil War, 1861-1865",
+      "DDC": 973.7,
+      "DDC Caption": "Administration of Abraham Lincoln, 1861-1865; Civil War"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 482-489",
+      "LCC Caption": "Confederate States of America",
+      "DDC": 973.713,
+      "DDC Caption": "The South and secession"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 661-738",
+      "LCC Caption": "Late nineteenth century, 1865-1900",
+      "DDC": 973.8,
+      "DDC Caption": "Reconstruction period, 1865-1901"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 666-670",
+      "LCC Caption": "Johnson's administration, April 15, 1865-1869",
+      "DDC": 973.81,
+      "DDC Caption": "Administration of Andrew Johnson, 1865-1869"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 668",
+      "LCC Caption": "Reconstruction, 1865-1877",
+      "DDC": "973.8-973.809",
+      "DDC Caption": "Reconstruction period, 1865-1901"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 669",
+      "LCC Caption": "Purchase of Alaska, 1867",
+      "DDC": 327.73,
+      "DDC Caption": "Foreign relations--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 671-680",
+      "LCC Caption": "Grant's administrations, 1869-1877",
+      "DDC": 973.82,
+      "DDC Caption": "Administration of Ulysses Simpson Grant, 1869-1877"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 681-685",
+      "LCC Caption": "Hayes' administration, 1877-1881",
+      "DDC": 973.83,
+      "DDC Caption": "Administration of Rutherford Birchard Hayes, 1877-1881"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 686-687.9",
+      "LCC Caption": "Garfield's administration, March 4-September 19, 1881",
+      "DDC": 973.84,
+      "DDC Caption": "Administrations of James Abram Garfield and Chester Alan Arthur, 1881-1885"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 691-695",
+      "LCC Caption": "Arthur's administration, September 19, 1881-1885",
+      "DDC": 973.84,
+      "DDC Caption": "Administrations of James Abram Garfield and Chester Alan Arthur, 1881-1885"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 696-700",
+      "LCC Caption": "Cleveland's first administration, 1885-1889",
+      "DDC": 973.85,
+      "DDC Caption": "First administration of Grover Cleveland, 1885-1889"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 701-705",
+      "LCC Caption": "Benjamin Harrison's administration, 1889-1893",
+      "DDC": 973.86,
+      "DDC Caption": "Administration of Benjamin Harrison, 1889-1893"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 706-710",
+      "LCC Caption": "Cleveland's second administration, 1893-1897",
+      "DDC": 973.87,
+      "DDC Caption": "Second administration of Grover Cleveland, 1893-1897"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 711-738",
+      "LCC Caption": "McKinley's first administration, 1897-1901",
+      "DDC": 973.88,
+      "DDC Caption": "Administration of William McKinley, 1897-1901"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 713",
+      "LCC Caption": "Annexation in 1898 of Hawaii, Philippines, and Puerto Rico",
+      "DDC": 327.73,
+      "DDC Caption": "Foreign relations--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 714-735",
+      "LCC Caption": "War of 1898 (Spanish-American War)",
+      "DDC": 973.89,
+      "DDC Caption": "Spanish-American War, 1898"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 740-837.7",
+      "LCC Caption": "Twentieth century",
+      "DDC": 973.91,
+      "DDC Caption": "1901-1953"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 751",
+      "LCC Caption": "McKinley's second administration, March 4-Sept 14, 1901",
+      "DDC": 973.88,
+      "DDC Caption": "Administration of William McKinley, 1897-1901"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 756-760",
+      "LCC Caption": "Theodore Roosevelt's administrations, Sept 14, 1901-1909",
+      "DDC": 973.911,
+      "DDC Caption": "Administration of Theodore Roosevelt, 1901-1909"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 761-765",
+      "LCC Caption": "Taft's administration, 1909-1913",
+      "DDC": 973.912,
+      "DDC Caption": "Administration of William Howard Taft, 1909-1913"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 766-783",
+      "LCC Caption": "Wilson's administrations, 1913-1921",
+      "DDC": 973.913,
+      "DDC Caption": "Administration of Woodrow Wilson, 1913-1921"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 768",
+      "LCC Caption": "Purchase of Danish West Indies (Virgin Islands, 1917)",
+      "DDC": 327.73,
+      "DDC Caption": "Foreign relations--United States"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 785-786",
+      "LCC Caption": "Harding's administration, 1921-August 2, 1923",
+      "DDC": 973.914,
+      "DDC Caption": "Administration of Warren Gamaliel Harding, 1921-1923"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 791-796",
+      "LCC Caption": "Coolidge's administration, August 2, 1923-1929",
+      "DDC": 973.915,
+      "DDC Caption": "Administration of Calvin Coolidge, 1923-1929"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 801-805",
+      "LCC Caption": "Hoover's administration, 1929-1933",
+      "DDC": 973.916,
+      "DDC Caption": "Administration of Herbert Clark Hoover, 1929-1933"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 806-812",
+      "LCC Caption": "Roosevelt's (F. D.) administrations, 1933-Apr 12, 1945",
+      "DDC": 973.917,
+      "DDC Caption": "Administration of Franklin Delano Roosevelt, 1933-1945"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 813-816",
+      "LCC Caption": "Truman's administrations, April 12, 1945-1953",
+      "DDC": 973.918,
+      "DDC Caption": "Administration of Harry S Truman, 1945-1953"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 835-837.7",
+      "LCC Caption": "Eisenhower's administrations, 1953-1961",
+      "DDC": 973.921,
+      "DDC Caption": "Administration of Dwight David Eisenhower, 1953-1961"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 838-889",
+      "LCC Caption": "Later twentieth century, 1961-",
+      "DDC": 973.92,
+      "DDC Caption": "1953-2001"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 841-843",
+      "LCC Caption": "Kennedy's administration, 1961-November 22, 1963",
+      "DDC": 973.922,
+      "DDC Caption": "Administration of John Fitzgerald Kennedy, 1961-1963"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 846-851",
+      "LCC Caption": "Johnson's administrations, November 22, 1963-1969",
+      "DDC": 973.923,
+      "DDC Caption": "Administration of Lyndon Baines Johnson, 1963-1969"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 855-861",
+      "LCC Caption": "Nixon's administrations, 1969-August 9, 1974",
+      "DDC": 973.924,
+      "DDC Caption": "Administration of Richard Milhous Nixon, 1969-1974"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 865-868",
+      "LCC Caption": "Ford's administration, August 9, 1974-1977",
+      "DDC": 973.925,
+      "DDC Caption": "Administration of Gerald Rudolph Ford, 1974-1977"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 872-875",
+      "LCC Caption": "Carter's administration, 1977-1981",
+      "DDC": 973.926,
+      "DDC Caption": "Administration of Jimmy (James Earl) Carter, 1977-1981"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 876-880",
+      "LCC Caption": "Reagan's administrations, 1981-1989",
+      "DDC": 973.927,
+      "DDC Caption": "Administration of Ronald Reagan, 1981-1989"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 881-884",
+      "LCC Caption": "Bush's administration, 1989-1993",
+      "DDC": 973.928,
+      "DDC Caption": "Administration of George Bush, 1989-1993"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 885-887",
+      "LCC Caption": "Clinton's administrations, 1993-2001",
+      "DDC": 973.929,
+      "DDC Caption": "Administration of Bill Clinton, 1993-2001"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 895+",
+      "LCC Caption": "Twenty-first century",
+      "DDC": 973.93,
+      "DDC Caption": "2001-"
+    },
+    {
+      "LCC": "E",
+      "LCC Range": "E 902",
+      "LCC Caption": "George W. Bush's administration, 2001",
+      "DDC": 973.931,
+      "DDC Caption": "Administration of George W. Bush, 2001"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F",
+      "LCC Caption": "History: America",
+      "DDC": "917-918",
+      "DDC Caption": "America--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F",
+      "LCC Caption": "History: America",
+      "DDC": "917.4 -917.409",
+      "DDC Caption": "Northeastern U. S. (New England & Middle Atlantic states)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F",
+      "LCC Caption": "History: America",
+      "DDC": "970-980",
+      "DDC Caption": "History of North America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1-15",
+      "LCC Caption": "New England",
+      "DDC": "917.4 -917.409",
+      "DDC Caption": "Northeastern U. S. (New England & Middle Atlantic states)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1-15",
+      "LCC Caption": "New England",
+      "DDC": "974 -974.04",
+      "DDC Caption": "Northeastern U. S. (New England & Middle Atlantic states)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1-975",
+      "LCC Caption": "United States local history",
+      "DDC": "917.4 -917.9",
+      "DDC Caption": "Specific states of United States--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1-975",
+      "LCC Caption": "United States local history",
+      "DDC": "974 -979",
+      "DDC Caption": "Specific states of United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 16-30",
+      "LCC Caption": "Maine",
+      "DDC": 917.41,
+      "DDC Caption": "Maine--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 16-30",
+      "LCC Caption": "Maine",
+      "DDC": 974.1,
+      "DDC Caption": "Maine"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 31-45",
+      "LCC Caption": "New Hampshire",
+      "DDC": 917.42,
+      "DDC Caption": "New Hampshire--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 31-45",
+      "LCC Caption": "New Hampshire",
+      "DDC": 974.2,
+      "DDC Caption": "New Hampshire"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 46-60",
+      "LCC Caption": "Vermont",
+      "DDC": 917.43,
+      "DDC Caption": "Vermont--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 46-60",
+      "LCC Caption": "Vermont",
+      "DDC": 974.3,
+      "DDC Caption": "Vermont"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 61-75",
+      "LCC Caption": "Massachusetts",
+      "DDC": 917.44,
+      "DDC Caption": "Massachusetts--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 61-75",
+      "LCC Caption": "Massachusetts",
+      "DDC": 974.4,
+      "DDC Caption": "Massachusetts"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 76-90",
+      "LCC Caption": "Rhode Island",
+      "DDC": 917.45,
+      "DDC Caption": "Rhode Island--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 76-90",
+      "LCC Caption": "Rhode Island",
+      "DDC": 974.5,
+      "DDC Caption": "Rhode Island"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 91-105",
+      "LCC Caption": "Connecticut",
+      "DDC": 917.46,
+      "DDC Caption": "Connecticut--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 91-105",
+      "LCC Caption": "Connecticut",
+      "DDC": 974.6,
+      "DDC Caption": "Connecticut"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 106",
+      "LCC Caption": "Atlantic coast. Middle Atlantic States",
+      "DDC": "917.4 -917.409",
+      "DDC Caption": "Northeastern U. S. (New England & Middle Atlantic states)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 106",
+      "LCC Caption": "Atlantic coast. Middle Atlantic States",
+      "DDC": "974 -974.04",
+      "DDC Caption": "Northeastern U. S. (New England & Middle Atlantic states)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 116-130",
+      "LCC Caption": "New York",
+      "DDC": 917.47,
+      "DDC Caption": "New York (State)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 116-130",
+      "LCC Caption": "New York",
+      "DDC": 974.7,
+      "DDC Caption": "New York (State)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 122.1",
+      "LCC Caption": "New Netherlands to 1664",
+      "DDC": 974.702,
+      "DDC Caption": "New York (State)--1620-1776"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 131-145",
+      "LCC Caption": "New Jersey",
+      "DDC": 917.49,
+      "DDC Caption": "New Jersey--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 131-145",
+      "LCC Caption": "New Jersey",
+      "DDC": 974.9,
+      "DDC Caption": "New Jersey"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 146-160",
+      "LCC Caption": "Pennsylvania",
+      "DDC": 917.48,
+      "DDC Caption": "Pennsylvania--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 146-160",
+      "LCC Caption": "Pennsylvania",
+      "DDC": 974.8,
+      "DDC Caption": "Pennsylvania"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 161-175",
+      "LCC Caption": "Delaware",
+      "DDC": 917.51,
+      "DDC Caption": "Delaware--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 161-175",
+      "LCC Caption": "Delaware",
+      "DDC": 975.1,
+      "DDC Caption": "Delaware"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 167",
+      "LCC Caption": "New Sweden (Dutch possession, 1655-1664)",
+      "DDC": 975.102,
+      "DDC Caption": "Delaware--1620-1776"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 176-190",
+      "LCC Caption": "Maryland",
+      "DDC": 917.52,
+      "DDC Caption": "Maryland--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 176-190",
+      "LCC Caption": "Maryland",
+      "DDC": 975.2,
+      "DDC Caption": "Maryland"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 191-205",
+      "LCC Caption": "District of Columbia. Washington",
+      "DDC": 917.53,
+      "DDC Caption": "District of Columbia (Washington)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 191-205",
+      "LCC Caption": "District of Columbia. Washington",
+      "DDC": 975.3,
+      "DDC Caption": "District of Columbia (Washington)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 206-220",
+      "LCC Caption": "The South. South Atlantic States",
+      "DDC": "917.5 -917.504",
+      "DDC Caption": "Southeastern United States (South Atlantic states)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 206-220",
+      "LCC Caption": "The South. South Atlantic States",
+      "DDC": "975 -975.04",
+      "DDC Caption": "Southeastern United States (South Atlantic states)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 221-235",
+      "LCC Caption": "Virginia",
+      "DDC": 917.55,
+      "DDC Caption": "Virginia--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 221-235",
+      "LCC Caption": "Virginia",
+      "DDC": 975.5,
+      "DDC Caption": "Virginia"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 236-250",
+      "LCC Caption": "West Virginia",
+      "DDC": 917.54,
+      "DDC Caption": "West Virginia--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 236-250",
+      "LCC Caption": "West Virginia",
+      "DDC": 975.4,
+      "DDC Caption": "West Virginia"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 251-265",
+      "LCC Caption": "North Carolina",
+      "DDC": 917.56,
+      "DDC Caption": "North Carolina--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 251-265",
+      "LCC Caption": "North Carolina",
+      "DDC": 975.6,
+      "DDC Caption": "North Carolina"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 266-280",
+      "LCC Caption": "South Carolina",
+      "DDC": 917.57,
+      "DDC Caption": "South Carolina--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 266-280",
+      "LCC Caption": "South Carolina",
+      "DDC": 975.7,
+      "DDC Caption": "South Carolina"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 281-295",
+      "LCC Caption": "Georgia",
+      "DDC": 917.58,
+      "DDC Caption": "Georgia--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 281-295",
+      "LCC Caption": "Georgia",
+      "DDC": 975.8,
+      "DDC Caption": "Georgia"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 296-301",
+      "LCC Caption": "Gulf States. West Florida",
+      "DDC": "917.6 -917.609",
+      "DDC Caption": "South central United States; Gulf Coast states--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 296-301",
+      "LCC Caption": "Gulf States. West Florida",
+      "DDC": "976 -976.04",
+      "DDC Caption": "South central United States; Gulf Coast states"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 301",
+      "LCC Caption": "British East and West Florida, 1763-1783",
+      "DDC": 975.901,
+      "DDC Caption": "Early history to 1763"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 301",
+      "LCC Caption": "British East and West Florida, 1763-1783",
+      "DDC": 975.902,
+      "DDC Caption": "English period, 1763-1783"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 306-320",
+      "LCC Caption": "Florida",
+      "DDC": 917.59,
+      "DDC Caption": "Florida--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 306-320",
+      "LCC Caption": "Florida",
+      "DDC": 975.9,
+      "DDC Caption": "Florida"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 314",
+      "LCC Caption": "Florida, Early to 1821",
+      "DDC": "975.01 -975.903",
+      "DDC Caption": "Florida--History--To 1821"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 321-335",
+      "LCC Caption": "Alabama",
+      "DDC": 917.61,
+      "DDC Caption": "Alabama--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 321-335",
+      "LCC Caption": "Alabama",
+      "DDC": 976.1,
+      "DDC Caption": "Alabama"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 336-350",
+      "LCC Caption": "Mississippi",
+      "DDC": 917.62,
+      "DDC Caption": "Mississippi--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 336-350",
+      "LCC Caption": "Mississippi",
+      "DDC": 976.2,
+      "DDC Caption": "Mississippi"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 350.5-355",
+      "LCC Caption": "Mississippi River and Valley. Middle West",
+      "DDC": "917.7 -917.709",
+      "DDC Caption": "North central United States; Lake states--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 350.5-355",
+      "LCC Caption": "Mississippi River and Valley. Middle West",
+      "DDC": "977 -977.03",
+      "DDC Caption": "North central United States; Lake states"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 366-380",
+      "LCC Caption": "Louisiana",
+      "DDC": 917.63,
+      "DDC Caption": "Louisiana--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 366-380",
+      "LCC Caption": "Louisiana",
+      "DDC": 976.3,
+      "DDC Caption": "Louisiana"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 372",
+      "LCC Caption": "French Louisiana, 1698-1803",
+      "DDC": 976.302,
+      "DDC Caption": "French period, 1718-1763"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 372",
+      "LCC Caption": "French Louisiana, 1698-1803",
+      "DDC": 976.304,
+      "DDC Caption": "French and territorial periods, 1803-1812"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 381-395",
+      "LCC Caption": "Texas",
+      "DDC": 917.64,
+      "DDC Caption": "Texas--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 381-395",
+      "LCC Caption": "Texas",
+      "DDC": 976.4,
+      "DDC Caption": "Texas"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 396",
+      "LCC Caption": "Old Southwest. Lower Mississippi Valley",
+      "DDC": "917.6 -917.609",
+      "DDC Caption": "South central United States; Gulf Coast states--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 396",
+      "LCC Caption": "Old Southwest. Lower Mississippi Valley",
+      "DDC": "976 -976.04",
+      "DDC Caption": "South central United States; Gulf Coast states"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 406-420",
+      "LCC Caption": "Arkansas",
+      "DDC": 917.67,
+      "DDC Caption": "Arkansas--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 406-420",
+      "LCC Caption": "Arkansas",
+      "DDC": 976.7,
+      "DDC Caption": "Arkansas"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 431-445",
+      "LCC Caption": "Tennessee",
+      "DDC": 917.68,
+      "DDC Caption": "Tennessee--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 431-445",
+      "LCC Caption": "Tennessee",
+      "DDC": 976.8,
+      "DDC Caption": "Tennessee"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 446-460",
+      "LCC Caption": "Kentucky",
+      "DDC": 917.69,
+      "DDC Caption": "Kentucky--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 446-460",
+      "LCC Caption": "Kentucky",
+      "DDC": 976.9,
+      "DDC Caption": "Kentucky"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 461-475",
+      "LCC Caption": "Missouri",
+      "DDC": 917.78,
+      "DDC Caption": "Missouri--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 461-475",
+      "LCC Caption": "Missouri",
+      "DDC": 977.8,
+      "DDC Caption": "Missouri"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 476-485",
+      "LCC Caption": "Old Northwest. Northwest Territory",
+      "DDC": "917.7 -917.709",
+      "DDC Caption": "North central United States; Lake states--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 476-485",
+      "LCC Caption": "Old Northwest. Northwest Territory",
+      "DDC": "977 -977.03",
+      "DDC Caption": "North central United States; Lake states"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 486-500",
+      "LCC Caption": "Ohio",
+      "DDC": 917.71,
+      "DDC Caption": "Ohio--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 486-500",
+      "LCC Caption": "Ohio",
+      "DDC": 977.1,
+      "DDC Caption": "Ohio"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 516-520",
+      "LCC Caption": "Ohio River and Valley",
+      "DDC": "917.7 -917.709",
+      "DDC Caption": "North central United States; Lake states--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 516-520",
+      "LCC Caption": "Ohio River and Valley",
+      "DDC": "977 -977.03",
+      "DDC Caption": "North central United States; Lake states"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 521-535",
+      "LCC Caption": "Indiana",
+      "DDC": 917.72,
+      "DDC Caption": "Indiana--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 521-535",
+      "LCC Caption": "Indiana",
+      "DDC": 977.2,
+      "DDC Caption": "Indiana"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 536-550",
+      "LCC Caption": "Illinois",
+      "DDC": 917.73,
+      "DDC Caption": "Illinois--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 536-550",
+      "LCC Caption": "Illinois",
+      "DDC": 977.3,
+      "DDC Caption": "Illinois"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 550.5-553.2",
+      "LCC Caption": "Lake Region. Great Lakes",
+      "DDC": "917.7 -917.709",
+      "DDC Caption": "North central United States; Lake states--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 550.5-553.2",
+      "LCC Caption": "Lake Region. Great Lakes",
+      "DDC": "977 -977.03",
+      "DDC Caption": "North central United States; Lake states"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 561-575",
+      "LCC Caption": "Michigan",
+      "DDC": 917.74,
+      "DDC Caption": "Michigan--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 561-575",
+      "LCC Caption": "Michigan",
+      "DDC": 977.4,
+      "DDC Caption": "Michigan"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 576-590",
+      "LCC Caption": "Wisconsin",
+      "DDC": 917.75,
+      "DDC Caption": "Wisconsin--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 576-590",
+      "LCC Caption": "Wisconsin",
+      "DDC": 977.5,
+      "DDC Caption": "Wisconsin"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 590.3-596.3",
+      "LCC Caption": "West, The. Trans-Mississippi Region. Great Plains",
+      "DDC": "917.8 -917.809",
+      "DDC Caption": "Western United States--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 590.3-596.3",
+      "LCC Caption": "West, The. Trans-Mississippi Region. Great Plains",
+      "DDC": "978 -978.03",
+      "DDC Caption": "Western United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 597",
+      "LCC Caption": "Northwest, The",
+      "DDC": "917.8 -917.809",
+      "DDC Caption": "Western United States--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 597",
+      "LCC Caption": "Northwest, The",
+      "DDC": "978 -978.03",
+      "DDC Caption": "Western United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 598",
+      "LCC Caption": "Missouri River and Valley",
+      "DDC": "917.8 -917.809",
+      "DDC Caption": "Western United States--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 598",
+      "LCC Caption": "Missouri River and Valley",
+      "DDC": "978 -978.03",
+      "DDC Caption": "Western United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 601-615",
+      "LCC Caption": "Minnesota",
+      "DDC": 917.76,
+      "DDC Caption": "Minnesota--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 601-615",
+      "LCC Caption": "Minnesota",
+      "DDC": 977.6,
+      "DDC Caption": "Minnesota"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 616-630",
+      "LCC Caption": "Iowa",
+      "DDC": 917.77,
+      "DDC Caption": "Iowa--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 616-630",
+      "LCC Caption": "Iowa",
+      "DDC": 977.7,
+      "DDC Caption": "Iowa"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 631-645",
+      "LCC Caption": "North Dakota",
+      "DDC": 917.84,
+      "DDC Caption": "North Dakota--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 631-645",
+      "LCC Caption": "North Dakota",
+      "DDC": 978.4,
+      "DDC Caption": "North Dakota"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 646-660",
+      "LCC Caption": "South Dakota",
+      "DDC": 917.83,
+      "DDC Caption": "South Dakota--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 646-660",
+      "LCC Caption": "South Dakota",
+      "DDC": 978.3,
+      "DDC Caption": "South Dakota"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 661-675",
+      "LCC Caption": "Nebraska",
+      "DDC": 917.82,
+      "DDC Caption": "Nebraska--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 661-675",
+      "LCC Caption": "Nebraska",
+      "DDC": 978.2,
+      "DDC Caption": "Nebraska"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 676-690",
+      "LCC Caption": "Kansas",
+      "DDC": 917.81,
+      "DDC Caption": "Kansas--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 676-690",
+      "LCC Caption": "Kansas",
+      "DDC": 978.1,
+      "DDC Caption": "Kansas"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 691-705",
+      "LCC Caption": "Oklahoma",
+      "DDC": 917.66,
+      "DDC Caption": "Oklahoma--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 691-705",
+      "LCC Caption": "Oklahoma",
+      "DDC": 976.6,
+      "DDC Caption": "Oklahoma"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 721-722",
+      "LCC Caption": "Rocky Mountains. Yellowstone National Park",
+      "DDC": "917.8 -917.809",
+      "DDC Caption": "Western United States--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 721-722",
+      "LCC Caption": "Rocky Mountains. Yellowstone National Park",
+      "DDC": 917.8752,
+      "DDC Caption": "Yellowstone National Park--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 721-722",
+      "LCC Caption": "Rocky Mountains. Yellowstone National Park",
+      "DDC": "978 -978.03",
+      "DDC Caption": "Western United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 721-722",
+      "LCC Caption": "Rocky Mountains. Yellowstone National Park",
+      "DDC": 978.752,
+      "DDC Caption": "Yellowstone National Park"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 726-740",
+      "LCC Caption": "Montana",
+      "DDC": 917.86,
+      "DDC Caption": "Montana--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 726-740",
+      "LCC Caption": "Montana",
+      "DDC": 978.6,
+      "DDC Caption": "Montana"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 741-755",
+      "LCC Caption": "Idaho",
+      "DDC": 917.96,
+      "DDC Caption": "Idaho--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 741-755",
+      "LCC Caption": "Idaho",
+      "DDC": 979.6,
+      "DDC Caption": "Idaho"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 756-770",
+      "LCC Caption": "Wyoming",
+      "DDC": 917.87,
+      "DDC Caption": "Wyoming--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 756-770",
+      "LCC Caption": "Wyoming",
+      "DDC": 978.7,
+      "DDC Caption": "Wyoming"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 771-785",
+      "LCC Caption": "Colorado",
+      "DDC": 917.88,
+      "DDC Caption": "Colorado--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 771-785",
+      "LCC Caption": "Colorado",
+      "DDC": 978.8,
+      "DDC Caption": "Colorado"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 786-790",
+      "LCC Caption": "New Southwest. Colorado River, Canyon, and Valley",
+      "DDC": "917.9 -917.909",
+      "DDC Caption": "Great Basin and Pacific Slope region--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 786-790",
+      "LCC Caption": "New Southwest. Colorado River, Canyon, and Valley",
+      "DDC": 917.913,
+      "DDC Caption": "Colorado Plateau region--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 786-790",
+      "LCC Caption": "New Southwest. Colorado River, Canyon, and Valley",
+      "DDC": "979 -979.03",
+      "DDC Caption": "Great Basin and Pacific Slope region"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 786-790",
+      "LCC Caption": "New Southwest. Colorado River, Canyon, and Valley",
+      "DDC": 979.13,
+      "DDC Caption": "Colorado Plateau region"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 791-805",
+      "LCC Caption": "New Mexico",
+      "DDC": 917.89,
+      "DDC Caption": "New Mexico--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 791-805",
+      "LCC Caption": "New Mexico",
+      "DDC": 978.9,
+      "DDC Caption": "New Mexico"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 806-820",
+      "LCC Caption": "Arizona",
+      "DDC": 917.91,
+      "DDC Caption": "Arizona--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 806-820",
+      "LCC Caption": "Arizona",
+      "DDC": 979.1,
+      "DDC Caption": "Arizona"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 821-835",
+      "LCC Caption": "Utah",
+      "DDC": 917.92,
+      "DDC Caption": "Utah--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 821-835",
+      "LCC Caption": "Utah",
+      "DDC": 979.2,
+      "DDC Caption": "Utah"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 836-850",
+      "LCC Caption": "Nevada",
+      "DDC": 917.93,
+      "DDC Caption": "Nevada--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 836-850",
+      "LCC Caption": "Nevada",
+      "DDC": 979.3,
+      "DDC Caption": "Nevada"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 850.5-851.5",
+      "LCC Caption": "Pacific States",
+      "DDC": "917.9 -917.909",
+      "DDC Caption": "Great Basin and Pacific Slope region--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 850.5-851.5",
+      "LCC Caption": "Pacific States",
+      "DDC": "979 -979.03",
+      "DDC Caption": "Great Basin and Pacific Slope region"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 851.7",
+      "LCC Caption": "Cascade Range",
+      "DDC": "917.95 -917.9509",
+      "DDC Caption": "Oregon--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 851.7",
+      "LCC Caption": "Cascade Range",
+      "DDC": "979.5 -979.504",
+      "DDC Caption": "Oregon"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 852-854",
+      "LCC Caption": "Pacific Northwest. Columbia River & Valley.",
+      "DDC": "917.95 -917.9509",
+      "DDC Caption": "Oregon--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 852-854",
+      "LCC Caption": "Pacific Northwest. Columbia River & Valley.",
+      "DDC": 917.97,
+      "DDC Caption": "Washington--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 852-854",
+      "LCC Caption": "Pacific Northwest. Columbia River & Valley.",
+      "DDC": "979.5 -979.504",
+      "DDC Caption": "Oregon"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 852-854",
+      "LCC Caption": "Pacific Northwest. Columbia River & Valley.",
+      "DDC": 979.7,
+      "DDC Caption": "Washington"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 856-870",
+      "LCC Caption": "California",
+      "DDC": 917.94,
+      "DDC Caption": "California--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 856-870",
+      "LCC Caption": "California",
+      "DDC": 979.4,
+      "DDC Caption": "California"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 871-885",
+      "LCC Caption": "Oregon",
+      "DDC": 917.95,
+      "DDC Caption": "Oregon--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 871-885",
+      "LCC Caption": "Oregon",
+      "DDC": 979.5,
+      "DDC Caption": "Oregon"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 886-900",
+      "LCC Caption": "Washington",
+      "DDC": 917.97,
+      "DDC Caption": "Washington--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 886-900",
+      "LCC Caption": "Washington",
+      "DDC": 979.7,
+      "DDC Caption": "Washington"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 901-951",
+      "LCC Caption": "Alaska",
+      "DDC": 917.98,
+      "DDC Caption": "Alaska--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 901-951",
+      "LCC Caption": "Alaska",
+      "DDC": 979.8,
+      "DDC Caption": "Alaska"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 951",
+      "LCC Caption": "Bering Sea and Aleutian Islands",
+      "DDC": 917.984,
+      "DDC Caption": "Southwestern Alaska--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 951",
+      "LCC Caption": "Bering Sea and Aleutian Islands",
+      "DDC": 979.84,
+      "DDC Caption": "Southwestern Alaska"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 965",
+      "LCC Caption": "Territories of the United States (General)",
+      "DDC": 325.373,
+      "DDC Caption": "Colonization by the United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 970",
+      "LCC Caption": "Insular possessions of the United States (General)",
+      "DDC": 325.373,
+      "DDC Caption": "Colonization by the United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 975",
+      "LCC Caption": "Central American, West Indian",
+      "DDC": 325.373,
+      "DDC Caption": "Colonization by the United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1001-1140",
+      "LCC Caption": "Canada",
+      "DDC": 917.1,
+      "DDC Caption": "Canada--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1001-1140",
+      "LCC Caption": "British America. Canada",
+      "DDC": 917.1,
+      "DDC Caption": "Canada--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1001-1140",
+      "LCC Caption": "Canada",
+      "DDC": 971,
+      "DDC Caption": "Canada"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1001-1140",
+      "LCC Caption": "British America. Canada",
+      "DDC": 971,
+      "DDC Caption": "Canada"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1030, F 1038",
+      "LCC Caption": "New France and Acadia, 1600-1763",
+      "DDC": "971.01 -971.018",
+      "DDC Caption": "Early history to 1763"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1030, F 1038",
+      "LCC Caption": "New France and Acadia, 1600-1763",
+      "DDC": "971.601 -971.604",
+      "DDC Caption": "Early history to 1763"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1035.8",
+      "LCC Caption": "Maritime provinces. Atlantic coast of Canada",
+      "DDC": "917.15 -917.1509",
+      "DDC Caption": "Atlantic Provinces; Maritime Provinces--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1035.8",
+      "LCC Caption": "Maritime provinces. Atlantic coast of Canada",
+      "DDC": "971.5 -971.504",
+      "DDC Caption": "Atlantic Provinces; Maritime Provinces"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1036-1040",
+      "LCC Caption": "Nova Scotia. Acadia",
+      "DDC": 917.16,
+      "DDC Caption": "Nova Scotia--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1036-1040",
+      "LCC Caption": "Nova Scotia. Acadia",
+      "DDC": 971.6,
+      "DDC Caption": "Nova Scotia"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1041-1045",
+      "LCC Caption": "New Brunswick",
+      "DDC": "917.151 -917.155",
+      "DDC Caption": "New Brunswick--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1041-1045",
+      "LCC Caption": "New Brunswick",
+      "DDC": "971.51 -971.55",
+      "DDC Caption": "New Brunswick"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1046-1049.7",
+      "LCC Caption": "Prince Edward Island",
+      "DDC": 917.17,
+      "DDC Caption": "Prince Edward Island--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1046-1049.7",
+      "LCC Caption": "Prince Edward Island",
+      "DDC": 971.7,
+      "DDC Caption": "Prince Edward Island"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1050",
+      "LCC Caption": "St. Lawrence Gulf, River and Valley (General)",
+      "DDC": "917.14 -917.1409",
+      "DDC Caption": "Quebec--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1050",
+      "LCC Caption": "St. Lawrence Gulf, River and Valley (General)",
+      "DDC": "971.4 -971.404",
+      "DDC Caption": "Quebec"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1051-1055",
+      "LCC Caption": "Quebec",
+      "DDC": 917.14,
+      "DDC Caption": "Quebec--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1051-1055",
+      "LCC Caption": "Quebec",
+      "DDC": 971.4,
+      "DDC Caption": "Quebec"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1056-1059.7",
+      "LCC Caption": "Ontario",
+      "DDC": 917.13,
+      "DDC Caption": "Ontario--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1056-1059.7",
+      "LCC Caption": "Ontario",
+      "DDC": 971.3,
+      "DDC Caption": "Ontario"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1060-1060.97",
+      "LCC Caption": "Canadian Northwest. Northwest Territories",
+      "DDC": "917.12 -917.1209",
+      "DDC Caption": "Western Canada--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1060-1060.97",
+      "LCC Caption": "Canadian Northwest. Northwest Territories",
+      "DDC": "971.2 -971.203",
+      "DDC Caption": "Western Canada"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1061-1065",
+      "LCC Caption": "Manitoba",
+      "DDC": 917.127,
+      "DDC Caption": "Manitoba--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1061-1065",
+      "LCC Caption": "Manitoba",
+      "DDC": 971.27,
+      "DDC Caption": "Manitoba"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1067",
+      "LCC Caption": "Assiniboia",
+      "DDC": "917.12 -917.1209",
+      "DDC Caption": "Western Canada--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1067",
+      "LCC Caption": "Assiniboia",
+      "DDC": "917.124 -917.12409",
+      "DDC Caption": "Saskatchewan--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1067",
+      "LCC Caption": "Assiniboia",
+      "DDC": "971.2 -971.202",
+      "DDC Caption": "Western Canada"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1067",
+      "LCC Caption": "Assiniboia",
+      "DDC": "971.24 -971.2402",
+      "DDC Caption": "Saskatchewan"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1070-1074.7",
+      "LCC Caption": "Saskatchewan",
+      "DDC": 917.124,
+      "DDC Caption": "Saskatchewan--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1070-1074.7",
+      "LCC Caption": "Saskatchewan",
+      "DDC": 971.24,
+      "DDC Caption": "Saskatchewan"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1075-1080",
+      "LCC Caption": "Alberta",
+      "DDC": 917.123,
+      "DDC Caption": "Alberta--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1075-1080",
+      "LCC Caption": "Alberta",
+      "DDC": 971.23,
+      "DDC Caption": "Alberta"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1086-1089.7",
+      "LCC Caption": "British Columbia",
+      "DDC": 917.11,
+      "DDC Caption": "British Columbia--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1086-1089.7",
+      "LCC Caption": "British Columbia",
+      "DDC": 971.1,
+      "DDC Caption": "British Columbia"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1090",
+      "LCC Caption": "Rocky Mountains of Canada",
+      "DDC": "917.11 -917.1109",
+      "DDC Caption": "Rocky Mountains--Canada--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1090",
+      "LCC Caption": "Rocky Mountains of Canada",
+      "DDC": "971.1 -971.104",
+      "DDC Caption": "Rocky Mountains--Canada"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1090.5",
+      "LCC Caption": "Arctic regions",
+      "DDC": "917.19 -917.1909",
+      "DDC Caption": "Canadian Arctic--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1090.5",
+      "LCC Caption": "Arctic regions",
+      "DDC": "971.9 -971.903",
+      "DDC Caption": "Canadian Arctic"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1091-1095.5",
+      "LCC Caption": "Yukon",
+      "DDC": 917.191,
+      "DDC Caption": "Yukon Territory--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1091-1095.5",
+      "LCC Caption": "Yukon",
+      "DDC": 971.91,
+      "DDC Caption": "Yukon Territory"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1096-1100.5",
+      "LCC Caption": "Mackenzie",
+      "DDC": 917.193,
+      "DDC Caption": "Northwest Territories (1999- )--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1096-1100.5",
+      "LCC Caption": "Mackenzie",
+      "DDC": 971.93,
+      "DDC Caption": "Northwest Territories (1999- )"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1101-1105.7",
+      "LCC Caption": "Franklin",
+      "DDC": 917.1952,
+      "DDC Caption": "Baffin Region (Qikiqtaaluk Region)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1101-1105.7",
+      "LCC Caption": "Franklin",
+      "DDC": 971.952,
+      "DDC Caption": "Baffin Region (Qikiqtaaluk Region)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1106-1110.5",
+      "LCC Caption": "Keewatin",
+      "DDC": 917.1958,
+      "DDC Caption": "Keewatin Region (Kivallik Region)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1106-1110.5",
+      "LCC Caption": "Keewatin",
+      "DDC": 971.958,
+      "DDC Caption": "Keewatin Region (Kivallik Region)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1121-1139",
+      "LCC Caption": "Newfoundland",
+      "DDC": "917.18 -917.181",
+      "DDC Caption": "Newfoundland--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1121-1139",
+      "LCC Caption": "Newfoundland",
+      "DDC": "971.8 -971.81",
+      "DDC Caption": "Newfoundland"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1135-1139",
+      "LCC Caption": "Labrador",
+      "DDC": 917.182,
+      "DDC Caption": "Labrador--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1135-1139",
+      "LCC Caption": "Labrador",
+      "DDC": 971.82,
+      "DDC Caption": "Labrador"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1140",
+      "LCC Caption": "Labrador Peninsula",
+      "DDC": "917.141 -917.14109",
+      "DDC Caption": "Northern region--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1140",
+      "LCC Caption": "Labrador Peninsula",
+      "DDC": "971.41 -971.4104",
+      "DDC Caption": "Northern region"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1141-1145.2",
+      "LCC Caption": "Nunavut",
+      "DDC": 971.95,
+      "DDC Caption": "Nunavut"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1170",
+      "LCC Caption": "Saint Pierre and Miquelon",
+      "DDC": 917.188,
+      "DDC Caption": "Saint Pierre and Miquelon--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1170",
+      "LCC Caption": "Saint Pierre and Miquelon",
+      "DDC": 971.88,
+      "DDC Caption": "Saint Pierre and Miquelon"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1201-1392",
+      "LCC Caption": "Mexico",
+      "DDC": "917.2 -917.27",
+      "DDC Caption": "Mexico--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1201-1392",
+      "LCC Caption": "Mexico",
+      "DDC": "972 -972.7",
+      "DDC Caption": "Mexico"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1201-3799",
+      "LCC Caption": "Latin America. Spanish America",
+      "DDC": 917.2,
+      "DDC Caption": "Mexico--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1201-3799",
+      "LCC Caption": "Latin America. Spanish America",
+      "DDC": 918,
+      "DDC Caption": "Geography of and travel in South America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1201-3799",
+      "LCC Caption": "Latin America. Spanish America",
+      "DDC": 972,
+      "DDC Caption": "Middle America Mexico"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1201-3799",
+      "LCC Caption": "Latin America. Spanish America",
+      "DDC": 980,
+      "DDC Caption": "General history of South America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1401-1419",
+      "LCC Caption": "Latin America (General)",
+      "DDC": "918 -918.09",
+      "DDC Caption": "Geography of and travel in South America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1401-1419",
+      "LCC Caption": "Latin America (General)",
+      "DDC": "980 -980.4",
+      "DDC Caption": "General history of South America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1421-1440",
+      "LCC Caption": "Central America",
+      "DDC": "917.28 -917.2809",
+      "DDC Caption": "Central America--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1421-1440",
+      "LCC Caption": "Central America",
+      "DDC": "972.8 -972.805",
+      "DDC Caption": "Central America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1435-1435.3",
+      "LCC Caption": "Mayas",
+      "DDC": 305.897415,
+      "DDC Caption": "Mayas--social aspects"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1435-1435.3",
+      "LCC Caption": "Mayas",
+      "DDC": "917.281 -917.28109",
+      "DDC Caption": "Guatemala--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1435-1435.3",
+      "LCC Caption": "Mayas",
+      "DDC": 972.6,
+      "DDC Caption": "Southern Gulf states of Mexico"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1435-1435.3",
+      "LCC Caption": "Mayas",
+      "DDC": 972.81,
+      "DDC Caption": "Guatemala"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1441+",
+      "LCC Caption": "British Honduras (Belize)",
+      "DDC": 917.282,
+      "DDC Caption": "Belize--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1441+",
+      "LCC Caption": "British Honduras (Belize)",
+      "DDC": 972.82,
+      "DDC Caption": "Belize"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1441-1457",
+      "LCC Caption": "Belize",
+      "DDC": 917.282,
+      "DDC Caption": "Belize--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1441-1457",
+      "LCC Caption": "Belize",
+      "DDC": 972.82,
+      "DDC Caption": "Belize"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1461-1477",
+      "LCC Caption": "Guatemala",
+      "DDC": 917.281,
+      "DDC Caption": "Guatemala--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1461-1477",
+      "LCC Caption": "Guatemala",
+      "DDC": 972.81,
+      "DDC Caption": "Guatemala"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1481-1497",
+      "LCC Caption": "Salvador (El Salvador)",
+      "DDC": 917.284,
+      "DDC Caption": "El Salvador--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1481-1497",
+      "LCC Caption": "Salvador (El Salvador)",
+      "DDC": 972.84,
+      "DDC Caption": "El Salvador"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1501-1517",
+      "LCC Caption": "Honduras",
+      "DDC": 917.283,
+      "DDC Caption": "Honduras--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1501-1517",
+      "LCC Caption": "Honduras",
+      "DDC": 972.83,
+      "DDC Caption": "Honduras"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1521-1537",
+      "LCC Caption": "Nicaragua",
+      "DDC": 917.285,
+      "DDC Caption": "Nicaragua--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1521-1537",
+      "LCC Caption": "Nicaragua",
+      "DDC": 972.85,
+      "DDC Caption": "Nicaragua"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1541-1557",
+      "LCC Caption": "Costa Rica",
+      "DDC": 917.286,
+      "DDC Caption": "Costa Rica--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1541-1557",
+      "LCC Caption": "Costa Rica",
+      "DDC": 972.86,
+      "DDC Caption": "Costa Rica"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1561-1577",
+      "LCC Caption": "Panama",
+      "DDC": 917.287,
+      "DDC Caption": "Panama--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1561-1577",
+      "LCC Caption": "Panama",
+      "DDC": 972.87,
+      "DDC Caption": "Panama"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1569.C2",
+      "LCC Caption": "Canal Zone. Panama Canal",
+      "DDC": 917.2875,
+      "DDC Caption": "Canal Area--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1569.C2",
+      "LCC Caption": "Canal Zone. Panama Canal",
+      "DDC": 972.875,
+      "DDC Caption": "Canal Area"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1601-1629",
+      "LCC Caption": "West Indies",
+      "DDC": "917.29 -917.2909",
+      "DDC Caption": "West Indies (Antilles) and Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1601-1629",
+      "LCC Caption": "West Indies",
+      "DDC": "972.9 -972.905",
+      "DDC Caption": "West Indies (Antilles) and Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1630+",
+      "LCC Caption": "Bermuda",
+      "DDC": 917.299,
+      "DDC Caption": "Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1630+",
+      "LCC Caption": "Bermuda",
+      "DDC": 972.99,
+      "DDC Caption": "Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1630-1640",
+      "LCC Caption": "Bermudas",
+      "DDC": 917.299,
+      "DDC Caption": "Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1630-1640",
+      "LCC Caption": "Bermudas",
+      "DDC": 972.99,
+      "DDC Caption": "Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1650+",
+      "LCC Caption": "Bahamas",
+      "DDC": 917.296,
+      "DDC Caption": "Bahama Islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1650+",
+      "LCC Caption": "Bahamas",
+      "DDC": 972.96,
+      "DDC Caption": "Bahama Islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1650-1660",
+      "LCC Caption": "Bahamas",
+      "DDC": 917.296,
+      "DDC Caption": "Bahama Islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1650-1660",
+      "LCC Caption": "Bahamas",
+      "DDC": 972.96,
+      "DDC Caption": "Bahama Islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1741-1991",
+      "LCC Caption": "Greater Antilles",
+      "DDC": "917.29 -917.295",
+      "DDC Caption": "Greater Antilles--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1741-1991",
+      "LCC Caption": "Greater Antilles",
+      "DDC": "972.9 -972.95",
+      "DDC Caption": "Greater Antilles"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1751-1854.9",
+      "LCC Caption": "Cuba",
+      "DDC": 917.291,
+      "DDC Caption": "Cuba--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1751-1854.9",
+      "LCC Caption": "Cuba",
+      "DDC": 972.91,
+      "DDC Caption": "Cuba"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1861-1896",
+      "LCC Caption": "Jamaica",
+      "DDC": 917.292,
+      "DDC Caption": "Jamaica and Cayman Islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1861-1896",
+      "LCC Caption": "Jamaica",
+      "DDC": 972.92,
+      "DDC Caption": "Jamaica and Cayman Islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1900-1941",
+      "LCC Caption": "Haiti (Island). Hispaniola",
+      "DDC": "917.293 -917.294",
+      "DDC Caption": "Dominican Republic; Haiti--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1900-1941",
+      "LCC Caption": "Haiti (Island). Hispaniola",
+      "DDC": "972.93 -972.94",
+      "DDC Caption": "Dominican Republic; Haiti"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1912-1930",
+      "LCC Caption": "Haiti (Republic)",
+      "DDC": 917.294,
+      "DDC Caption": "Haiti--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1912-1930",
+      "LCC Caption": "Haiti (Republic)",
+      "DDC": 972.94,
+      "DDC Caption": "Haiti"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1931-1941",
+      "LCC Caption": "Dominican Republic",
+      "DDC": 917.293,
+      "DDC Caption": "Dominican Republic--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1931-1941",
+      "LCC Caption": "Dominican Republic",
+      "DDC": 972.93,
+      "DDC Caption": "Dominican Republic"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1951-1983",
+      "LCC Caption": "Puerto Rico",
+      "DDC": 917.295,
+      "DDC Caption": "Puerto Rico--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1951-1983",
+      "LCC Caption": "Puerto Rico",
+      "DDC": 972.95,
+      "DDC Caption": "Puerto Rico"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1991",
+      "LCC Caption": "Navassa",
+      "DDC": 917.29,
+      "DDC Caption": "West Indies (Antilles) and Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 1991",
+      "LCC Caption": "Navassa",
+      "DDC": 972.9,
+      "DDC Caption": "West Indies (Antilles) and Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2001-2152",
+      "LCC Caption": "Lesser Antilles",
+      "DDC": 917.29,
+      "DDC Caption": "West Indies (Antilles) and Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2001-2152",
+      "LCC Caption": "Lesser Antilles",
+      "DDC": "917.297 -917.298",
+      "DDC Caption": "Lesser Antilles (Caribbees)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2001-2152",
+      "LCC Caption": "Lesser Antilles",
+      "DDC": 972.9,
+      "DDC Caption": "West Indies (Antilles) and Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2001-2152",
+      "LCC Caption": "Lesser Antilles",
+      "DDC": "972.97 -972.98",
+      "DDC Caption": "Lesser Antilles (Caribbees)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2006",
+      "LCC Caption": "Leeward Islands",
+      "DDC": "917.297 -917.29709",
+      "DDC Caption": "Leeward Islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2006",
+      "LCC Caption": "Leeward Islands",
+      "DDC": "972.97 -972.97009",
+      "DDC Caption": "Leeward Islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2011",
+      "LCC Caption": "Windward Islands",
+      "DDC": "917.2984 -917.298409",
+      "DDC Caption": "Windward Islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2011",
+      "LCC Caption": "Windward Islands",
+      "DDC": "972.984 -972.984009",
+      "DDC Caption": "Windward Islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2016",
+      "LCC Caption": "Islands along Venezuela coast",
+      "DDC": "917.298 -917.29809",
+      "DDC Caption": "Windward and other southern islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2016",
+      "LCC Caption": "Islands along Venezuela coast",
+      "DDC": "917.2983 -917.298309",
+      "DDC Caption": "Trinidad and Tobago--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2016",
+      "LCC Caption": "Islands along Venezuela coast",
+      "DDC": "972.98 -972.9805",
+      "DDC Caption": "Windward and other southern islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2016",
+      "LCC Caption": "Islands along Venezuela coast",
+      "DDC": "972.983 -972.983009",
+      "DDC Caption": "Trinidad and Tobago"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2033-2129",
+      "LCC Caption": "Lesser Antilles. Caribbees",
+      "DDC": "917.297 -917.298",
+      "DDC Caption": "Lesser Antilles (Caribbees)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2033-2129",
+      "LCC Caption": "Lesser Antilles. Caribbees",
+      "DDC": "972.97 -972.98",
+      "DDC Caption": "Lesser Antilles (Caribbees)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2131+",
+      "LCC Caption": "British West Indies",
+      "DDC": 917.29,
+      "DDC Caption": "West Indies (Antilles) and Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2131+",
+      "LCC Caption": "British West Indies",
+      "DDC": 972.9,
+      "DDC Caption": "West Indies (Antilles) and Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2131-2133",
+      "LCC Caption": "British West Indies",
+      "DDC": 917.29,
+      "DDC Caption": "West Indies (Antilles) and Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2131-2133",
+      "LCC Caption": "British West Indies",
+      "DDC": 972.9,
+      "DDC Caption": "West Indies (Antilles) and Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2136",
+      "LCC Caption": "Virgin Islands of the United States",
+      "DDC": 917.29722,
+      "DDC Caption": "Virgin Islands of the United States--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2136",
+      "LCC Caption": "Virgin Islands of the United States",
+      "DDC": 972.9722,
+      "DDC Caption": "Virgin Islands of the United States"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2141",
+      "LCC Caption": "Netherlands West Indies. Dutch West Indies",
+      "DDC": 917.2986,
+      "DDC Caption": "Netherlands islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2141",
+      "LCC Caption": "Dutch West Indies",
+      "DDC": 917.2986,
+      "DDC Caption": "Netherlands islands--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2141",
+      "LCC Caption": "Netherlands West Indies. Dutch West Indies",
+      "DDC": 972.986,
+      "DDC Caption": "Netherlands islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2141",
+      "LCC Caption": "Dutch West Indies",
+      "DDC": 972.986,
+      "DDC Caption": "Netherlands islands"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2151",
+      "LCC Caption": "French West Indies",
+      "DDC": 917.2976,
+      "DDC Caption": "Guadeloupe--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2151",
+      "LCC Caption": "French West Indies",
+      "DDC": 972.976,
+      "DDC Caption": "Guadeloupe"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2155-2191",
+      "LCC Caption": "Caribbean area. Caribbean Sea",
+      "DDC": "917.29 -917.2909",
+      "DDC Caption": "West Indies (Antilles) and Bermuda--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2155-2191",
+      "LCC Caption": "Caribbean area. Caribbean Sea",
+      "DDC": "972.9 -972.905",
+      "DDC Caption": "West Indies (Antilles) and Bermuda"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2201-3799",
+      "LCC Caption": "South America",
+      "DDC": 918,
+      "DDC Caption": "Geography of and travel in South America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2201-3799",
+      "LCC Caption": "South America",
+      "DDC": 980,
+      "DDC Caption": "General history of South America"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2251-2299",
+      "LCC Caption": "Colombia",
+      "DDC": 918.61,
+      "DDC Caption": "Colombia--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2251-2299",
+      "LCC Caption": "Colombia",
+      "DDC": 986.1,
+      "DDC Caption": "Colombia"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2301-2349",
+      "LCC Caption": "Venezuela",
+      "DDC": 918.7,
+      "DDC Caption": "Venezuela--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2301-2349",
+      "LCC Caption": "Venezuela",
+      "DDC": 987,
+      "DDC Caption": "Venezuela"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2351",
+      "LCC Caption": "Guiana",
+      "DDC": "918.8 -918.809",
+      "DDC Caption": "Guiana--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2351",
+      "LCC Caption": "Guiana",
+      "DDC": "988 -988.03",
+      "DDC Caption": "Guiana"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2361+",
+      "LCC Caption": "British Guiana",
+      "DDC": 918.81,
+      "DDC Caption": "Guyana--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2361+",
+      "LCC Caption": "British Guiana",
+      "DDC": 988.1,
+      "DDC Caption": "Guyana"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2361-2391",
+      "LCC Caption": "Guyana. British Guiana",
+      "DDC": 918.81,
+      "DDC Caption": "Guyana--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2361-2391",
+      "LCC Caption": "Guyana. British Guiana",
+      "DDC": 988.1,
+      "DDC Caption": "Guyana"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2401",
+      "LCC Caption": "Dutch Guinea",
+      "DDC": 918.83,
+      "DDC Caption": "Surinam (Suriname)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2401",
+      "LCC Caption": "Dutch Guinea",
+      "DDC": 988.3,
+      "DDC Caption": "Surinam (Suriname)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2401-2431",
+      "LCC Caption": "Surinam",
+      "DDC": 918.83,
+      "DDC Caption": "Surinam (Suriname)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2401-2431",
+      "LCC Caption": "Surinam",
+      "DDC": 988.3,
+      "DDC Caption": "Surinam (Suriname)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2441+",
+      "LCC Caption": "French Guiana",
+      "DDC": 918.82,
+      "DDC Caption": "French Guiana (Guyane)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2441+",
+      "LCC Caption": "French Guiana",
+      "DDC": 988.2,
+      "DDC Caption": "French Guiana (Guyane)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2441-2471",
+      "LCC Caption": "French Guiana",
+      "DDC": 918.82,
+      "DDC Caption": "French Guiana (Guyane)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2441-2471",
+      "LCC Caption": "French Guiana",
+      "DDC": 988.2,
+      "DDC Caption": "French Guiana (Guyane)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2501-2659",
+      "LCC Caption": "Brazil",
+      "DDC": 918.1,
+      "DDC Caption": "Brazil--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2501-2659",
+      "LCC Caption": "Brazil",
+      "DDC": 981,
+      "DDC Caption": "Brazil"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2529",
+      "LCC Caption": "French Colony in Brazil, 1555-1567",
+      "DDC": 981.032,
+      "DDC Caption": "Period of hereditary captaincies, 1533-1762"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2532",
+      "LCC Caption": "Dutch Colony in Brazil, 1625-1661",
+      "DDC": 981.032,
+      "DDC Caption": "Period of hereditary captaincies, 1533-1762"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2661-2699",
+      "LCC Caption": "Paraguay",
+      "DDC": 918.92,
+      "DDC Caption": "Paraguay--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2661-2699",
+      "LCC Caption": "Paraguay",
+      "DDC": 989.2,
+      "DDC Caption": "Paraguay"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2701-2799",
+      "LCC Caption": "Uruguay",
+      "DDC": 918.95,
+      "DDC Caption": "Uruguay--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2701-2799",
+      "LCC Caption": "Uruguay",
+      "DDC": 989.5,
+      "DDC Caption": "Uruguay"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2801-3021",
+      "LCC Caption": "Argentina",
+      "DDC": 918.2,
+      "DDC Caption": "Argentina--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 2801-3021",
+      "LCC Caption": "Argentina",
+      "DDC": 982,
+      "DDC Caption": "Argentina"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3031+",
+      "LCC Caption": "Falkland Islands",
+      "DDC": 919.711,
+      "DDC Caption": "Falkland Islands (Islas Malvinas)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3031+",
+      "LCC Caption": "Falkland Islands",
+      "DDC": 997.11,
+      "DDC Caption": "Falkland Islands (Islas Malvinas)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3031-3031.5",
+      "LCC Caption": "Falkland Islands",
+      "DDC": 919.711,
+      "DDC Caption": "Falkland Islands (Islas Malvinas)--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3031-3031.5",
+      "LCC Caption": "Falkland Islands",
+      "DDC": 997.11,
+      "DDC Caption": "Falkland Islands (Islas Malvinas)"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3051-3285",
+      "LCC Caption": "Chile",
+      "DDC": 918.3,
+      "DDC Caption": "Chile--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3051-3285",
+      "LCC Caption": "Chile",
+      "DDC": 983,
+      "DDC Caption": "Chile"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3301-3359",
+      "LCC Caption": "Bolivia",
+      "DDC": 918.4,
+      "DDC Caption": "Bolivia--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3301-3359",
+      "LCC Caption": "Bolivia",
+      "DDC": 984,
+      "DDC Caption": "Bolivia"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3401-3619",
+      "LCC Caption": "Peru",
+      "DDC": 918.5,
+      "DDC Caption": "Peru--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3401-3619",
+      "LCC Caption": "Peru",
+      "DDC": 985,
+      "DDC Caption": "Peru"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3701-3799",
+      "LCC Caption": "Ecuador",
+      "DDC": 918.66,
+      "DDC Caption": "Ecuador--description & travel"
+    },
+    {
+      "LCC": "F",
+      "LCC Range": "F 3701-3799",
+      "LCC Caption": "Ecuador",
+      "DDC": 986.6,
+      "DDC Caption": "Ecuador"
+    },
+    {
+      "LCC": "G",
+      "LCC Range": "G",
+      "LCC Caption": "Geography (General)",
+      "DDC": "910 - 912",
+      "DDC Caption": "Geography & travel"
+    },
+    {
+      "LCC": "GA",
+      "LCC Range": "GA",
+      "LCC Caption": "Mathematical geography. Cartography",
+      "DDC": 526,
+      "DDC Caption": "Mathematical geography"
+    },
+    {
+      "LCC": "GB",
+      "LCC Range": "GB",
+      "LCC Caption": "Physical geography",
+      "DDC": "551.4 - 551.45",
+      "DDC Caption": "Geomorphology"
+    },
+    {
+      "LCC": "GC",
+      "LCC Range": "GC",
+      "LCC Caption": "Oceanography",
+      "DDC": "551.46 - 551.47",
+      "DDC Caption": "Oceanography"
+    },
+    {
+      "LCC": "GE",
+      "LCC Range": "GE",
+      "LCC Caption": "Environmental sciences",
+      "DDC": "333.7 - 333.709",
+      "DDC Caption": "Natural resources & energy"
+    },
+    {
+      "LCC": "GF",
+      "LCC Range": "GF",
+      "LCC Caption": "Human ecology. Anthropogeography",
+      "DDC": "304 - 304.2",
+      "DDC Caption": "Factors affecting social behavior; Human ecology"
+    },
+    {
+      "LCC": "GN",
+      "LCC Range": "GN",
+      "LCC Caption": "Anthropology",
+      "DDC": "302.3 - 302.4",
+      "DDC Caption": "Social interaction"
+    },
+    {
+      "LCC": "GN",
+      "LCC Range": "GN",
+      "LCC Caption": "Anthropology",
+      "DDC": 305,
+      "DDC Caption": "Social groups"
+    },
+    {
+      "LCC": "GN",
+      "LCC Range": "GN",
+      "LCC Caption": "Anthropology",
+      "DDC": 306.3,
+      "DDC Caption": "Economic institutions"
+    },
+    {
+      "LCC": "GN",
+      "LCC Range": "GN",
+      "LCC Caption": "Anthropology",
+      "DDC": 306.8,
+      "DDC Caption": "Marriage & family"
+    },
+    {
+      "LCC": "GN",
+      "LCC Range": "GN",
+      "LCC Caption": "Anthropology",
+      "DDC": 599.9,
+      "DDC Caption": "Physical anthropology"
+    },
+    {
+      "LCC": "GR",
+      "LCC Range": "GR",
+      "LCC Caption": "Folklore",
+      "DDC": "398.2 - 398.4",
+      "DDC Caption": "Folk literature"
+    },
+    {
+      "LCC": "GR",
+      "LCC Range": "GR",
+      "LCC Caption": "Folklore",
+      "DDC": 398.8,
+      "DDC Caption": "Rhymes & rhyming games"
+    },
+    {
+      "LCC": "GT",
+      "LCC Range": "GT",
+      "LCC Caption": "Manners and customs (General)",
+      "DDC": "390 - 394",
+      "DDC Caption": "Customs, etiquette & folklore"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV",
+      "LCC Caption": "Recreation. Leisure",
+      "DDC": 790,
+      "DDC Caption": "Sports, games & entertainment"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV",
+      "LCC Caption": "Recreation. Leisure",
+      "DDC": 796,
+      "DDC Caption": "Athletic & outdoor sports & games"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV",
+      "LCC Caption": "Recreation. Leisure",
+      "DDC": 796.4,
+      "DDC Caption": "Weight lifting, track & field, gymnastics"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV",
+      "LCC Caption": "Recreation. Leisure",
+      "DDC": 797,
+      "DDC Caption": "Aquatic & air sports"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1019.2-1038.2",
+      "LCC Caption": "Motor sports",
+      "DDC": 796.7,
+      "DDC Caption": "Driving motor vehicles"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1040-1059",
+      "LCC Caption": "Cycling. Bicycling",
+      "DDC": 796.6,
+      "DDC Caption": "Cycling & related activities"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1060.5-1098",
+      "LCC Caption": "Track and field athletics",
+      "DDC": 796.42,
+      "DDC Caption": "Track & field"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1100-1150.9",
+      "LCC Caption": "Fighting sports. Martial arts",
+      "DDC": 796.8,
+      "DDC Caption": "Combat sports"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1151-1190",
+      "LCC Caption": "Shooting",
+      "DDC": 799.3,
+      "DDC Caption": "Shooting other than game"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1199-1570",
+      "LCC Caption": "Games and amusements",
+      "DDC": 793,
+      "DDC Caption": "Indoor games & amusements"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1199-1570",
+      "LCC Caption": "Games and amusements",
+      "DDC": 794,
+      "DDC Caption": "Indoor games of skill"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 1199-1570",
+      "LCC Caption": "Games and amusements",
+      "DDC": 795,
+      "DDC Caption": "Games of chance"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 191.2-200.66",
+      "LCC Caption": "Outdoor life. Outdoor recreation",
+      "DDC": 796.5,
+      "DDC Caption": "Outdoor life"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 460-555",
+      "LCC Caption": "Gymnastics. Gymnastic exercises",
+      "DDC": "796.44 - 796.47",
+      "DDC Caption": "Gymnastics"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 545.5-548",
+      "LCC Caption": "Weight training. Weight lifting. Body building",
+      "DDC": 796.41,
+      "DDC Caption": "Weight lifting"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 750-770.27",
+      "LCC Caption": "Air sports",
+      "DDC": 797.5,
+      "DDC Caption": "Air sports"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 770.3- 840",
+      "LCC Caption": "Water sports",
+      "DDC": "797.1 - 797.3",
+      "DDC Caption": "Aquatic sports"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 840.7-857",
+      "LCC Caption": "Winter sports",
+      "DDC": 796.9,
+      "DDC Caption": "Ice & snow sports"
+    },
+    {
+      "LCC": "GV",
+      "LCC Range": "GV 861-1017",
+      "LCC Caption": "Ball games",
+      "DDC": 796.3,
+      "DDC Caption": "Ball games"
+    },
+    {
+      "LCC": "H",
+      "LCC Range": "H 1-99",
+      "LCC Caption": "Social sciences (General)",
+      "DDC": "300 - 300.9",
+      "DDC Caption": "Social sciences, sociology & anthropology"
+    },
+    {
+      "LCC": "HA",
+      "LCC Range": "HA",
+      "LCC Caption": "Statistics",
+      "DDC": 310,
+      "DDC Caption": "Collections of general statistics"
+    },
+    {
+      "LCC": "HB",
+      "LCC Range": "HB",
+      "LCC Caption": "Economic theory. Demography",
+      "DDC": "330 - 330.1",
+      "DDC Caption": "Systems, schools, theories"
+    },
+    {
+      "LCC": "HB",
+      "LCC Range": "HB",
+      "LCC Caption": "Economic theory. Demography",
+      "DDC": 339,
+      "DDC Caption": "Macroeconomics & related topics"
+    },
+    {
+      "LCC": "HC",
+      "LCC Range": "HC",
+      "LCC Caption": "Economic history and conditions",
+      "DDC": 330.9,
+      "DDC Caption": "Economic situation & conditions"
+    },
+    {
+      "LCC": "HD",
+      "LCC Range": "HD",
+      "LCC Caption": "Economic history and conditions",
+      "DDC": 331,
+      "DDC Caption": "Labor economics"
+    },
+    {
+      "LCC": "HD",
+      "LCC Range": "HD",
+      "LCC Caption": "Economic history and conditions",
+      "DDC": "333 - 333.5",
+      "DDC Caption": "Economics of land"
+    },
+    {
+      "LCC": "HD",
+      "LCC Range": "HD",
+      "LCC Caption": "Economic history and conditions",
+      "DDC": 338,
+      "DDC Caption": "Production"
+    },
+    {
+      "LCC": "HE",
+      "LCC Range": "HE",
+      "LCC Caption": "Transportation and communications",
+      "DDC": "383 - 388",
+      "DDC Caption": "Communications & transportation"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 337,
+      "DDC Caption": "International economics"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 381,
+      "DDC Caption": "Internal commerce (Domestic trade)"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 382,
+      "DDC Caption": "International commerce (Foreign trade)"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 650,
+      "DDC Caption": "Management & public relations"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 651,
+      "DDC Caption": "Office services"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 657,
+      "DDC Caption": "Accounting"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 658,
+      "DDC Caption": "General management"
+    },
+    {
+      "LCC": "HF",
+      "LCC Range": "HF",
+      "LCC Caption": "Commerce",
+      "DDC": 659.1,
+      "DDC Caption": "Advertising"
+    },
+    {
+      "LCC": "HG",
+      "LCC Range": "HG",
+      "LCC Caption": "Finance",
+      "DDC": 332,
+      "DDC Caption": "Financial economics"
+    },
+    {
+      "LCC": "HJ",
+      "LCC Range": "HJ",
+      "LCC Caption": "Public finance",
+      "DDC": 336,
+      "DDC Caption": "Public finance"
+    },
+    {
+      "LCC": "HQ",
+      "LCC Range": "HQ",
+      "LCC Caption": "The Family. Marriage. Women",
+      "DDC": "649.1 - 641.7",
+      "DDC Caption": "Child rearing & home care of children"
+    },
+    {
+      "LCC": "HV",
+      "LCC Range": "HV",
+      "LCC Caption": "Sign language. Gesture--Systems of speech of the deaf",
+      "DDC": 419,
+      "DDC Caption": "Sign languages"
+    },
+    {
+      "LCC": "HX",
+      "LCC Range": "HX",
+      "LCC Caption": "Socialism. Communism. Anarchism",
+      "DDC": 335,
+      "DDC Caption": "Socialism & related systems"
+    },
+    {
+      "LCC": "JA",
+      "LCC Range": "JA",
+      "LCC Caption": "Political science",
+      "DDC": "320 - 320.09",
+      "DDC Caption": "Political science"
+    },
+    {
+      "LCC": "K",
+      "LCC Range": "K",
+      "LCC Caption": "Law in general. Comparative and uniform law. Jurisprudence",
+      "DDC": "340 - 340.5",
+      "DDC Caption": "Law"
+    },
+    {
+      "LCC": "KZ",
+      "LCC Range": "KZ",
+      "LCC Caption": "Law of nations",
+      "DDC": 341,
+      "DDC Caption": "International law"
+    },
+    {
+      "LCC": "L",
+      "LCC Range": "L",
+      "LCC Caption": "Education (General)",
+      "DDC": 370,
+      "DDC Caption": "Education"
+    },
+    {
+      "LCC": "L",
+      "LCC Range": "L",
+      "LCC Caption": "Education (General)",
+      "DDC": 370.1,
+      "DDC Caption": "Philosophy & theory"
+    },
+    {
+      "LCC": "L",
+      "LCC Range": "L",
+      "LCC Caption": "Education (General)",
+      "DDC": 370.3,
+      "DDC Caption": "Education--Dictionaries"
+    },
+    {
+      "LCC": "L",
+      "LCC Range": "L",
+      "LCC Caption": "Education (General)",
+      "DDC": 370.5,
+      "DDC Caption": "Education--Periodicals"
+    },
+    {
+      "LCC": "L",
+      "LCC Range": "L",
+      "LCC Caption": "Education (General)",
+      "DDC": 370.7,
+      "DDC Caption": "Education, research, related topics"
+    },
+    {
+      "LCC": "L",
+      "LCC Range": "L",
+      "LCC Caption": "Education (General)",
+      "DDC": 370.8,
+      "DDC Caption": "History & description with respect to kinds of persons"
+    },
+    {
+      "LCC": "LA",
+      "LCC Range": "LA",
+      "LCC Caption": "History of education",
+      "DDC": 370.9,
+      "DDC Caption": "Historical, geographic, persons treatment"
+    },
+    {
+      "LCC": "LB",
+      "LCC Range": "LB",
+      "LCC Caption": "Theory and practice of education",
+      "DDC": 370.15,
+      "DDC Caption": "Educational psychology"
+    },
+    {
+      "LCC": "LB",
+      "LCC Range": "LB",
+      "LCC Caption": "Theory and practice of education",
+      "DDC": 371,
+      "DDC Caption": "Schools & activities; special education"
+    },
+    {
+      "LCC": "LB",
+      "LCC Range": "LB",
+      "LCC Caption": "Theory and practice of education",
+      "DDC": 372,
+      "DDC Caption": "Elementary education"
+    },
+    {
+      "LCC": "LB",
+      "LCC Range": "LB",
+      "LCC Caption": "Theory and practice of education",
+      "DDC": 373,
+      "DDC Caption": "Secondary education"
+    },
+    {
+      "LCC": "LB",
+      "LCC Range": "LB",
+      "LCC Caption": "Theory and practice of education",
+      "DDC": 378.1,
+      "DDC Caption": "Organization & activities in higher education"
+    },
+    {
+      "LCC": "LB",
+      "LCC Range": "LB",
+      "LCC Caption": "Theory and practice of education",
+      "DDC": 378.2,
+      "DDC Caption": "Academic degrees & related topics"
+    },
+    {
+      "LCC": "LB",
+      "LCC Range": "LB",
+      "LCC Caption": "Theory and practice of education",
+      "DDC": 378.3,
+      "DDC Caption": "Student aid & related topics"
+    },
+    {
+      "LCC": "LC",
+      "LCC Range": "LC",
+      "LCC Caption": "Special aspects of education",
+      "DDC": 306.43,
+      "DDC Caption": "Education--sociology"
+    },
+    {
+      "LCC": "LC",
+      "LCC Range": "LC",
+      "LCC Caption": "Special aspects of education",
+      "DDC": 370.11,
+      "DDC Caption": "Education for specific objectives"
+    },
+    {
+      "LCC": "LC",
+      "LCC Range": "LC",
+      "LCC Caption": "Special aspects of education",
+      "DDC": 371.82,
+      "DDC Caption": "Specific kinds of students"
+    },
+    {
+      "LCC": "LC",
+      "LCC Range": "LC",
+      "LCC Caption": "Special aspects of education",
+      "DDC": 374,
+      "DDC Caption": "Adult education"
+    },
+    {
+      "LCC": "LC",
+      "LCC Range": "LC",
+      "LCC Caption": "Special aspects of education",
+      "DDC": 379,
+      "DDC Caption": "Public policy issues in education"
+    },
+    {
+      "LCC": "LD",
+      "LCC Range": "LD",
+      "LCC Caption": "Individual institutions - United States",
+      "DDC": "378.73 - 378.79",
+      "DDC Caption": "Higher education--United States"
+    },
+    {
+      "LCC": "LE",
+      "LCC Range": "LE",
+      "LCC Caption": "Individual institutions - America (except United States)",
+      "DDC": 378.8,
+      "DDC Caption": "Universities & colleges--Latin America"
+    },
+    {
+      "LCC": "LF",
+      "LCC Range": "LF",
+      "LCC Caption": "Individual institutions - Europe",
+      "DDC": 378.4,
+      "DDC Caption": "Higher education--Europe"
+    },
+    {
+      "LCC": "LG",
+      "LCC Range": "LG",
+      "LCC Caption": "Individual institutions - Asia, Africa, Oceania",
+      "DDC": "378.5 - 378.6",
+      "DDC Caption": "Higher education--Africa"
+    },
+    {
+      "LCC": "LH",
+      "LCC Range": "LH",
+      "LCC Caption": "College and school magazines and newspapers",
+      "DDC": 378,
+      "DDC Caption": "Higher education"
+    },
+    {
+      "LCC": "LT",
+      "LCC Range": "LT",
+      "LCC Caption": "Textbooks",
+      "DDC": "na",
+      "DDC Caption": "na"
+    },
+    {
+      "LCC": "M",
+      "LCC Range": "M",
+      "LCC Caption": "Musical Works",
+      "DDC": "782 - 788",
+      "DDC Caption": "Ensembles, voices, instruments"
+    },
+    {
+      "LCC": "ML",
+      "LCC Range": "ML",
+      "LCC Caption": "Literature on music",
+      "DDC": 780,
+      "DDC Caption": "Music"
+    },
+    {
+      "LCC": "MT",
+      "LCC Range": "MT",
+      "LCC Caption": "Musical instruction and study",
+      "DDC": "781 - 781.4",
+      "DDC Caption": "General principles & musical forms"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 700,
+      "DDC Caption": "The arts; Fine and decorative arts"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 701,
+      "DDC Caption": "Philosophy of fine & decorative arts"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 702,
+      "DDC Caption": "Miscellany of fine & decorative arts"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 703,
+      "DDC Caption": "Dictionaries of fine & decorative arts"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 704,
+      "DDC Caption": "Special topics of fine & decorative arts"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 705,
+      "DDC Caption": "Serial publications of fine & decorative arts"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 706,
+      "DDC Caption": "Organizations & management"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 707,
+      "DDC Caption": "Education, research, related topics"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 708,
+      "DDC Caption": "Galleries, museums, private collections"
+    },
+    {
+      "LCC": "N",
+      "LCC Range": "N",
+      "LCC Caption": "Visual arts (General)",
+      "DDC": 709,
+      "DDC Caption": "Historical, geographic, persons treatment"
+    },
+    {
+      "LCC": "NA",
+      "LCC Range": "NA",
+      "LCC Caption": "Architecture",
+      "DDC": 711,
+      "DDC Caption": "Area planning (Civic art)"
+    },
+    {
+      "LCC": "NA",
+      "LCC Range": "NA",
+      "LCC Caption": "Architecture",
+      "DDC": 720,
+      "DDC Caption": "Architecture"
+    },
+    {
+      "LCC": "NB",
+      "LCC Range": "NB",
+      "LCC Caption": "Sculpture",
+      "DDC": 730,
+      "DDC Caption": "Plastic arts; Sculpture"
+    },
+    {
+      "LCC": "NC",
+      "LCC Range": "NC",
+      "LCC Caption": "Drawing. Design. Illustration",
+      "DDC": 740,
+      "DDC Caption": "Drawing & decorative arts"
+    },
+    {
+      "LCC": "NC",
+      "LCC Range": "NC",
+      "LCC Caption": "Drawing. Design. Illustration",
+      "DDC": 741,
+      "DDC Caption": "Drawing & drawings"
+    },
+    {
+      "LCC": "NC",
+      "LCC Range": "NC",
+      "LCC Caption": "Drawing. Design. Illustration",
+      "DDC": 742,
+      "DDC Caption": "Perspective"
+    },
+    {
+      "LCC": "NC",
+      "LCC Range": "NC",
+      "LCC Caption": "Drawing. Design. Illustration",
+      "DDC": 743,
+      "DDC Caption": "Drawing & drawings by subject"
+    },
+    {
+      "LCC": "ND",
+      "LCC Range": "ND",
+      "LCC Caption": "Painting",
+      "DDC": 750,
+      "DDC Caption": "Painting & paintings"
+    },
+    {
+      "LCC": "NE",
+      "LCC Range": "NE",
+      "LCC Caption": "Print media",
+      "DDC": 760,
+      "DDC Caption": "Graphic arts; Printmaking & prints"
+    },
+    {
+      "LCC": "NK",
+      "LCC Range": "NK",
+      "LCC Caption": "Decorative arts. Applied arts",
+      "DDC": 745,
+      "DDC Caption": "Decorative arts"
+    },
+    {
+      "LCC": "NK",
+      "LCC Range": "NK",
+      "LCC Caption": "Decorative arts. Applied arts",
+      "DDC": 746,
+      "DDC Caption": "Textile arts"
+    },
+    {
+      "LCC": "NK",
+      "LCC Range": "NK",
+      "LCC Caption": "Decorative arts. Applied arts",
+      "DDC": 747,
+      "DDC Caption": "Interior decoration"
+    },
+    {
+      "LCC": "NK",
+      "LCC Range": "NK",
+      "LCC Caption": "Decorative arts. Applied arts",
+      "DDC": 748,
+      "DDC Caption": "Glass"
+    },
+    {
+      "LCC": "NK",
+      "LCC Range": "NK",
+      "LCC Caption": "Decorative arts. Applied arts",
+      "DDC": 749,
+      "DDC Caption": "Furniture & accessories"
+    },
+    {
+      "LCC": "NX",
+      "LCC Range": "NX",
+      "LCC Caption": "Arts in general",
+      "DDC": 700.1,
+      "DDC Caption": "Philosophy of the arts"
+    },
+    {
+      "LCC": "NX",
+      "LCC Range": "NX",
+      "LCC Caption": "Arts in general",
+      "DDC": 700.4,
+      "DDC Caption": "Special topics of the arts"
+    },
+    {
+      "LCC": "NX",
+      "LCC Range": "NX",
+      "LCC Caption": "Arts in general",
+      "DDC": 700.5,
+      "DDC Caption": "Serial publications of the arts"
+    },
+    {
+      "LCC": "NX",
+      "LCC Range": "NX",
+      "LCC Caption": "Arts in general",
+      "DDC": 700.9,
+      "DDC Caption": "Historical, geographic, persons treatment of the arts"
+    },
+    {
+      "LCC": "P",
+      "LCC Range": "P",
+      "LCC Caption": "Philology. Linguistics",
+      "DDC": "400 - 418",
+      "DDC Caption": "Language; Linguistics"
+    },
+    {
+      "LCC": "P",
+      "LCC Range": "P",
+      "LCC Caption": "Philology. Linguistics",
+      "DDC": "491.993 - 491.998",
+      "DDC Caption": "Other Indo-European languages"
+    },
+    {
+      "LCC": "P",
+      "LCC Range": "P 1078",
+      "LCC Caption": "Philology. Linguistics",
+      "DDC": 499.94,
+      "DDC Caption": "Etruscan language"
+    },
+    {
+      "LCC": "P",
+      "LCC Range": "P 117-117.5",
+      "LCC Caption": "Sign language. Gesture--General",
+      "DDC": 419,
+      "DDC Caption": "Sign languages"
+    },
+    {
+      "LCC": "PA",
+      "LCC Range": "PA",
+      "LCC Caption": "Greek & Latin languages & literatures",
+      "DDC": 470,
+      "DDC Caption": "Latin & Italic languages"
+    },
+    {
+      "LCC": "PA",
+      "LCC Range": "PA",
+      "LCC Caption": "Greek & Latin languages & literatures",
+      "DDC": 480,
+      "DDC Caption": "Classical & modern Greek languages"
+    },
+    {
+      "LCC": "PA",
+      "LCC Range": "PA",
+      "LCC Caption": "Greek & Latin languages & literatures",
+      "DDC": 870,
+      "DDC Caption": "Latin & Italic literatures"
+    },
+    {
+      "LCC": "PA",
+      "LCC Range": "PA",
+      "LCC Caption": "Greek & Latin languages & literatures",
+      "DDC": 880,
+      "DDC Caption": "Classical & modern Greek literatures"
+    },
+    {
+      "LCC": "PB",
+      "LCC Range": "PB",
+      "LCC Caption": "Modern languages. Celtic languages",
+      "DDC": 491.6,
+      "DDC Caption": "Celtic languages"
+    },
+    {
+      "LCC": "PB",
+      "LCC Range": "PB",
+      "LCC Caption": "Modern languages. Celtic languages",
+      "DDC": 891.6,
+      "DDC Caption": "Celtic literatures"
+    },
+    {
+      "LCC": "PB",
+      "LCC Range": "PB 1 - 431",
+      "LCC Caption": "Modern languages. Celtic languages--General",
+      "DDC": 410,
+      "DDC Caption": "Linguistics"
+    },
+    {
+      "LCC": "PC",
+      "LCC Range": "PC",
+      "LCC Caption": "Romance languages",
+      "DDC": 849,
+      "DDC Caption": "Provencal & Catalan literatures"
+    },
+    {
+      "LCC": "PC",
+      "LCC Range": "PC",
+      "LCC Caption": "Romance languages",
+      "DDC": 859,
+      "DDC Caption": "Romanian & Rhaeto-Romanic literatures"
+    },
+    {
+      "LCC": "PC",
+      "LCC Range": "PC 2001 - 3761",
+      "LCC Caption": "Romance languages",
+      "DDC": 440,
+      "DDC Caption": "French & related languages"
+    },
+    {
+      "LCC": "PC",
+      "LCC Range": "PC 4001+",
+      "LCC Caption": "Romance languages",
+      "DDC": 460,
+      "DDC Caption": "Spanish & Portuguese languages"
+    },
+    {
+      "LCC": "PC",
+      "LCC Range": "PC 601 - 1984",
+      "LCC Caption": "Romance languages",
+      "DDC": 450,
+      "DDC Caption": "Italian, Romanian & related languages"
+    },
+    {
+      "LCC": "PD",
+      "LCC Range": "PD",
+      "LCC Caption": "Germanic languages. Scandinavian languages",
+      "DDC": "430 - 438",
+      "DDC Caption": "German & related languages"
+    },
+    {
+      "LCC": "PD",
+      "LCC Range": "PD",
+      "LCC Caption": "Germanic languages. Scandinavian languages",
+      "DDC": "439.5 - 439.8",
+      "DDC Caption": "North Germanic languages (Nordic languages)"
+    },
+    {
+      "LCC": "PD",
+      "LCC Range": "PD",
+      "LCC Caption": "Germanic languages. Scandinavian languages",
+      "DDC": 439.9,
+      "DDC Caption": "East Germanic languages"
+    },
+    {
+      "LCC": "PE",
+      "LCC Range": "PE",
+      "LCC Caption": "English language",
+      "DDC": 420,
+      "DDC Caption": "English & Old English Languages"
+    },
+    {
+      "LCC": "PF",
+      "LCC Range": "PF",
+      "LCC Caption": "West Germanic languages",
+      "DDC": "430 - 438",
+      "DDC Caption": "German & related languages"
+    },
+    {
+      "LCC": "PF",
+      "LCC Range": "PF",
+      "LCC Caption": "West Germanic languages",
+      "DDC": "439.2 - 439.4",
+      "DDC Caption": "Low Germanic languages"
+    },
+    {
+      "LCC": "PF",
+      "LCC Range": "PF",
+      "LCC Caption": "West Germanic languages",
+      "DDC": 839.2,
+      "DDC Caption": "Frisian literature"
+    },
+    {
+      "LCC": "PG",
+      "LCC Range": "PG",
+      "LCC Caption": "Slavic, Baltic, Albanian languages & literatures",
+      "DDC": 491.7,
+      "DDC Caption": "East Slavic languages; Russian language"
+    },
+    {
+      "LCC": "PG",
+      "LCC Range": "PG",
+      "LCC Caption": "Slavic, Baltic, Albanian languages & literatures",
+      "DDC": 491.8,
+      "DDC Caption": "Slavic (Slavonic) languages"
+    },
+    {
+      "LCC": "PG",
+      "LCC Range": "PG",
+      "LCC Caption": "Slavic, Baltic, Albanian languages & literatures",
+      "DDC": "491.9 - 491.991",
+      "DDC Caption": "Baltic languages; Albanian language"
+    },
+    {
+      "LCC": "PG",
+      "LCC Range": "PG",
+      "LCC Caption": "Slavic, Baltic, Albanian languages & literatures",
+      "DDC": 891.7,
+      "DDC Caption": "East Slavic literatures; Russian literature"
+    },
+    {
+      "LCC": "PG",
+      "LCC Range": "PG",
+      "LCC Caption": "Slavic, Baltic, Albanian languages & literatures",
+      "DDC": 891.8,
+      "DDC Caption": "Slavic (Slavonic) literatures"
+    },
+    {
+      "LCC": "PG",
+      "LCC Range": "PG",
+      "LCC Caption": "Slavic, Baltic, Albanian languages & literatures",
+      "DDC": "891.9 - 891.991",
+      "DDC Caption": "Baltic literatures; Albanian literature"
+    },
+    {
+      "LCC": "PH",
+      "LCC Range": "PH",
+      "LCC Caption": "Finno-Ugric, Basque languages & literatures",
+      "DDC": 494.4,
+      "DDC Caption": "Samoyedic languages"
+    },
+    {
+      "LCC": "PH",
+      "LCC Range": "PH",
+      "LCC Caption": "Finno-Ugric, Basque languages & literatures",
+      "DDC": 494.5,
+      "DDC Caption": "Finno-Ugric languages"
+    },
+    {
+      "LCC": "PH",
+      "LCC Range": "PH",
+      "LCC Caption": "Finno-Ugric, Basque languages & literatures",
+      "DDC": 499.92,
+      "DDC Caption": "Basque language"
+    },
+    {
+      "LCC": "PH",
+      "LCC Range": "PH",
+      "LCC Caption": "Finno-Ugric, Basque languages & literatures",
+      "DDC": 894.5,
+      "DDC Caption": "Finno-Ugric literatures"
+    },
+    {
+      "LCC": "PH",
+      "LCC Range": "PH",
+      "LCC Caption": "Finno-Ugric, Basque languages & literatures",
+      "DDC": 899.92,
+      "DDC Caption": "Basque literature"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures--Yiddish language",
+      "DDC": 439.1,
+      "DDC Caption": "Yiddish language"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures",
+      "DDC": 492,
+      "DDC Caption": "Afro-Asiatic languages; Semitic languages"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures",
+      "DDC": "493 - 493.5",
+      "DDC Caption": "Non-Semitic Afro-Asiatic languages"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures",
+      "DDC": 499.95,
+      "DDC Caption": "Sumerian language"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures--Yiddish literature",
+      "DDC": 839.1,
+      "DDC Caption": "Yiddish literature"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures",
+      "DDC": 892,
+      "DDC Caption": "Afro-Asiatic literatures; Semitic literatures"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures",
+      "DDC": "893 - 893.5",
+      "DDC Caption": "Non-Semitic Afro-Asiatic literatures"
+    },
+    {
+      "LCC": "PJ",
+      "LCC Range": "PJ",
+      "LCC Caption": "Oriental languages & literatures",
+      "DDC": 899.95,
+      "DDC Caption": "Sumerian literature"
+    },
+    {
+      "LCC": "PK",
+      "LCC Range": "PK",
+      "LCC Caption": "Indo-Iranian language & literature",
+      "DDC": "491.1 - 491.5",
+      "DDC Caption": "Indo-Iranian languages"
+    },
+    {
+      "LCC": "PK",
+      "LCC Range": "PK",
+      "LCC Caption": "Indo-Iranian language & literature",
+      "DDC": 499.96,
+      "DDC Caption": "Caucasian languages"
+    },
+    {
+      "LCC": "PK",
+      "LCC Range": "PK",
+      "LCC Caption": "Indo-Iranian language & literature",
+      "DDC": "891.1 - 891.5",
+      "DDC Caption": "Indo-Iranian literatures"
+    },
+    {
+      "LCC": "PK",
+      "LCC Range": "PK",
+      "LCC Caption": "Indo-Iranian language & literature",
+      "DDC": 899.96,
+      "DDC Caption": "Caucasian literatures"
+    },
+    {
+      "LCC": "PK",
+      "LCC Range": "PK 8001 - 8499",
+      "LCC Caption": "Indo-Iranian language & literature",
+      "DDC": 491.992,
+      "DDC Caption": "Armenian language"
+    },
+    {
+      "LCC": "PK",
+      "LCC Range": "PK 8501 - 8835",
+      "LCC Caption": "Indo-Iranian language & literature",
+      "DDC": 891.992,
+      "DDC Caption": "Armenian literature"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": "494 - 494.3",
+      "DDC Caption": "Ural-Altaic languages"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 494.6,
+      "DDC Caption": "Ainu language"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 494.8,
+      "DDC Caption": "Dravidian languages"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 495,
+      "DDC Caption": "Languages of East & Southeast Asia"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": "499.1 - 499.5",
+      "DDC Caption": "Austronesian & other languages"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": "894 - 894.4",
+      "DDC Caption": "Ural-Altaic literatures"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 894.6,
+      "DDC Caption": "Ainu literature"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 894.8,
+      "DDC Caption": "Dravidian literatures"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 895,
+      "DDC Caption": "Literatures of East & Southeast Asia"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": "899.1 - 899.5",
+      "DDC Caption": "Austronesian & other literatures"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL 8000 - 8844",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 493.7,
+      "DDC Caption": "Chadic languages"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL 8000 - 8844",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 496,
+      "DDC Caption": "African languages"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL 8000 - 8844",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 893.7,
+      "DDC Caption": "Chadic literatures"
+    },
+    {
+      "LCC": "PL",
+      "LCC Range": "PL 8000 - 8844",
+      "LCC Caption": "Languages of Eastern Asia, Africa, Oceania",
+      "DDC": 896,
+      "DDC Caption": "African literatures"
+    },
+    {
+      "LCC": "PM",
+      "LCC Range": "PM",
+      "LCC Caption": "Hyperborean, Indian, & artificial languages",
+      "DDC": 494.6,
+      "DDC Caption": "Altaic, Uralic, Hyperborean, Dravidian languages"
+    },
+    {
+      "LCC": "PM",
+      "LCC Range": "PM",
+      "LCC Caption": "Hyperborean, Indian, & artificial languages",
+      "DDC": 497,
+      "DDC Caption": "North American native languages"
+    },
+    {
+      "LCC": "PM",
+      "LCC Range": "PM",
+      "LCC Caption": "Hyperborean, Indian, & artificial languages",
+      "DDC": 498,
+      "DDC Caption": "South American native languages"
+    },
+    {
+      "LCC": "PM",
+      "LCC Range": "PM",
+      "LCC Caption": "Hyperborean, Indian, & artificial languages",
+      "DDC": 499.99,
+      "DDC Caption": "Artificial languages"
+    },
+    {
+      "LCC": "PM",
+      "LCC Range": "PM",
+      "LCC Caption": "Hyperborean, Indian, & artificial languages",
+      "DDC": 897,
+      "DDC Caption": "Literatures of North American native languages"
+    },
+    {
+      "LCC": "PM",
+      "LCC Range": "PM",
+      "LCC Caption": "Hyperborean, Indian, & artificial languages",
+      "DDC": 898,
+      "DDC Caption": "Literatures of South American native languages"
+    },
+    {
+      "LCC": "PN",
+      "LCC Range": "PN",
+      "LCC Caption": "Literature (General)",
+      "DDC": "800 - 809",
+      "DDC Caption": "Literature, rhetoric & criticism"
+    },
+    {
+      "LCC": "PQ",
+      "LCC Range": "PQ 1 - 3999",
+      "LCC Caption": "French, Italian, Spanish, & Portuguese literatures",
+      "DDC": 840,
+      "DDC Caption": "French & related literatures"
+    },
+    {
+      "LCC": "PQ",
+      "LCC Range": "PQ 4001 - 5999",
+      "LCC Caption": "French, Italian, Spanish, & Portuguese literatures",
+      "DDC": 850,
+      "DDC Caption": "Italian, Romanian & related literatures"
+    },
+    {
+      "LCC": "PQ",
+      "LCC Range": "PQ 6001+",
+      "LCC Caption": "French, Italian, Spanish, & Portuguese literatures",
+      "DDC": 860,
+      "DDC Caption": "Spanish & Portuguese literatures"
+    },
+    {
+      "LCC": "PR",
+      "LCC Range": "PR",
+      "LCC Caption": "English literature",
+      "DDC": 820,
+      "DDC Caption": "English & Old English (Anglo-Saxon) literatures"
+    },
+    {
+      "LCC": "PS",
+      "LCC Range": "PS",
+      "LCC Caption": "American literature",
+      "DDC": 810,
+      "DDC Caption": "American literature in English"
+    },
+    {
+      "LCC": "PT",
+      "LCC Range": "PT",
+      "LCC Caption": "German literature",
+      "DDC": 830,
+      "DDC Caption": "German & related literatures"
+    },
+    {
+      "LCC": "PZ",
+      "LCC Range": "PZ",
+      "LCC Caption": "Juvenile belles lettres",
+      "DDC": "Not a DDC class",
+      "DDC Caption": "na"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 500,
+      "DDC Caption": "Natural sciences & mathematics"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 501,
+      "DDC Caption": "Philosophy of science"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 502,
+      "DDC Caption": "Miscellany"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 503,
+      "DDC Caption": "Dictionaries & encyclopedias"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 505,
+      "DDC Caption": "Serial publications"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 506,
+      "DDC Caption": "Organizations & management"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 507,
+      "DDC Caption": "Education, research, related topics"
+    },
+    {
+      "LCC": "Q",
+      "LCC Range": "Q",
+      "LCC Caption": "Science (General)",
+      "DDC": 509,
+      "DDC Caption": "Historical, geographic, persons treatment"
+    },
+    {
+      "LCC": "QA",
+      "LCC Range": "QA",
+      "LCC Caption": "Mathematics",
+      "DDC": 3,
+      "DDC Caption": "Systems"
+    },
+    {
+      "LCC": "QA",
+      "LCC Range": "QA",
+      "LCC Caption": "Mathematics",
+      "DDC": 510,
+      "DDC Caption": "Mathematics"
+    },
+    {
+      "LCC": "QA",
+      "LCC Range": "QA75.5 - 76.95",
+      "LCC Caption": "Mathematics",
+      "DDC": "004 - 006",
+      "DDC Caption": "Data processing; Computer science"
+    },
+    {
+      "LCC": "QB",
+      "LCC Range": "QB",
+      "LCC Caption": "Astronomy",
+      "DDC": 520,
+      "DDC Caption": "Astronomy & allied sciences"
+    },
+    {
+      "LCC": "QB",
+      "LCC Range": "QB",
+      "LCC Caption": "Astronomy",
+      "DDC": 521,
+      "DDC Caption": "Celestial mechanics"
+    },
+    {
+      "LCC": "QB",
+      "LCC Range": "QB",
+      "LCC Caption": "Astronomy",
+      "DDC": 522,
+      "DDC Caption": "Techniques, equipment, materials"
+    },
+    {
+      "LCC": "QB",
+      "LCC Range": "QB",
+      "LCC Caption": "Astronomy",
+      "DDC": 523,
+      "DDC Caption": "Specific celestial bodies & phenomena"
+    },
+    {
+      "LCC": "QB",
+      "LCC Range": "QB",
+      "LCC Caption": "Astronomy",
+      "DDC": 525,
+      "DDC Caption": "Earth (Astronomical geography)"
+    },
+    {
+      "LCC": "QB",
+      "LCC Range": "QB",
+      "LCC Caption": "Astronomy",
+      "DDC": 528,
+      "DDC Caption": "Ephemerides"
+    },
+    {
+      "LCC": "QB",
+      "LCC Range": "QB",
+      "LCC Caption": "Astronomy",
+      "DDC": 529,
+      "DDC Caption": "Chronology"
+    },
+    {
+      "LCC": "QC",
+      "LCC Range": "QC",
+      "LCC Caption": "Physics",
+      "DDC": 530,
+      "DDC Caption": "Physics"
+    },
+    {
+      "LCC": "QD",
+      "LCC Range": "QD",
+      "LCC Caption": "Chemistry",
+      "DDC": 540,
+      "DDC Caption": "Chemistry & allied sciences"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 550,
+      "DDC Caption": "Earth sciences"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 551,
+      "DDC Caption": "Geology, hydrology, meteorology"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 552,
+      "DDC Caption": "Petrology"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 553,
+      "DDC Caption": "Economic geology"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 554,
+      "DDC Caption": "Earth sciences of Europe"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 555,
+      "DDC Caption": "Earth sciences of Asia"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 556,
+      "DDC Caption": "Earth sciences of Africa"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 557,
+      "DDC Caption": "Earth sciences of North America"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 558,
+      "DDC Caption": "Earth sciences of South America"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE",
+      "LCC Caption": "Geology",
+      "DDC": 559,
+      "DDC Caption": "Earth sciences of other areas"
+    },
+    {
+      "LCC": "QE",
+      "LCC Range": "QE701+",
+      "LCC Caption": "Geology--Paleontology",
+      "DDC": "560 - 561",
+      "DDC Caption": "Paleontology; Paleozoology"
+    },
+    {
+      "LCC": "QH",
+      "LCC Range": "QH",
+      "LCC Caption": "Biology (General)",
+      "DDC": 576,
+      "DDC Caption": "Genetics & evolution"
+    },
+    {
+      "LCC": "QH",
+      "LCC Range": "QH",
+      "LCC Caption": "Biology (General)",
+      "DDC": 577,
+      "DDC Caption": "Ecology"
+    },
+    {
+      "LCC": "QH",
+      "LCC Range": "QH",
+      "LCC Caption": "Biology (General)",
+      "DDC": 578,
+      "DDC Caption": "Natural history of organisms"
+    },
+    {
+      "LCC": "QHN",
+      "LCC Range": "QHN",
+      "LCC Caption": "Natural history (General)",
+      "DDC": 508,
+      "DDC Caption": "Natural history"
+    },
+    {
+      "LCC": "QK",
+      "LCC Range": "QK",
+      "LCC Caption": "Botany",
+      "DDC": 571,
+      "DDC Caption": "Physiology & related subjects"
+    },
+    {
+      "LCC": "QK",
+      "LCC Range": "QK",
+      "LCC Caption": "Botany",
+      "DDC": 572,
+      "DDC Caption": "Biochemistry"
+    },
+    {
+      "LCC": "QK",
+      "LCC Range": "QK",
+      "LCC Caption": "Botany",
+      "DDC": 573,
+      "DDC Caption": "Specific systems in animals"
+    },
+    {
+      "LCC": "QK",
+      "LCC Range": "QK",
+      "LCC Caption": "Botany",
+      "DDC": 575,
+      "DDC Caption": "Specific parts of & physiological systems in plants"
+    },
+    {
+      "LCC": "QK",
+      "LCC Range": "QK",
+      "LCC Caption": "Botany",
+      "DDC": "579.4 - 579.8",
+      "DDC Caption": "Protozoa, fungi, mushrooms, lichens, algae"
+    },
+    {
+      "LCC": "QK",
+      "LCC Range": "QK",
+      "LCC Caption": "Botany",
+      "DDC": 580,
+      "DDC Caption": "Plants"
+    },
+    {
+      "LCC": "QL",
+      "LCC Range": "QL",
+      "LCC Caption": "Zoology",
+      "DDC": 590,
+      "DDC Caption": "Animals"
+    },
+    {
+      "LCC": "QM",
+      "LCC Range": "QM",
+      "LCC Caption": "Human anatomy",
+      "DDC": 611,
+      "DDC Caption": "Human anatomy, cytology, histology"
+    },
+    {
+      "LCC": "QP",
+      "LCC Range": "QP",
+      "LCC Caption": "Physiology",
+      "DDC": 571,
+      "DDC Caption": "Physiology & related subjects"
+    },
+    {
+      "LCC": "QP",
+      "LCC Range": "QP",
+      "LCC Caption": "Physiology",
+      "DDC": 572,
+      "DDC Caption": "Biochemistry"
+    },
+    {
+      "LCC": "QP",
+      "LCC Range": "QP",
+      "LCC Caption": "Physiology",
+      "DDC": 573,
+      "DDC Caption": "Specific systems in animals"
+    },
+    {
+      "LCC": "QP",
+      "LCC Range": "QP",
+      "LCC Caption": "Physiology",
+      "DDC": 612,
+      "DDC Caption": "Human physiology"
+    },
+    {
+      "LCC": "QR",
+      "LCC Range": "QR",
+      "LCC Caption": "Microbiology",
+      "DDC": "579 - 579.3",
+      "DDC Caption": "Microorganisms"
+    },
+    {
+      "LCC": "QS",
+      "LCC Range": "QS",
+      "LCC Caption": "Human Anatomy",
+      "DDC": 611,
+      "DDC Caption": "Human anatomy, cytology, histology"
+    },
+    {
+      "LCC": "QS",
+      "LCC Range": "QS1-132",
+      "LCC Caption": "Anatomy",
+      "DDC": 611,
+      "DDC Caption": "Human anatomy, cytology, histology"
+    },
+    {
+      "LCC": "QS",
+      "LCC Range": "QS504-539",
+      "LCC Caption": "Histology",
+      "DDC": 362.1783,
+      "DDC Caption": "Organ & tissue banks"
+    },
+    {
+      "LCC": "QS",
+      "LCC Range": "QS504-539",
+      "LCC Caption": "Histology",
+      "DDC": 611.018,
+      "DDC Caption": "Cytology & histology"
+    },
+    {
+      "LCC": "QS",
+      "LCC Range": "QS604-681",
+      "LCC Caption": "Embryology",
+      "DDC": 612.64,
+      "DDC Caption": "Physiology of embryo & fetus"
+    },
+    {
+      "LCC": "QS",
+      "LCC Range": "QS604-681",
+      "LCC Caption": "Embryology",
+      "DDC": 616.043,
+      "DDC Caption": "Congenital diseases"
+    },
+    {
+      "LCC": "QT",
+      "LCC Range": "QT",
+      "LCC Caption": "Physiology",
+      "DDC": 612,
+      "DDC Caption": "Human physiology"
+    },
+    {
+      "LCC": "QT",
+      "LCC Range": "QT104-172",
+      "LCC Caption": "Human Physiology",
+      "DDC": 612,
+      "DDC Caption": "Human physiology"
+    },
+    {
+      "LCC": "QT",
+      "LCC Range": "QT1-33.1",
+      "LCC Caption": "Physiology (General)",
+      "DDC": 612,
+      "DDC Caption": "Human physiology"
+    },
+    {
+      "LCC": "QT",
+      "LCC Range": "QT180-275",
+      "LCC Caption": "Physiology & Hygiene",
+      "DDC": 613,
+      "DDC Caption": "Promotion of health"
+    },
+    {
+      "LCC": "QT",
+      "LCC Range": "QT180-275",
+      "LCC Caption": "Physiology & Hygiene",
+      "DDC": 617.1027,
+      "DDC Caption": "Athletic injuries"
+    },
+    {
+      "LCC": "QU",
+      "LCC Range": "QU",
+      "LCC Caption": "Biochemistry",
+      "DDC": 612.015,
+      "DDC Caption": "Biochemistry"
+    },
+    {
+      "LCC": "QU",
+      "LCC Range": "QU",
+      "LCC Caption": "Biochemistry",
+      "DDC": 613.2,
+      "DDC Caption": "Dietetics"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV",
+      "LCC Caption": "Pharmacology",
+      "DDC": 615.1,
+      "DDC Caption": "Drugs (Materia medica)"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV11",
+      "LCC Caption": "Pharmacology--History",
+      "DDC": 615.109,
+      "DDC Caption": "Drugs (Materia medica)--history"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV1-370",
+      "LCC Caption": "Pharmacology (General)",
+      "DDC": 615.1,
+      "DDC Caption": "Drugs (Materia medica)"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV1-370",
+      "LCC Caption": "Pharmacology (General)",
+      "DDC": 615.2,
+      "DDC Caption": "Inorganic drugs"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV1-370",
+      "LCC Caption": "Pharmacology (General)",
+      "DDC": 615.3,
+      "DDC Caption": "Organic drugs"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV1-370",
+      "LCC Caption": "Pharmacology (General)",
+      "DDC": 615.7,
+      "DDC Caption": "Pharmacodynamics"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV600-667",
+      "LCC Caption": "Toxicology",
+      "DDC": 615.9,
+      "DDC Caption": "Toxicology"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV701-835",
+      "LCC Caption": "Pharmacy and Pharmaceutics",
+      "DDC": 615.1,
+      "DDC Caption": "Drugs (Materia medica)"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV701-835",
+      "LCC Caption": "Pharmacy and Pharmaceutics",
+      "DDC": 615.2,
+      "DDC Caption": "Inorganic drugs"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV701-835",
+      "LCC Caption": "Pharmacy and Pharmaceutics",
+      "DDC": 615.3,
+      "DDC Caption": "Organic drugs"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV701-835",
+      "LCC Caption": "Pharmacy and Pharmaceutics",
+      "DDC": 615.4,
+      "DDC Caption": "Practical pharmacy"
+    },
+    {
+      "LCC": "QV",
+      "LCC Range": "QV701-835",
+      "LCC Caption": "Pharmacy and Pharmaceutics",
+      "DDC": 615.7,
+      "DDC Caption": "Pharmacodynamics"
+    },
+    {
+      "LCC": "QW",
+      "LCC Range": "QW",
+      "LCC Caption": "Microbiology and Immunology",
+      "DDC": 616.01,
+      "DDC Caption": "Medical microbiology"
+    },
+    {
+      "LCC": "QW",
+      "LCC Range": "QW",
+      "LCC Caption": "Microbiology and Immunology",
+      "DDC": 616.079,
+      "DDC Caption": "Immunity"
+    },
+    {
+      "LCC": "QX",
+      "LCC Range": "QX",
+      "LCC Caption": "Parasitology",
+      "DDC": 616.96,
+      "DDC Caption": "Parasitic diseases"
+    },
+    {
+      "LCC": "QY",
+      "LCC Range": "QY",
+      "LCC Caption": "Clinical Pathology",
+      "DDC": 616.07,
+      "DDC Caption": "Pathology"
+    },
+    {
+      "LCC": "QY",
+      "LCC Range": "QY11",
+      "LCC Caption": "Clinical Pathology--History",
+      "DDC": 616.0709,
+      "DDC Caption": "Pathology--history"
+    },
+    {
+      "LCC": "QZ",
+      "LCC Range": "QZ",
+      "LCC Caption": "Pathology",
+      "DDC": 571.9,
+      "DDC Caption": "Diseases--Pathology"
+    },
+    {
+      "LCC": "QZ",
+      "LCC Range": "QZ",
+      "LCC Caption": "Pathology",
+      "DDC": 616.07,
+      "DDC Caption": "Pathology"
+    },
+    {
+      "LCC": "QZ",
+      "LCC Range": "QZ",
+      "LCC Caption": "Pathology",
+      "DDC": 616.992,
+      "DDC Caption": "Tumors"
+    },
+    {
+      "LCC": "QZ",
+      "LCC Range": "QZ",
+      "LCC Caption": "Pathology",
+      "DDC": 616.993,
+      "DDC Caption": "Benign tumors"
+    },
+    {
+      "LCC": "QZ",
+      "LCC Range": "QZ",
+      "LCC Caption": "Pathology",
+      "DDC": 616.994,
+      "DDC Caption": "Cancers"
+    },
+    {
+      "LCC": "QZ",
+      "LCC Range": "QZ",
+      "LCC Caption": "Pathology",
+      "DDC": 636.089607,
+      "DDC Caption": "Veterinary pathology"
+    },
+    {
+      "LCC": "QZ",
+      "LCC Range": "QZ11",
+      "LCC Caption": "Pathology--History",
+      "DDC": 616.0709,
+      "DDC Caption": "Pathology--history"
+    },
+    {
+      "LCC": "S",
+      "LCC Range": "S",
+      "LCC Caption": "Agriculture (General)",
+      "DDC": 630,
+      "DDC Caption": "Agriculture"
+    },
+    {
+      "LCC": "S",
+      "LCC Range": "S",
+      "LCC Caption": "Agriculture (General)",
+      "DDC": "631 - 631.4",
+      "DDC Caption": "Techniques, equipment, materials"
+    },
+    {
+      "LCC": "S",
+      "LCC Range": "S",
+      "LCC Caption": "Agriculture (General)",
+      "DDC": 631.6,
+      "DDC Caption": "Clearing, drainage, revegetation"
+    },
+    {
+      "LCC": "S",
+      "LCC Range": "S",
+      "LCC Caption": "Agriculture (General)",
+      "DDC": 631.7,
+      "DDC Caption": "Water conservation"
+    },
+    {
+      "LCC": "S",
+      "LCC Range": "S",
+      "LCC Caption": "Agriculture (General)",
+      "DDC": 631.8,
+      "DDC Caption": "Fertilizers, soil conditioners, growth regulators"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": 581.6,
+      "DDC Caption": "Miscellaneous nontaxonomic kinds of plants"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": 631.5,
+      "DDC Caption": "Cultivation & harvesting"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": 632,
+      "DDC Caption": "Plant injuries, diseases, pests"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": 633,
+      "DDC Caption": "Field & plantation crops"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": "634.1 - 634.6",
+      "DDC Caption": "Orchards & their fruits"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": 634.7,
+      "DDC Caption": "Berries & herbaceous tropical & subtropical fruits"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": 634.8,
+      "DDC Caption": "Grapes"
+    },
+    {
+      "LCC": "SB",
+      "LCC Range": "SB",
+      "LCC Caption": "Plant culture",
+      "DDC": 635,
+      "DDC Caption": "Garden crops (Horticulture)"
+    },
+    {
+      "LCC": "SD",
+      "LCC Range": "SD",
+      "LCC Caption": "Forestry",
+      "DDC": 634.9,
+      "DDC Caption": "Forestry"
+    },
+    {
+      "LCC": "SF",
+      "LCC Range": "SF",
+      "LCC Caption": "Animal culture",
+      "DDC": 636,
+      "DDC Caption": "Animal husbandry"
+    },
+    {
+      "LCC": "SF",
+      "LCC Range": "SF",
+      "LCC Caption": "Animal culture",
+      "DDC": 637,
+      "DDC Caption": "Processing dairy & related products"
+    },
+    {
+      "LCC": "SF",
+      "LCC Range": "SF",
+      "LCC Caption": "Animal culture",
+      "DDC": 638,
+      "DDC Caption": "Insect culture"
+    },
+    {
+      "LCC": "SF",
+      "LCC Range": "SF",
+      "LCC Caption": "Animal culture",
+      "DDC": 798,
+      "DDC Caption": "Equestrian sports & animal racing"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 639.2,
+      "DDC Caption": "Commercial fishing, whaling, sealing"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 639.3,
+      "DDC Caption": "Culture of cold-blooded vertebrates; Fish culture"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 639.4,
+      "DDC Caption": "Mollusk fisheries & culture"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 639.5,
+      "DDC Caption": "Crustacean fisheries"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 639.6,
+      "DDC Caption": "Crustacean culture"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 639.7,
+      "DDC Caption": "Harvest & culture of invertebrates other than mollusks & crustaceans"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 639.8,
+      "DDC Caption": "Aquaculture"
+    },
+    {
+      "LCC": "SH",
+      "LCC Range": "SH",
+      "LCC Caption": "Aquaculture. Fisheries. Angling",
+      "DDC": 799.1,
+      "DDC Caption": "Fishing"
+    },
+    {
+      "LCC": "SK",
+      "LCC Range": "SK",
+      "LCC Caption": "Hunting sports",
+      "DDC": 639.1,
+      "DDC Caption": "Hunting"
+    },
+    {
+      "LCC": "SK",
+      "LCC Range": "SK",
+      "LCC Caption": "Hunting sports",
+      "DDC": 639.9,
+      "DDC Caption": "Conservation of biological resources"
+    },
+    {
+      "LCC": "SK",
+      "LCC Range": "SK",
+      "LCC Caption": "Hunting sports",
+      "DDC": 799.2,
+      "DDC Caption": "Hunting"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 600,
+      "DDC Caption": "Technology (Applied sciences)"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 601,
+      "DDC Caption": "Philosophy & theory"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 602,
+      "DDC Caption": "Miscellany"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 603,
+      "DDC Caption": "Dictionaries & encyclopedias"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 604,
+      "DDC Caption": "Technical drawing, hazardous materials technology"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 605,
+      "DDC Caption": "Serial publications"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 606,
+      "DDC Caption": "Organizations"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 607,
+      "DDC Caption": "Education, research, related topics"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 608,
+      "DDC Caption": "Inventions & patents"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 609,
+      "DDC Caption": "Historical, geographic, persons treatment"
+    },
+    {
+      "LCC": "T",
+      "LCC Range": "T",
+      "LCC Caption": "Technology (General)",
+      "DDC": 620.8,
+      "DDC Caption": "Human factors & safety engineering"
+    },
+    {
+      "LCC": "TA",
+      "LCC Range": "TA",
+      "LCC Caption": "Engineering (General). Civil engineering",
+      "DDC": 526.9,
+      "DDC Caption": "Surveying"
+    },
+    {
+      "LCC": "TA",
+      "LCC Range": "TA",
+      "LCC Caption": "Engineering (General). Civil engineering",
+      "DDC": 624,
+      "DDC Caption": "Civil engineering"
+    },
+    {
+      "LCC": "TA",
+      "LCC Range": "TA",
+      "LCC Caption": "Engineering (General). Civil engineering",
+      "DDC": 624.1,
+      "DDC Caption": "Structural engineering & underground construction"
+    },
+    {
+      "LCC": "TA",
+      "LCC Range": "TA",
+      "LCC Caption": "Engineering (General). Civil engineering",
+      "DDC": 629.04,
+      "DDC Caption": "Transportation engineering"
+    },
+    {
+      "LCC": "TA",
+      "LCC Range": "TA",
+      "LCC Caption": "Engineering (General). Civil engineering",
+      "DDC": 681.2,
+      "DDC Caption": "Testing, measuring, sensing instruments"
+    },
+    {
+      "LCC": "TC",
+      "LCC Range": "TC",
+      "LCC Caption": "Hydraulic engineering",
+      "DDC": 627,
+      "DDC Caption": "Hydraulic engineering"
+    },
+    {
+      "LCC": "TD",
+      "LCC Range": "TD",
+      "LCC Caption": "Environmental technology. Sanitary engineering",
+      "DDC": 363.7,
+      "DDC Caption": "Environmental problems"
+    },
+    {
+      "LCC": "TD",
+      "LCC Range": "TD",
+      "LCC Caption": "Environmental technology. Sanitary engineering",
+      "DDC": 628,
+      "DDC Caption": "Sanitary & municipal engineering"
+    },
+    {
+      "LCC": "TE",
+      "LCC Range": "TE",
+      "LCC Caption": "Highway engineering. Roads and pavements",
+      "DDC": "625.7 - 625.8",
+      "DDC Caption": "Engineering of roads"
+    },
+    {
+      "LCC": "TG",
+      "LCC Range": "TG",
+      "LCC Caption": "Bridge engineering",
+      "DDC": "624.2 - 625.8",
+      "DDC Caption": "Bridges--Design and construction"
+    },
+    {
+      "LCC": "TH",
+      "LCC Range": "TH",
+      "LCC Caption": "Building construction",
+      "DDC": 690,
+      "DDC Caption": "Buildings"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 604.2,
+      "DDC Caption": "Technical drawing"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 621.1,
+      "DDC Caption": "Steam engineering"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 621.2,
+      "DDC Caption": "Hydraulic-power technology"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 621.4,
+      "DDC Caption": "Engines, power plants, propulsion systems"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 621.5,
+      "DDC Caption": "Pneumatic, vacuum, low-temperature technologies"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 621.6,
+      "DDC Caption": "Blowers, fans, pumps"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 621.8,
+      "DDC Caption": "Machine engineering"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 621.9,
+      "DDC Caption": "Tools"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 625.26,
+      "DDC Caption": "Locomotives"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 629.8,
+      "DDC Caption": "Automatic control engineering"
+    },
+    {
+      "LCC": "TJ",
+      "LCC Range": "TJ",
+      "LCC Caption": "Mechanical engineering and machinery",
+      "DDC": 681,
+      "DDC Caption": "Precision instruments & other devices"
+    },
+    {
+      "LCC": "TK",
+      "LCC Range": "TK",
+      "LCC Caption": "Electrical engineering. Electronics. Nuclear engineering",
+      "DDC": 621.3,
+      "DDC Caption": "Electrical engineering"
+    },
+    {
+      "LCC": "TK",
+      "LCC Range": "TK",
+      "LCC Caption": "Electrical engineering. Electronics. Nuclear engineering",
+      "DDC": 621.48,
+      "DDC Caption": "Nuclear engineering"
+    },
+    {
+      "LCC": "TL",
+      "LCC Range": "TL",
+      "LCC Caption": "Motor vehicles. Aeronautics. Astronautics",
+      "DDC": 629.1,
+      "DDC Caption": "Aerospace engineering"
+    },
+    {
+      "LCC": "TL",
+      "LCC Range": "TL",
+      "LCC Caption": "Motor vehicles. Aeronautics. Astronautics",
+      "DDC": 629.2,
+      "DDC Caption": "Motor land vehicles, cycles"
+    },
+    {
+      "LCC": "TL",
+      "LCC Range": "TL",
+      "LCC Caption": "Motor vehicles. Aeronautics. Astronautics",
+      "DDC": 629.3,
+      "DDC Caption": "Air-cushion vehicles (Ground-effect machines, Hovercraft)"
+    },
+    {
+      "LCC": "TL",
+      "LCC Range": "TL",
+      "LCC Caption": "Motor vehicles. Aeronautics. Astronautics",
+      "DDC": 629.4,
+      "DDC Caption": "Astronautics"
+    },
+    {
+      "LCC": "TN",
+      "LCC Range": "TN",
+      "LCC Caption": "Mining engineering. Metallurgy",
+      "DDC": 622,
+      "DDC Caption": "Mining & related operations"
+    },
+    {
+      "LCC": "TN",
+      "LCC Range": "TN",
+      "LCC Caption": "Mining engineering. Metallurgy",
+      "DDC": 669,
+      "DDC Caption": "Metallurgy"
+    },
+    {
+      "LCC": "TP",
+      "LCC Range": "TP",
+      "LCC Caption": "Chemical technology",
+      "DDC": 660,
+      "DDC Caption": "Chemical engineering"
+    },
+    {
+      "LCC": "TR",
+      "LCC Range": "TR",
+      "LCC Caption": "Photography",
+      "DDC": 621.367,
+      "DDC Caption": "Technological photography & photo-optics"
+    },
+    {
+      "LCC": "TR",
+      "LCC Range": "TR",
+      "LCC Caption": "Photography",
+      "DDC": 770,
+      "DDC Caption": "Photography & photographs"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 658.5,
+      "DDC Caption": "Management of production"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 664.7,
+      "DDC Caption": "Grains, other seeds, their derived products"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 664.9,
+      "DDC Caption": "Meats & allied foods"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 670,
+      "DDC Caption": "Manufacturing"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 681.1,
+      "DDC Caption": "Instruments for measuring time, counting & calculating machines"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 683,
+      "DDC Caption": "Hardware & household appliances"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 683.3,
+      "DDC Caption": "Locksmithing"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 683.4,
+      "DDC Caption": "Small firearms"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 684.1,
+      "DDC Caption": "Furniture"
+    },
+    {
+      "LCC": "TS",
+      "LCC Range": "TS",
+      "LCC Caption": "Manufactures",
+      "DDC": 685,
+      "DDC Caption": "Leather, fur goods, related products"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 646.1,
+      "DDC Caption": "Sewing materials & equipment"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 646.2,
+      "DDC Caption": "Sewing & related operations"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 646.3,
+      "DDC Caption": "Clothing & accessories"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 646.4,
+      "DDC Caption": "Clothing & accessories construction"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 646.72,
+      "DDC Caption": "Care of hair, face, skin"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 745.5,
+      "DDC Caption": "Handicrafts"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 745.7,
+      "DDC Caption": "Decorative coloring"
+    },
+    {
+      "LCC": "TT",
+      "LCC Range": "TT",
+      "LCC Caption": "Handicrafts. Arts and crafts",
+      "DDC": 746,
+      "DDC Caption": "Textile arts"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 613.2,
+      "DDC Caption": "Dietetics"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 640,
+      "DDC Caption": "Home economics & family living"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 641,
+      "DDC Caption": "Food & drink"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 642,
+      "DDC Caption": "Meals & table service"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 643,
+      "DDC Caption": "Housing & household equipment"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 644,
+      "DDC Caption": "Household utilities"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 645,
+      "DDC Caption": "Household furnishings"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 646,
+      "DDC Caption": "Sewing, clothing, personal living"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 647,
+      "DDC Caption": "Management of public households"
+    },
+    {
+      "LCC": "TX",
+      "LCC Range": "TX",
+      "LCC Caption": "Home economics. Hospitality industry",
+      "DDC": 648,
+      "DDC Caption": "Housekeeping"
+    },
+    {
+      "LCC": "U",
+      "LCC Range": "U",
+      "LCC Caption": "Military science (General)",
+      "DDC": 355.02,
+      "DDC Caption": "War & warfare"
+    },
+    {
+      "LCC": "U",
+      "LCC Range": "U",
+      "LCC Caption": "Military science (General)",
+      "DDC": 355.1,
+      "DDC Caption": "Military life & customs"
+    },
+    {
+      "LCC": "U",
+      "LCC Range": "U",
+      "LCC Caption": "Military science (General)",
+      "DDC": 355.4,
+      "DDC Caption": "Military operations"
+    },
+    {
+      "LCC": "U",
+      "LCC Range": "U",
+      "LCC Caption": "Military science (General)",
+      "DDC": 355.5,
+      "DDC Caption": "Military training"
+    },
+    {
+      "LCC": "U",
+      "LCC Range": "U",
+      "LCC Caption": "Military science (General)",
+      "DDC": 355.82,
+      "DDC Caption": "Specific kinds of weapons (ordnance)"
+    },
+    {
+      "LCC": "U",
+      "LCC Range": "U",
+      "LCC Caption": "Military science (General)",
+      "DDC": 623.4,
+      "DDC Caption": "Ordnance"
+    },
+    {
+      "LCC": "UA",
+      "LCC Range": "UA",
+      "LCC Caption": "Armies: Organization, distribution, military situation",
+      "DDC": 355.03,
+      "DDC Caption": "Military situation & policy"
+    },
+    {
+      "LCC": "UA",
+      "LCC Range": "UA",
+      "LCC Caption": "Armies: Organization, distribution, military situation",
+      "DDC": "355.3 - 355.31",
+      "DDC Caption": "Organization & personnel of military forces"
+    },
+    {
+      "LCC": "UA",
+      "LCC Range": "UA",
+      "LCC Caption": "Armies: Organization, distribution, military situation",
+      "DDC": 355.35,
+      "DDC Caption": "Combat units according to field of service"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": "355.2 - 355.23",
+      "DDC Caption": "Military resources"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": 355.22,
+      "DDC Caption": "Human resources"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": 355.23,
+      "DDC Caption": "Civilian workers"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": 355.33,
+      "DDC Caption": "Personnel & their hierarchy"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": 355.34,
+      "DDC Caption": "Noncombat services"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": 355.6,
+      "DDC Caption": "Military administration"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": 355.7,
+      "DDC Caption": "Military installations"
+    },
+    {
+      "LCC": "UB",
+      "LCC Range": "UB",
+      "LCC Caption": "Military administration",
+      "DDC": 362.86,
+      "DDC Caption": "Veterans"
+    },
+    {
+      "LCC": "UC",
+      "LCC Range": "UC",
+      "LCC Caption": "Maintenance and transportation",
+      "DDC": "355.24 - 355.29",
+      "DDC Caption": "Strategic materials"
+    },
+    {
+      "LCC": "UC",
+      "LCC Range": "UC",
+      "LCC Caption": "Maintenance and transportation",
+      "DDC": 355.621,
+      "DDC Caption": "Supply administration"
+    },
+    {
+      "LCC": "UC",
+      "LCC Range": "UC",
+      "LCC Caption": "Maintenance and transportation",
+      "DDC": 355.8,
+      "DDC Caption": "Military equipment & supplies; Weapons (Ordnance)"
+    },
+    {
+      "LCC": "UD",
+      "LCC Range": "UD",
+      "LCC Caption": "Infantry",
+      "DDC": 355.54,
+      "DDC Caption": "Basic training"
+    },
+    {
+      "LCC": "UD",
+      "LCC Range": "UD",
+      "LCC Caption": "Infantry",
+      "DDC": 356,
+      "DDC Caption": "Foot forces & warfare"
+    },
+    {
+      "LCC": "UE",
+      "LCC Range": "UE",
+      "LCC Caption": "Cavalry. Armor",
+      "DDC": 357,
+      "DDC Caption": "Mounted forces & warfare"
+    },
+    {
+      "LCC": "UE",
+      "LCC Range": "UE",
+      "LCC Caption": "Cavalry. Armor",
+      "DDC": 358.18,
+      "DDC Caption": "Armored forces"
+    },
+    {
+      "LCC": "UF",
+      "LCC Range": "UF",
+      "LCC Caption": "Artillery",
+      "DDC": 355.82,
+      "DDC Caption": "Specific kinds of weapons (ordnance)"
+    },
+    {
+      "LCC": "UF",
+      "LCC Range": "UF",
+      "LCC Caption": "Artillery",
+      "DDC": 358.1,
+      "DDC Caption": "Missile forces; army artillery & armored forces"
+    },
+    {
+      "LCC": "UF",
+      "LCC Range": "UF",
+      "LCC Caption": "Artillery",
+      "DDC": 358.12,
+      "DDC Caption": "Army artillery forces"
+    },
+    {
+      "LCC": "UF",
+      "LCC Range": "UF",
+      "LCC Caption": "Artillery",
+      "DDC": 358.13,
+      "DDC Caption": "Antiaircraft artillery forces"
+    },
+    {
+      "LCC": "UF",
+      "LCC Range": "UF",
+      "LCC Caption": "Artillery",
+      "DDC": 358.16,
+      "DDC Caption": "Coast artillery forces"
+    },
+    {
+      "LCC": "UF",
+      "LCC Range": "UF",
+      "LCC Caption": "Artillery",
+      "DDC": 623.4,
+      "DDC Caption": "Ordnance"
+    },
+    {
+      "LCC": "UG",
+      "LCC Range": "UG",
+      "LCC Caption": "Military engineering. Air forces",
+      "DDC": 358.17,
+      "DDC Caption": "Guided missile forces"
+    },
+    {
+      "LCC": "UG",
+      "LCC Range": "UG",
+      "LCC Caption": "Military engineering. Air forces",
+      "DDC": 358.2,
+      "DDC Caption": "Army engineering"
+    },
+    {
+      "LCC": "UG",
+      "LCC Range": "UG",
+      "LCC Caption": "Military engineering. Air forces",
+      "DDC": 358.3,
+      "DDC Caption": "Chemical, biological, radiological warfare"
+    },
+    {
+      "LCC": "UG",
+      "LCC Range": "UG",
+      "LCC Caption": "Military engineering. Air forces",
+      "DDC": 358.4,
+      "DDC Caption": "Air forces & warfare"
+    },
+    {
+      "LCC": "UG",
+      "LCC Range": "UG",
+      "LCC Caption": "Military engineering. Air forces",
+      "DDC": 358.8,
+      "DDC Caption": "Space forces"
+    },
+    {
+      "LCC": "UG",
+      "LCC Range": "UG",
+      "LCC Caption": "Military engineering. Air forces",
+      "DDC": 623,
+      "DDC Caption": "Military & nautical engineering"
+    },
+    {
+      "LCC": "UH",
+      "LCC Range": "UH",
+      "LCC Caption": "Other services",
+      "DDC": 355.34,
+      "DDC Caption": "Noncombat services"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": "359 - 359.009",
+      "DDC Caption": "Sea (Naval) forces & warfare"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": 359.009,
+      "DDC Caption": "Naval history"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": 359.1,
+      "DDC Caption": "Navy life"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": "359.4 - 359.5",
+      "DDC Caption": "Naval operations & training"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": 359.7,
+      "DDC Caption": "Naval installations"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": 359.82,
+      "DDC Caption": "Specific kinds of weapons (ordnance)"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": 359.83,
+      "DDC Caption": "Transportation equipment & supplies"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": 359.93,
+      "DDC Caption": "Submarine forces"
+    },
+    {
+      "LCC": "V",
+      "LCC Range": "V",
+      "LCC Caption": "Naval science (General)",
+      "DDC": 623.82,
+      "DDC Caption": "Nautical craft"
+    },
+    {
+      "LCC": "VA",
+      "LCC Range": "VA",
+      "LCC Caption": "Navies Organization, distribution, naval situation",
+      "DDC": 359.03,
+      "DDC Caption": "Situation & policy"
+    },
+    {
+      "LCC": "VA",
+      "LCC Range": "VA",
+      "LCC Caption": "Navies Organization, distribution, naval situation",
+      "DDC": "359.3 - 359.32",
+      "DDC Caption": "Organization & personnel of naval forces"
+    },
+    {
+      "LCC": "VA",
+      "LCC Range": "VA",
+      "LCC Caption": "Navies Organization, distribution, naval situation",
+      "DDC": 359.7,
+      "DDC Caption": "Naval installations"
+    },
+    {
+      "LCC": "VB",
+      "LCC Range": "VB",
+      "LCC Caption": "Naval administration",
+      "DDC": 359.6,
+      "DDC Caption": "Naval administration"
+    },
+    {
+      "LCC": "VB",
+      "LCC Range": "VB",
+      "LCC Caption": "Naval administration",
+      "DDC": 362.86,
+      "DDC Caption": "Veterans"
+    },
+    {
+      "LCC": "VC",
+      "LCC Range": "VC",
+      "LCC Caption": "Naval maintenance",
+      "DDC": 359.8,
+      "DDC Caption": "Naval equipment & supplies; Naval weapons"
+    },
+    {
+      "LCC": "VD",
+      "LCC Range": "VD",
+      "LCC Caption": "Naval seamen",
+      "DDC": 359.338,
+      "DDC Caption": "Seamen"
+    },
+    {
+      "LCC": "VE",
+      "LCC Range": "VE",
+      "LCC Caption": "Marines",
+      "DDC": 359.96,
+      "DDC Caption": "Marine forces"
+    },
+    {
+      "LCC": "VF",
+      "LCC Range": "VF",
+      "LCC Caption": "Naval ordnance",
+      "DDC": 623.4,
+      "DDC Caption": "Ordnance"
+    },
+    {
+      "LCC": "VG",
+      "LCC Range": "VG",
+      "LCC Caption": "Minor services of navies",
+      "DDC": 359.94,
+      "DDC Caption": "Naval air forces"
+    },
+    {
+      "LCC": "VG",
+      "LCC Range": "VG",
+      "LCC Caption": "Minor services of navies",
+      "DDC": 359.96,
+      "DDC Caption": "Marine forces"
+    },
+    {
+      "LCC": "VG",
+      "LCC Range": "VG",
+      "LCC Caption": "Minor services of navies",
+      "DDC": 359.97,
+      "DDC Caption": "Coast guard"
+    },
+    {
+      "LCC": "VK",
+      "LCC Range": "VK",
+      "LCC Caption": "Navigation. Merchant marine",
+      "DDC": 387.1,
+      "DDC Caption": "Ports"
+    },
+    {
+      "LCC": "VK",
+      "LCC Range": "VK",
+      "LCC Caption": "Navigation. Merchant marine",
+      "DDC": 527,
+      "DDC Caption": "Celestial navigation"
+    },
+    {
+      "LCC": "VK",
+      "LCC Range": "VK",
+      "LCC Caption": "Navigation. Merchant marine",
+      "DDC": 623.88,
+      "DDC Caption": "Seamanship"
+    },
+    {
+      "LCC": "VK",
+      "LCC Range": "VK",
+      "LCC Caption": "Navigation. Merchant marine",
+      "DDC": 623.89,
+      "DDC Caption": "Navigation"
+    },
+    {
+      "LCC": "VM",
+      "LCC Range": "VM",
+      "LCC Caption": "Naval architecture. Shipbuilding. Marine engineering",
+      "DDC": 623.81,
+      "DDC Caption": "Naval architecture"
+    },
+    {
+      "LCC": "VM",
+      "LCC Range": "VM",
+      "LCC Caption": "Naval architecture. Shipbuilding. Marine engineering",
+      "DDC": 623.82,
+      "DDC Caption": "Nautical craft"
+    },
+    {
+      "LCC": "VM",
+      "LCC Range": "VM",
+      "LCC Caption": "Naval architecture. Shipbuilding. Marine engineering",
+      "DDC": 623.83,
+      "DDC Caption": "Shipyards"
+    },
+    {
+      "LCC": "VM",
+      "LCC Range": "VM",
+      "LCC Caption": "Naval architecture. Shipbuilding. Marine engineering",
+      "DDC": 623.84,
+      "DDC Caption": "Hulls of nautical craft"
+    },
+    {
+      "LCC": "VM",
+      "LCC Range": "VM",
+      "LCC Caption": "Naval architecture. Shipbuilding. Marine engineering",
+      "DDC": 623.85,
+      "DDC Caption": "Engineering systems of nautical craft"
+    },
+    {
+      "LCC": "VM",
+      "LCC Range": "VM",
+      "LCC Caption": "Naval architecture. Shipbuilding. Marine engineering",
+      "DDC": 623.86,
+      "DDC Caption": "Equipment & outfit of nautical craft"
+    },
+    {
+      "LCC": "VM",
+      "LCC Range": "VM",
+      "LCC Caption": "Naval architecture. Shipbuilding. Marine engineering",
+      "DDC": 623.87,
+      "DDC Caption": "Power plants of nautical craft"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W",
+      "LCC Caption": "Medical Profession",
+      "DDC": 362.1,
+      "DDC Caption": "Diseases (Human)--social services"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W",
+      "LCC Caption": "Medical Profession",
+      "DDC": 610,
+      "DDC Caption": "Medical sciences; Medicine"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W100-275",
+      "LCC Caption": "Medical Service Plans",
+      "DDC": 362.1042,
+      "DDC Caption": "Diseases (Human)--social services--social aspects"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W100-275",
+      "LCC Caption": "Medical Service Plans",
+      "DDC": 368.382,
+      "DDC Caption": "Health insurance"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W1-96",
+      "LCC Caption": "Medical Profession--General",
+      "DDC": 362.1,
+      "DDC Caption": "Diseases (Human)--social services"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W1-96",
+      "LCC Caption": "Medical Profession--General",
+      "DDC": 610,
+      "DDC Caption": "Medical sciences; Medicine"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W322-323",
+      "LCC Caption": "Other Medical Services",
+      "DDC": 362.1,
+      "DDC Caption": "Diseases (Human)--social services"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W322-323",
+      "LCC Caption": "Other Medical Services",
+      "DDC": 362.1042,
+      "DDC Caption": "Diseases (Human)--social services--social aspects"
+    },
+    {
+      "LCC": "W",
+      "LCC Range": "W601-925",
+      "LCC Caption": "Forensic Medicine & Dentistry",
+      "DDC": 614.1,
+      "DDC Caption": "Forensic medicine"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA",
+      "LCC Caption": "Public health",
+      "DDC": 362.1,
+      "DDC Caption": "Diseases (Human)--social services"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA",
+      "LCC Caption": "Public Health",
+      "DDC": 614,
+      "DDC Caption": "Incidence & prevention of disease"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA11",
+      "LCC Caption": "Public Health--History",
+      "DDC": 362.109,
+      "DDC Caption": "Diseases (Human)--history"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA11",
+      "LCC Caption": "Public Health--History",
+      "DDC": 614.09,
+      "DDC Caption": "Incidence & prevention of disease--history"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA1-106",
+      "LCC Caption": "Public Health (General)",
+      "DDC": 362.1,
+      "DDC Caption": "Diseases (Human)--social services"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA1-106",
+      "LCC Caption": "Public Health (General)",
+      "DDC": 614,
+      "DDC Caption": "Incidence & prevention of disease"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA250-292",
+      "LCC Caption": "Accident and Injury Prevention",
+      "DDC": 363.1,
+      "DDC Caption": "Public safety programs"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA250-292",
+      "LCC Caption": "Accident and Injury Prevention",
+      "DDC": 613.6,
+      "DDC Caption": "Special topics of health & safety"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA250-292",
+      "LCC Caption": "Accident and Injury Prevention",
+      "DDC": 616.0252,
+      "DDC Caption": "First aid"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA250-292",
+      "LCC Caption": "Accident and Injury Prevention",
+      "DDC": 617.10262,
+      "DDC Caption": "First aid"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA300-395",
+      "LCC Caption": "Health Problems (special pops.)",
+      "DDC": 362.1042,
+      "DDC Caption": "Diseases (Human)--social services--social aspects"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA300-395",
+      "LCC Caption": "Health Problems (special pops.)",
+      "DDC": 362.108,
+      "DDC Caption": "Services to specific kinds of persons with physical illnesses"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA400-495",
+      "LCC Caption": "Occup. Med., Health and Hygiene",
+      "DDC": 362.1969803,
+      "DDC Caption": "Industrial & occupational medicine"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA400-495",
+      "LCC Caption": "Occup. Med., Health and Hygiene",
+      "DDC": 613.62,
+      "DDC Caption": "Industrial & occupational health"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA400-495",
+      "LCC Caption": "Occup. Med., Health and Hygiene",
+      "DDC": 616.9803,
+      "DDC Caption": "Industrial & occupational medicine"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA525-590",
+      "LCC Caption": "Health Admin. and Organization",
+      "DDC": 362.1,
+      "DDC Caption": "Diseases (Human)--social services"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA670-847",
+      "LCC Caption": "Sanitation and Environ. Control",
+      "DDC": 363.7,
+      "DDC Caption": "Environmental problems"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA670-847",
+      "LCC Caption": "Sanitation and Environ. Control",
+      "DDC": 628,
+      "DDC Caption": "Sanitary & municipal engineering"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA900-950",
+      "LCC Caption": "Statistics and Surveys",
+      "DDC": 362.10723,
+      "DDC Caption": "Health services--surveys--descriptive research"
+    },
+    {
+      "LCC": "WA",
+      "LCC Range": "WA900-950",
+      "LCC Caption": "Statistics and Surveys",
+      "DDC": 614.42,
+      "DDC Caption": "Incidence"
+    },
+    {
+      "LCC": "WB",
+      "LCC Range": "WB",
+      "LCC Caption": "Practice of Medicine",
+      "DDC": 610,
+      "DDC Caption": "Medical sciences; Medicine"
+    },
+    {
+      "LCC": "WB",
+      "LCC Range": "WB",
+      "LCC Caption": "Practice of Medicine",
+      "DDC": 615.5,
+      "DDC Caption": "Therapeutics"
+    },
+    {
+      "LCC": "WB",
+      "LCC Range": "WB",
+      "LCC Caption": "Practice of Medicine",
+      "DDC": 615.6,
+      "DDC Caption": "Methods of administering medication"
+    },
+    {
+      "LCC": "WB",
+      "LCC Range": "WB",
+      "LCC Caption": "Practice of Medicine",
+      "DDC": 615.8,
+      "DDC Caption": "Specific therapies & kinds of therapies"
+    },
+    {
+      "LCC": "WB",
+      "LCC Range": "WB",
+      "LCC Caption": "Practice of Medicine",
+      "DDC": 616,
+      "DDC Caption": "Diseases"
+    },
+    {
+      "LCC": "WB",
+      "LCC Range": "WB930",
+      "LCC Caption": "Homeopathy",
+      "DDC": 615.532,
+      "DDC Caption": "Homeopathy"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC",
+      "LCC Caption": "Infectious/Communicable Disease",
+      "DDC": 362.1969,
+      "DDC Caption": "Other diseases; Communicable diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC",
+      "LCC Caption": "Infectious/Communicable Disease",
+      "DDC": 614.5,
+      "DDC Caption": "Incidence of & public measures to prevent diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC",
+      "LCC Caption": "Infectious/Communicable Disease",
+      "DDC": 616.9,
+      "DDC Caption": "Other diseases; Communicable diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC11",
+      "LCC Caption": "Infectious/Comm. Dis.--History",
+      "DDC": 362.1969009,
+      "DDC Caption": "Other diseases; Communicable diseases--history"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC11",
+      "LCC Caption": "Infectious/Comm. Dis.--History",
+      "DDC": 616.909,
+      "DDC Caption": "Other diseases; Communicable diseases--history"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC1-100",
+      "LCC Caption": "Infectious/Comm. Dis. (General)",
+      "DDC": 362.1969,
+      "DDC Caption": "Other diseases; Communicable diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC1-100",
+      "LCC Caption": "Infectious/Comm. Dis. (General)",
+      "DDC": 616.9,
+      "DDC Caption": "Other diseases; Communicable diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC140-185",
+      "LCC Caption": "Sexually Transmitted Diseases",
+      "DDC": 362.196951,
+      "DDC Caption": "Sexually transmitted diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC140-185",
+      "LCC Caption": "Sexually Transmitted Diseases",
+      "DDC": 616.951,
+      "DDC Caption": "Sexually transmitted diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC195-425",
+      "LCC Caption": "Infection/Bacterial Infections",
+      "DDC": 362.19692,
+      "DDC Caption": "Bacterial & viral diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC195-425",
+      "LCC Caption": "Infection/Bacterial Infections",
+      "DDC": 616.92,
+      "DDC Caption": "Bacterial & viral diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC500-593",
+      "LCC Caption": "Virus Diseases",
+      "DDC": 362.196925,
+      "DDC Caption": "Viral diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC500-593",
+      "LCC Caption": "Virus Diseases",
+      "DDC": 362.1969792,
+      "DDC Caption": "Acquired immune deficiency syndrome (AIDS)"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC500-593",
+      "LCC Caption": "Virus Diseases",
+      "DDC": 616.925,
+      "DDC Caption": "Viral diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC500-593",
+      "LCC Caption": "Virus Diseases",
+      "DDC": 616.9792,
+      "DDC Caption": "Acquired immune deficiency syndrome (AIDS)"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC680-950",
+      "LCC Caption": "Tropical and Parasitic Diseases",
+      "DDC": 362.19696,
+      "DDC Caption": "Parasitic diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC680-950",
+      "LCC Caption": "Tropical and Parasitic Diseases",
+      "DDC": 362.1969883,
+      "DDC Caption": "Tropical diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC680-950",
+      "LCC Caption": "Tropical and Parasitic Diseases",
+      "DDC": 616.96,
+      "DDC Caption": "Parasitic diseases"
+    },
+    {
+      "LCC": "WC",
+      "LCC Range": "WC680-950",
+      "LCC Caption": "Tropical and Parasitic Diseases",
+      "DDC": 616.9883,
+      "DDC Caption": "Tropical diseases"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD200-226",
+      "LCC Caption": "Metabolic Diseases",
+      "DDC": 362.19639,
+      "DDC Caption": "Nutritional & metabolic diseases"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD200-226",
+      "LCC Caption": "Metabolic Diseases",
+      "DDC": 616.39,
+      "DDC Caption": "Nutritional & metabolic diseases"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD400-430",
+      "LCC Caption": "Animal Poisons",
+      "DDC": 615.94,
+      "DDC Caption": "Animal poisons"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD500-530",
+      "LCC Caption": "Plant Poisons",
+      "DDC": 615.952,
+      "DDC Caption": "Plant & microorganism poisons"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD600-675",
+      "LCC Caption": "Diseases by Physical Agents",
+      "DDC": 362.196989,
+      "DDC Caption": "Diseases due to physical agents"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD600-675",
+      "LCC Caption": "Diseases by Physical Agents",
+      "DDC": 616.989,
+      "DDC Caption": "Diseases due to physical agents"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD700-758",
+      "LCC Caption": "Aviation and Space Medicine",
+      "DDC": 362.1969802,
+      "DDC Caption": "Aviation medicine"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD700-758",
+      "LCC Caption": "Aviation and Space Medicine",
+      "DDC": 362.1969802,
+      "DDC Caption": "Space medicine"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD700-758",
+      "LCC Caption": "Aviation and Space Medicine",
+      "DDC": 616.980213,
+      "DDC Caption": "Aviation medicine"
+    },
+    {
+      "LCC": "WD",
+      "LCC Range": "WD700-758",
+      "LCC Caption": "Aviation and Space Medicine",
+      "DDC": 616.980214,
+      "DDC Caption": "Space medicine"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE",
+      "LCC Caption": "Musculoskeletal System",
+      "DDC": 362.1967,
+      "DDC Caption": "Diseases of musculoskeletal system"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE",
+      "LCC Caption": "Musculoskeletal System",
+      "DDC": 362.19747,
+      "DDC Caption": "Musculoskeletal system--surgery"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE",
+      "LCC Caption": "Musculoskeletal System",
+      "DDC": 611.7,
+      "DDC Caption": "Musculoskeletal system, integument"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE",
+      "LCC Caption": "Musculoskeletal System",
+      "DDC": 612.7,
+      "DDC Caption": "Musculoskeletal system, integument"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE",
+      "LCC Caption": "Musculoskeletal System",
+      "DDC": 616.7,
+      "DDC Caption": "Diseases of musculoskeletal system"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE",
+      "LCC Caption": "Musculoskeletal System",
+      "DDC": 617.47,
+      "DDC Caption": "Musculoskeletal system--surgery"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE11",
+      "LCC Caption": "Musculoskel. System--History",
+      "DDC": 362.1967009,
+      "DDC Caption": "Diseases of musculoskeletal system--history"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE11",
+      "LCC Caption": "Musculoskel. System--History",
+      "DDC": 616.7009,
+      "DDC Caption": "Diseases of musculoskeletal system--history"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE168-190",
+      "LCC Caption": "Orthopaedics",
+      "DDC": 362.1967,
+      "DDC Caption": "Diseases of musculoskeletal system"
+    },
+    {
+      "LCC": "WE",
+      "LCC Range": "WE168-190",
+      "LCC Caption": "Orthopaedics",
+      "DDC": 616.7,
+      "DDC Caption": "Diseases of musculoskeletal system"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 362.1962,
+      "DDC Caption": "Diseases of respiratory system"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 362.196995,
+      "DDC Caption": "Tuberculosis"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 362.19754,
+      "DDC Caption": "Respiratory system--surgery"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 611.2,
+      "DDC Caption": "Respiratory organs"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 612.2,
+      "DDC Caption": "Respiration"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 616.2,
+      "DDC Caption": "Diseases of respiratory system"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 616.995,
+      "DDC Caption": "Tuberculosis"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF",
+      "LCC Caption": "Respiratory System",
+      "DDC": 617.54,
+      "DDC Caption": "Thorax (Chest) & respiratory system"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF11",
+      "LCC Caption": "Respiratory System--History",
+      "DDC": 362.1962009,
+      "DDC Caption": "Diseases of respiratory system--history"
+    },
+    {
+      "LCC": "WF",
+      "LCC Range": "WF11",
+      "LCC Caption": "Respiratory System--History",
+      "DDC": 616.2009,
+      "DDC Caption": "Diseases of respiratory system--history"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG",
+      "LCC Caption": "Cardiovascular System",
+      "DDC": 362.1961,
+      "DDC Caption": "Diseases of cardiovascular system"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG",
+      "LCC Caption": "Cardiovascular System",
+      "DDC": 362.19741,
+      "DDC Caption": "Cardiovascular system--surgery"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG",
+      "LCC Caption": "Cardiovascular System",
+      "DDC": 611.1,
+      "DDC Caption": "Cardiovascular organs"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG",
+      "LCC Caption": "Cardiovascular System",
+      "DDC": 612.1,
+      "DDC Caption": "Cardiovascular system"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG",
+      "LCC Caption": "Cardiovascular System",
+      "DDC": 616.1,
+      "DDC Caption": "Diseases of cardiovascular system"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG",
+      "LCC Caption": "Cardiovascular System",
+      "DDC": 617.41,
+      "DDC Caption": "Cardiovascular system--surgery"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG11",
+      "LCC Caption": "Cardiovascular System--History",
+      "DDC": 362.1961009,
+      "DDC Caption": "Diseases of cardiovascular system--history"
+    },
+    {
+      "LCC": "WG",
+      "LCC Range": "WG11",
+      "LCC Caption": "Cardiovascular System--History",
+      "DDC": 616.1009,
+      "DDC Caption": "Diseases of cardiovascular system--history"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 362.19615,
+      "DDC Caption": "Diseases of blood"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 362.19642,
+      "DDC Caption": "Diseases of lymphatic system"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 611.0185,
+      "DDC Caption": "Blood & lymph elements"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 611.42,
+      "DDC Caption": "Lymphatic system"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 611.46,
+      "DDC Caption": "Lymphatic glands"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 612.11,
+      "DDC Caption": "Blood"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 612.42,
+      "DDC Caption": "Lymph & lymphatics"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 616.15,
+      "DDC Caption": "Diseases of blood"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH",
+      "LCC Caption": "Hemic/Lymph. Systems",
+      "DDC": 616.42,
+      "DDC Caption": "Diseases of lymphatic system"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH11",
+      "LCC Caption": "Hemic/Lymph. Systems--History",
+      "DDC": 362.1961501,
+      "DDC Caption": "Diseases of blood--history"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH11",
+      "LCC Caption": "Hemic/Lymph. Systems--History",
+      "DDC": 362.1964201,
+      "DDC Caption": "Diseases of lymphatic system--history"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH11",
+      "LCC Caption": "Hemic/Lymph. Systems--History",
+      "DDC": 616.15009,
+      "DDC Caption": "Diseases of blood--history"
+    },
+    {
+      "LCC": "WH",
+      "LCC Range": "WH11",
+      "LCC Caption": "Hemic/Lymph. Systems--History",
+      "DDC": 616.42009,
+      "DDC Caption": "Diseases of lymphatic system--history"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI",
+      "LCC Caption": "Gastrointestinal System",
+      "DDC": 362.1963,
+      "DDC Caption": "Diseases of digestive system"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI",
+      "LCC Caption": "Gastrointestinal System",
+      "DDC": 362.19743,
+      "DDC Caption": "Digestive system--surgery"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI",
+      "LCC Caption": "Gastrointestinal System",
+      "DDC": 611.3,
+      "DDC Caption": "Digestive tract organs"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI",
+      "LCC Caption": "Gastrointestinal System",
+      "DDC": 612.3,
+      "DDC Caption": "Digestion"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI",
+      "LCC Caption": "Gastrointestinal System",
+      "DDC": 616.3,
+      "DDC Caption": "Diseases of digestive system"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI",
+      "LCC Caption": "Gastrointestinal System",
+      "DDC": 617.43,
+      "DDC Caption": "Digestive system--surgery"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI11",
+      "LCC Caption": "Digestive System--History",
+      "DDC": 362.1963009,
+      "DDC Caption": "Diseases of digestive system--history"
+    },
+    {
+      "LCC": "WI",
+      "LCC Range": "WI11",
+      "LCC Caption": "Digestive System--History",
+      "DDC": 616.3009,
+      "DDC Caption": "Diseases of digestive system--history"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ",
+      "LCC Caption": "Urogenital System",
+      "DDC": 362.1966,
+      "DDC Caption": "Diseases of the urogenital system"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ",
+      "LCC Caption": "Urogenital System",
+      "DDC": 362.19746,
+      "DDC Caption": "Urogenital system--surgery"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ",
+      "LCC Caption": "Urogenital System",
+      "DDC": 611.6,
+      "DDC Caption": "Urogenital organs"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ",
+      "LCC Caption": "Urogenital System",
+      "DDC": 612.46,
+      "DDC Caption": "Excretion"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ",
+      "LCC Caption": "Urogenital System",
+      "DDC": 616.6,
+      "DDC Caption": "Diseases of the urogenital system"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ",
+      "LCC Caption": "Urogenital System",
+      "DDC": 617.46,
+      "DDC Caption": "Urogenital system--surgery"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ11",
+      "LCC Caption": "Urogenital System--History",
+      "DDC": 362.1966009,
+      "DDC Caption": "Diseases of the urogenital system--history"
+    },
+    {
+      "LCC": "WJ",
+      "LCC Range": "WJ11",
+      "LCC Caption": "Urogenital System--History",
+      "DDC": 616.6009,
+      "DDC Caption": "Diseases of the urogenital system--history"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK",
+      "LCC Caption": "Endocrine System",
+      "DDC": 362.1964,
+      "DDC Caption": "Endocrine system--human diseases"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK",
+      "LCC Caption": "Endocrine System",
+      "DDC": 362.19744,
+      "DDC Caption": "Endocrine system--surgery"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK",
+      "LCC Caption": "Endocrine System",
+      "DDC": 611.4,
+      "DDC Caption": "Lymphatic & glandular organs"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK",
+      "LCC Caption": "Endocrine System",
+      "DDC": 612.4,
+      "DDC Caption": "Secretion, excretion, related functions"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK",
+      "LCC Caption": "Endocrine System",
+      "DDC": 616.4,
+      "DDC Caption": "Endocrine system--human diseases"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK",
+      "LCC Caption": "Endocrine System",
+      "DDC": 617.44,
+      "DDC Caption": "Endocrine system--surgery"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK11",
+      "LCC Caption": "Endocrine System--History",
+      "DDC": 362.1964009,
+      "DDC Caption": "Endocrine system--human diseases--history"
+    },
+    {
+      "LCC": "WK",
+      "LCC Range": "WK11",
+      "LCC Caption": "Endocrine System--History",
+      "DDC": 616.4009,
+      "DDC Caption": "Endocrine system--human diseases--history"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL",
+      "LCC Caption": "Nervous System",
+      "DDC": 362.1968,
+      "DDC Caption": "Diseases of nervous system & mental disorders"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL",
+      "LCC Caption": "Nervous System",
+      "DDC": 362.19748,
+      "DDC Caption": "Nervous system--surgery"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL",
+      "LCC Caption": "Nervous System",
+      "DDC": 611.8,
+      "DDC Caption": "Nervous system"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL",
+      "LCC Caption": "Nervous System",
+      "DDC": 612.8,
+      "DDC Caption": "Nervous functions--Sensory functions"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL",
+      "LCC Caption": "Nervous System",
+      "DDC": 616.8,
+      "DDC Caption": "Diseases of nervous system & mental disorders"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL",
+      "LCC Caption": "Nervous System",
+      "DDC": 617.48,
+      "DDC Caption": "Nervous system"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL11",
+      "LCC Caption": "Nervous System--History",
+      "DDC": 362.1968009,
+      "DDC Caption": "Diseases of nervous system & mental disorders--history"
+    },
+    {
+      "LCC": "WL",
+      "LCC Range": "WL11",
+      "LCC Caption": "Nervous System--History",
+      "DDC": 616.809,
+      "DDC Caption": "Diseases of nervous system & mental disorders--history"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM11",
+      "LCC Caption": "Psychiatry--History",
+      "DDC": 616.89009,
+      "DDC Caption": "Mental disorders--history"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM1-105",
+      "LCC Caption": "Psychiatry (General)",
+      "DDC": 362.2,
+      "DDC Caption": "Mental & emotional illnesses"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM1-105",
+      "LCC Caption": "Psychiatry (General)",
+      "DDC": 616.89,
+      "DDC Caption": "Mental disorders"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM140-165",
+      "LCC Caption": "Mental Disorders. Diagnosis.",
+      "DDC": 616.89075,
+      "DDC Caption": "Mental illness--psychiatry--diagnosis"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM170-197",
+      "LCC Caption": "Neurotic Disorders",
+      "DDC": 362.25,
+      "DDC Caption": "Neuroses"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM170-197",
+      "LCC Caption": "Neurotic Disorders",
+      "DDC": 616.852,
+      "DDC Caption": "Neuroses"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM200-220",
+      "LCC Caption": "Psychotic Disorders",
+      "DDC": 362.26,
+      "DDC Caption": "Psychoses"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM200-220",
+      "LCC Caption": "Psychotic Disorders",
+      "DDC": 616.89,
+      "DDC Caption": "Mental disorders"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM270-290",
+      "LCC Caption": "Substance-Related Disorders",
+      "DDC": 362.29,
+      "DDC Caption": "Substance abuse"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM270-290",
+      "LCC Caption": "Substance-Related Disorders",
+      "DDC": 616.86,
+      "DDC Caption": "Substance abuse (Drug abuse)"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM300-308",
+      "LCC Caption": "Mental Retardation",
+      "DDC": 362.3,
+      "DDC Caption": "Mental retardation"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM300-308",
+      "LCC Caption": "Mental Retardation",
+      "DDC": 616.8588,
+      "DDC Caption": "Mental retardation & learning disabilities"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM400-460.7",
+      "LCC Caption": "Therapies",
+      "DDC": 616.891,
+      "DDC Caption": "Therapy"
+    },
+    {
+      "LCC": "WM",
+      "LCC Range": "WM475-611",
+      "LCC Caption": "Other Disorders",
+      "DDC": 616.85,
+      "DDC Caption": "Miscellaneous diseases of nervous system & mental disorders"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN",
+      "LCC Caption": "Radiology/Diagnostic Imaging",
+      "DDC": 362.1960754,
+      "DDC Caption": "Physical diagnosis"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN",
+      "LCC Caption": "Radiology/Diagnostic Imaging",
+      "DDC": 362.1960757,
+      "DDC Caption": "Radiological diagnosis"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN",
+      "LCC Caption": "Radiology/Diagnostic Imaging",
+      "DDC": 615.842,
+      "DDC Caption": "Radiotherapy (Radiation therapy, Actinotherapy)"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN",
+      "LCC Caption": "Radiology/Diagnostic Imaging",
+      "DDC": 616.0754,
+      "DDC Caption": "Physical diagnosis"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN",
+      "LCC Caption": "Radiology/Diagnostic Imaging",
+      "DDC": 616.0757,
+      "DDC Caption": "Radiological diagnosis"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN11",
+      "LCC Caption": "Radiol./Diag. Imaging--History",
+      "DDC": 616.075409,
+      "DDC Caption": "Physical diagnosis--history"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN11",
+      "LCC Caption": "Radiol./Diag. Imaging--History",
+      "DDC": 616.075709,
+      "DDC Caption": "Radiological diagnosis--history"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN440",
+      "LCC Caption": "Nuclear Medicine",
+      "DDC": 362.1960758,
+      "DDC Caption": "Radioisotope scanning"
+    },
+    {
+      "LCC": "WN",
+      "LCC Range": "WN440",
+      "LCC Caption": "Nuclear Medicine",
+      "DDC": 616.07575,
+      "DDC Caption": "Radioisotope scanning"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO",
+      "LCC Caption": "Surgery",
+      "DDC": 362.197,
+      "DDC Caption": "Surgery & related medical specialties"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO",
+      "LCC Caption": "Surgery",
+      "DDC": 617,
+      "DDC Caption": "Surgery & related medical specialties"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO11",
+      "LCC Caption": "Surgery--History",
+      "DDC": 362.197009,
+      "DDC Caption": "Surgery--history"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO11",
+      "LCC Caption": "Surgery--History",
+      "DDC": 617.09,
+      "DDC Caption": "Surgery--history"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO1-149",
+      "LCC Caption": "Surgery (General)",
+      "DDC": 362.197,
+      "DDC Caption": "Surgery & related medical specialties"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO1-149",
+      "LCC Caption": "Surgery (General)",
+      "DDC": 617,
+      "DDC Caption": "Surgery & related medical specialties"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO162-198",
+      "LCC Caption": "Surg. Procedure/Armamentarium",
+      "DDC": 362.19705,
+      "DDC Caption": "Surgery utilizing specific instruments & techniques"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO162-198",
+      "LCC Caption": "Surg. Procedure/Armamentarium",
+      "DDC": 362.19791,
+      "DDC Caption": "Operative surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO162-198",
+      "LCC Caption": "Surg. Procedure/Armamentarium",
+      "DDC": 617.05,
+      "DDC Caption": "Surgery utilizing specific instruments & techniques"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO162-198",
+      "LCC Caption": "Surg. Procedure/Armamentarium",
+      "DDC": 617.91,
+      "DDC Caption": "Operative surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO200-460",
+      "LCC Caption": "Anesthesia",
+      "DDC": 362.19796,
+      "DDC Caption": "Anesthesiology"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO200-460",
+      "LCC Caption": "Anesthesia",
+      "DDC": 617.96,
+      "DDC Caption": "Anesthesiology"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO500-517",
+      "LCC Caption": "Operative Surg./Surg. Techniques",
+      "DDC": 362.19705,
+      "DDC Caption": "Surgery utilizing specific instruments & techniques"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO500-517",
+      "LCC Caption": "Operative Surg./Surg. Techniques",
+      "DDC": 617.05,
+      "DDC Caption": "Surgery utilizing specific instruments & techniques"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO500-517",
+      "LCC Caption": "Operative Surg./Surg. Techniques",
+      "DDC": 617.91,
+      "DDC Caption": "Operative surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO600-640",
+      "LCC Caption": "Plastic Surgery",
+      "DDC": 362.19795,
+      "DDC Caption": "Plastic surgery; Organ transplants"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO600-640",
+      "LCC Caption": "Plastic Surgery",
+      "DDC": 617.95,
+      "DDC Caption": "Plastic surgery; Organ transplants"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO700-820",
+      "LCC Caption": "Traumatic/Industrial/Emerg. Surg.",
+      "DDC": 362.1971,
+      "DDC Caption": "Injuries & wounds"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO700-820",
+      "LCC Caption": "Traumatic/Industrial/Emerg. Surg.",
+      "DDC": 362.19799,
+      "DDC Caption": "Military surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO700-820",
+      "LCC Caption": "Traumatic/Industrial/Emerg. Surg.",
+      "DDC": 617.1,
+      "DDC Caption": "Injuries & wounds"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO700-820",
+      "LCC Caption": "Traumatic/Industrial/Emerg. Surg.",
+      "DDC": 617.99,
+      "DDC Caption": "Military surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO925-950",
+      "LCC Caption": "Surgery in Special Age Groups",
+      "DDC": 362.19797,
+      "DDC Caption": "Geriatric surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO925-950",
+      "LCC Caption": "Surgery in Special Age Groups",
+      "DDC": 362.19798,
+      "DDC Caption": "Pediatric surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO925-950",
+      "LCC Caption": "Surgery in Special Age Groups",
+      "DDC": 617.97,
+      "DDC Caption": "Geriatric surgery"
+    },
+    {
+      "LCC": "WO",
+      "LCC Range": "WO925-950",
+      "LCC Caption": "Surgery in Special Age Groups",
+      "DDC": 617.98,
+      "DDC Caption": "Pediatric surgery"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP",
+      "LCC Caption": "Gynecology",
+      "DDC": 362.1981,
+      "DDC Caption": "Gynecology"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP",
+      "LCC Caption": "Gynecology",
+      "DDC": 618.1,
+      "DDC Caption": "Gynecology"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP1-390",
+      "LCC Caption": "Gynecology (General)",
+      "DDC": 362.1981,
+      "DDC Caption": "Gynecology"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP1-390",
+      "LCC Caption": "Gynecology (General)",
+      "DDC": 611.65,
+      "DDC Caption": "Ovaries & fallopian tubes"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP1-390",
+      "LCC Caption": "Gynecology (General)",
+      "DDC": 618.1,
+      "DDC Caption": "Gynecology"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP400-480",
+      "LCC Caption": "Uterus & Cervix Uteri",
+      "DDC": 362.19814,
+      "DDC Caption": "Diseases of uterus"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP400-480",
+      "LCC Caption": "Uterus & Cervix Uteri",
+      "DDC": 618.14,
+      "DDC Caption": "Diseases of uterus"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP505-660",
+      "LCC Caption": "Physiology & Functional Disorders",
+      "DDC": 362.1981,
+      "DDC Caption": "Gynecology"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP505-660",
+      "LCC Caption": "Physiology & Functional Disorders",
+      "DDC": 612.62,
+      "DDC Caption": "Female reproductive system"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP505-660",
+      "LCC Caption": "Physiology & Functional Disorders",
+      "DDC": 618.1,
+      "DDC Caption": "Gynecology"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP800-910",
+      "LCC Caption": "Breast",
+      "DDC": 362.19819,
+      "DDC Caption": "Diseases of breast"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP800-910",
+      "LCC Caption": "Breast",
+      "DDC": 612.664,
+      "DDC Caption": "Mammary glands & lactation"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP800-910",
+      "LCC Caption": "Breast",
+      "DDC": 616.99449,
+      "DDC Caption": "Breast cancer--medicine"
+    },
+    {
+      "LCC": "WP",
+      "LCC Range": "WP800-910",
+      "LCC Caption": "Breast",
+      "DDC": 618.19,
+      "DDC Caption": "Diseases of breast"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ",
+      "LCC Caption": "Obstetrics",
+      "DDC": 362.1982,
+      "DDC Caption": "Obstetrics"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ",
+      "LCC Caption": "Obstetrics",
+      "DDC": 618.2,
+      "DDC Caption": "Obstetrics"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ11",
+      "LCC Caption": "Obstetrics--History",
+      "DDC": 362.1982009,
+      "DDC Caption": "Obstetrics--history"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ11",
+      "LCC Caption": "Obstetrics--History",
+      "DDC": 618.2009,
+      "DDC Caption": "Obstetrics--history"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ1-175",
+      "LCC Caption": "Obstetrics (General)",
+      "DDC": 362.1982,
+      "DDC Caption": "Obstetrics"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ1-175",
+      "LCC Caption": "Obstetrics (General)",
+      "DDC": 618.2,
+      "DDC Caption": "Obstetrics"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ200-260",
+      "LCC Caption": "Pregnancy",
+      "DDC": 362.1982,
+      "DDC Caption": "Obstetrics"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ200-260",
+      "LCC Caption": "Pregnancy",
+      "DDC": 362.1983,
+      "DDC Caption": "Diseases & complications of pregnancy"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ200-260",
+      "LCC Caption": "Pregnancy",
+      "DDC": 612.63,
+      "DDC Caption": "Pregnancy & childbirth"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ200-260",
+      "LCC Caption": "Pregnancy",
+      "DDC": 618.2,
+      "DDC Caption": "Obstetrics"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ200-260",
+      "LCC Caption": "Pregnancy",
+      "DDC": 618.3,
+      "DDC Caption": "Diseases & complications of pregnancy"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ300-330",
+      "LCC Caption": "Labor",
+      "DDC": 362.1984,
+      "DDC Caption": "Childbirth (Parturition)--Labor"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ300-330",
+      "LCC Caption": "Labor",
+      "DDC": 362.1985,
+      "DDC Caption": "Complicated labor (Dystocia)"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ300-330",
+      "LCC Caption": "Labor",
+      "DDC": 618.4,
+      "DDC Caption": "Childbirth (Parturition)--Labor"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ300-330",
+      "LCC Caption": "Labor",
+      "DDC": 618.5,
+      "DDC Caption": "Complicated labor (Dystocia)"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ400-450",
+      "LCC Caption": "Obstetrical Surgery",
+      "DDC": 362.1988,
+      "DDC Caption": "Obstetrical surgery"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ400-450",
+      "LCC Caption": "Obstetrical Surgery",
+      "DDC": 618.8,
+      "DDC Caption": "Obstetrical surgery"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ500-505",
+      "LCC Caption": "Puerperium",
+      "DDC": 362.1986,
+      "DDC Caption": "Normal puerperium"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ500-505",
+      "LCC Caption": "Puerperium",
+      "DDC": 362.1987,
+      "DDC Caption": "Puerperal diseases"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ500-505",
+      "LCC Caption": "Puerperium",
+      "DDC": 618.6,
+      "DDC Caption": "Normal puerperium"
+    },
+    {
+      "LCC": "WQ",
+      "LCC Range": "WQ500-505",
+      "LCC Caption": "Puerperium",
+      "DDC": 618.7,
+      "DDC Caption": "Puerperal diseases"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 362.1965,
+      "DDC Caption": "Diseases of integument, hair, nails"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 362.19677,
+      "DDC Caption": "Diseases of connective tissues"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 362.197477,
+      "DDC Caption": "Skin--surgery"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 611.77,
+      "DDC Caption": "Integument"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 612.79,
+      "DDC Caption": "Integument; Skin"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 616.5,
+      "DDC Caption": "Diseases of integument, hair, nails"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 616.77,
+      "DDC Caption": "Diseases of connective tissues"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR",
+      "LCC Caption": "Dermatology",
+      "DDC": 617.477,
+      "DDC Caption": "Skin--surgery"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR11",
+      "LCC Caption": "Dermatology--History",
+      "DDC": 362.1965009,
+      "DDC Caption": "Diseases of integument, hair, nails--history"
+    },
+    {
+      "LCC": "WR",
+      "LCC Range": "WR11",
+      "LCC Caption": "Dermatology--History",
+      "DDC": 616.5009,
+      "DDC Caption": "Diseases of integument, hair, nails--history"
+    },
+    {
+      "LCC": "WS",
+      "LCC Range": "WS",
+      "LCC Caption": "Pediatrics",
+      "DDC": 362.19892,
+      "DDC Caption": "Pediatrics"
+    },
+    {
+      "LCC": "WS",
+      "LCC Range": "WS",
+      "LCC Caption": "Pediatrics",
+      "DDC": 618.92,
+      "DDC Caption": "Pediatrics"
+    },
+    {
+      "LCC": "WS",
+      "LCC Range": "WS11",
+      "LCC Caption": "Pediatrics--History",
+      "DDC": 362.19892,
+      "DDC Caption": "Pediatrics--history"
+    },
+    {
+      "LCC": "WS",
+      "LCC Range": "WS11",
+      "LCC Caption": "Pediatrics--History",
+      "DDC": 618.920009,
+      "DDC Caption": "Pediatrics--history"
+    },
+    {
+      "LCC": "WT",
+      "LCC Range": "WT",
+      "LCC Caption": "Geriatrics/Chronic Diseases",
+      "DDC": 362.196044,
+      "DDC Caption": "Chronic diseases"
+    },
+    {
+      "LCC": "WT",
+      "LCC Range": "WT",
+      "LCC Caption": "Geriatrics/Chronic Diseases",
+      "DDC": 362.19897,
+      "DDC Caption": "Geriatric disorders"
+    },
+    {
+      "LCC": "WT",
+      "LCC Range": "WT",
+      "LCC Caption": "Geriatrics/Chronic Diseases",
+      "DDC": 616.044,
+      "DDC Caption": "Chronic diseases"
+    },
+    {
+      "LCC": "WT",
+      "LCC Range": "WT",
+      "LCC Caption": "Geriatrics/Chronic Diseases",
+      "DDC": 618.97,
+      "DDC Caption": "Geriatrics"
+    },
+    {
+      "LCC": "WT",
+      "LCC Range": "WT11",
+      "LCC Caption": "Geriatrics/Chronic Dis.--History",
+      "DDC": 362.196044,
+      "DDC Caption": "Chronic diseases--history"
+    },
+    {
+      "LCC": "WT",
+      "LCC Range": "WT11",
+      "LCC Caption": "Geriatrics/Chronic Dis.--History",
+      "DDC": 616.04409,
+      "DDC Caption": "Chronic diseases--history"
+    },
+    {
+      "LCC": "WU",
+      "LCC Range": "WU",
+      "LCC Caption": "Dentistry/Oral Surgery",
+      "DDC": 362.197522,
+      "DDC Caption": "Oral region"
+    },
+    {
+      "LCC": "WU",
+      "LCC Range": "WU",
+      "LCC Caption": "Dentistry/Oral Surgery",
+      "DDC": 362.1976,
+      "DDC Caption": "Dentistry"
+    },
+    {
+      "LCC": "WU",
+      "LCC Range": "WU",
+      "LCC Caption": "Dentistry/Oral Surgery",
+      "DDC": 617.522059,
+      "DDC Caption": "Oral region--surgery"
+    },
+    {
+      "LCC": "WU",
+      "LCC Range": "WU",
+      "LCC Caption": "Dentistry/Oral Surgery",
+      "DDC": 617.6,
+      "DDC Caption": "Dentistry"
+    },
+    {
+      "LCC": "WU",
+      "LCC Range": "WU11",
+      "LCC Caption": "Dentistry/Oral Surg.--History",
+      "DDC": 362.1976009,
+      "DDC Caption": "Dentistry--history"
+    },
+    {
+      "LCC": "WU",
+      "LCC Range": "WU11",
+      "LCC Caption": "Dentistry/Oral Surg.--History",
+      "DDC": 617.5220591,
+      "DDC Caption": "Oral region--surgery--history"
+    },
+    {
+      "LCC": "WU",
+      "LCC Range": "WU11",
+      "LCC Caption": "Dentistry/Oral Surg.--History",
+      "DDC": 617.609,
+      "DDC Caption": "Dentistry--history"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 362.19621,
+      "DDC Caption": "Diseases of nose, larynx, accessory organs"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 362.19622,
+      "DDC Caption": "Diseases of larynx, glottis, vocal cords, epiglottis"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 362.19751,
+      "DDC Caption": "Otorhinolaryngology"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 362.1978,
+      "DDC Caption": "Otology & audiology"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 616.21,
+      "DDC Caption": "Diseases of nose, larynx, accessory organs"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 616.22,
+      "DDC Caption": "Diseases of larynx, glottis, vocal cords, epiglottis"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 617.51,
+      "DDC Caption": "Head"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV",
+      "LCC Caption": "Otorhinolaryngology",
+      "DDC": 617.8,
+      "DDC Caption": "Otology & audiology"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV11",
+      "LCC Caption": "Otorhinolaryngology--History",
+      "DDC": 362.1975101,
+      "DDC Caption": "Otorhinolaryngology--history"
+    },
+    {
+      "LCC": "WV",
+      "LCC Range": "WV11",
+      "LCC Caption": "Otorhinolaryngology--History",
+      "DDC": 617.5109,
+      "DDC Caption": "Head--history"
+    },
+    {
+      "LCC": "WW",
+      "LCC Range": "WW",
+      "LCC Caption": "Ophthalmology",
+      "DDC": 362.1977,
+      "DDC Caption": "Ophthalmology"
+    },
+    {
+      "LCC": "WW",
+      "LCC Range": "WW",
+      "LCC Caption": "Ophthalmology",
+      "DDC": 617.7,
+      "DDC Caption": "Ophthalmology"
+    },
+    {
+      "LCC": "WW",
+      "LCC Range": "WW11",
+      "LCC Caption": "Ophthalmology--History",
+      "DDC": 362.1977009,
+      "DDC Caption": "Ophthalmology--history"
+    },
+    {
+      "LCC": "WW",
+      "LCC Range": "WW11",
+      "LCC Caption": "Ophthalmology--History",
+      "DDC": 617.709,
+      "DDC Caption": "Ophthalmology--history"
+    },
+    {
+      "LCC": "WX",
+      "LCC Range": "WX",
+      "LCC Caption": "Hospitals & Health Facilities",
+      "DDC": 362.11,
+      "DDC Caption": "Hospitals & related institutions"
+    },
+    {
+      "LCC": "WX",
+      "LCC Range": "WX11",
+      "LCC Caption": "Hospitals/Health Fac.--History",
+      "DDC": 362.1109,
+      "DDC Caption": "Hospitals & related institutions--history"
+    },
+    {
+      "LCC": "WY",
+      "LCC Range": "WY",
+      "LCC Caption": "Nursing",
+      "DDC": 362.173,
+      "DDC Caption": "Nurses--health services"
+    },
+    {
+      "LCC": "WY",
+      "LCC Range": "WY",
+      "LCC Caption": "Nursing",
+      "DDC": 610.73,
+      "DDC Caption": "Nursing"
+    },
+    {
+      "LCC": "WY",
+      "LCC Range": "WY11",
+      "LCC Caption": "Nursing--History",
+      "DDC": 362.17309,
+      "DDC Caption": "Nurses--health services--history"
+    },
+    {
+      "LCC": "WY",
+      "LCC Range": "WY11",
+      "LCC Caption": "Nursing--History",
+      "DDC": 610.7309,
+      "DDC Caption": "Nursing--history"
+    },
+    {
+      "LCC": "WZ",
+      "LCC Range": "WZ",
+      "LCC Caption": "History of Medicine",
+      "DDC": 362.109,
+      "DDC Caption": "Diseases (Human)--history"
+    },
+    {
+      "LCC": "WZ",
+      "LCC Range": "WZ",
+      "LCC Caption": "History of Medicine",
+      "DDC": 610.9,
+      "DDC Caption": "Medicine--history"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 40-104.5",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": "652-653",
+      "DDC Caption": "Processes of written communication; Shorthand"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 40-104.5",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 686,
+      "DDC Caption": "Printing & related activities"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 40-104.5",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 745.6,
+      "DDC Caption": "Calligraphy, heraldic design, illumination"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 105-115.5",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 90,
+      "DDC Caption": "Manuscripts, rare books, other rare printed materials"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 105-115.5",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 417.7,
+      "DDC Caption": "Paleography"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 116-659",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 2,
+      "DDC Caption": "Books"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 116-659",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 70.5,
+      "DDC Caption": "Publishing"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 116-659",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 686,
+      "DDC Caption": "Printing & related activities"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 662-1000.5",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 20,
+      "DDC Caption": "Library & information sciences"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 699-699.5",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": "025.04-025.06",
+      "DDC Caption": "Information storage & retrieval systems"
+    },
+    {
+      "LCC": "Z",
+      "LCC Range": "Z 1001-8999",
+      "LCC Caption": "Books. Writing. Paleography. Libraries. Bibliography",
+      "DDC": 10,
+      "DDC Caption": "Bibliography"
+    },
+    {
+      "LCC": "ZA",
+      "LCC Range": "ZA 3150-3159",
+      "LCC Caption": "Information resources (General)",
+      "DDC": 27,
+      "DDC Caption": "General libraries, archives, information centers"
+    },
+    {
+      "LCC": "ZA",
+      "LCC Range": "ZA 3201-3250",
+      "LCC Caption": "Information resources (General)",
+      "DDC": 303.4833,
+      "DDC Caption": "Information technology--social effects"
+    },
+    {
+      "LCC": "ZA",
+      "LCC Range": "ZA 4050-4480",
+      "LCC Caption": "Information resources (General)",
+      "DDC": "025.04-025.06",
+      "DDC Caption": "Information storage & retrieval systems"
+    },
+    {
+      "LCC": "ZA",
+      "LCC Range": "ZA 4050-4480",
+      "LCC Caption": "Information resources (General)",
+      "DDC": 25.524,
+      "DDC Caption": "Information search & retrieval"
+    },
+    {
+      "LCC": "ZA",
+      "LCC Range": "ZA 5060-5185",
+      "LCC Caption": "Information resources (General)",
+      "DDC": 25.04,
+      "DDC Caption": "Information storage & retrieval systems"
+    }
+  ]

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -5,1999 +5,2167 @@
 import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
 
-export default function LcCallToDewey(lcCall, genre=null) {  //{ lcCall, parentPhone }
-    console.info("Dewing it", lcCall, "--", genre)
-    if (!lcCall) return
 
-    //this if for Px class, for GV uses 'GV Bio'
-    const autoDeweyGenres = ['fiction', 'poetry', 'drama']
-    const autoDeweyGenre = genre
-    const autoDeweyResult = null
+    export function LcCallToDewey(lcCall, genre=null){  //{ lcCall, parentPhone }
+        console.info("Dewing it", lcCall, "--", genre)
+        if (!lcCall) return
 
-    const lccsWithLocalLogics = ['PG', 'PH', 'PQ', 'PR', 'PS', 'PT', 'GV']
+        //this if for Px class, for GV uses 'GV Bio'
+        const autoDeweyGenres = ['fiction', 'poetry', 'drama']
+        const autoDeweyGenre = genre
+        const autoDeweyResult = null
 
-    //autoDewey mode
-    const convertLccWithLocalLogics = (letter, number) => {
-        console.info("convertLccWithLocalLogics", letter, "--", number)
-        //these are basically copy and pasted form VBA
+        const lccsWithLocalLogics = ['PG', 'PH', 'PQ', 'PR', 'PS', 'PT', 'GV']
 
-        const Left = (str, numChars) => {
-            return str.substring(0, numChars)
-        }
+        //autoDewey mode
+        const convertLccWithLocalLogics = (letter, number) => {
+            console.info("convertLccWithLocalLogics", letter, "--", number)
+            //these are basically copy and pasted form VBA
 
-        const Mid = (str, start, numChars) => {
-            const indexStart = start - 1
-            const indexEnd = indexStart + numChars
-            return str.substring(indexStart, indexEnd)
-        }
+            const Left = (str, numChars) => {
+                return str.substring(0, numChars)
+            }
 
-        const Val = (val) => {
-            return Number(val)
-        }
+            const Mid = (str, start, numChars) => {
+                const indexStart = start - 1
+                const indexEnd = indexStart + numChars
+                return str.substring(indexStart, indexEnd)
+            }
 
-        const Len = (str) => {
-            return str.length
-        }
+            const Val = (val) => {
+                return Number(val)
+            }
 
-        const InStr = (str, subStr) => {
-            return str.includes(subStr) ? 1 : 0
-        }
+            const Len = (str) => {
+                return str.length
+            }
 
-        const IsNumeric = (val) => {
-            const testResult = Number(val)
-            return Number.isNaN(testResult) ? false : true
-        }
+            const InStr = (str, subStr) => {
+                return str.includes(subStr) ? 1 : 0
+            }
 
-        let sDewey$
-        let sGenre$
-        let sCountry$
-        const Period1 = {}
-        const Period2 = {}
-        const Period3 = {}
-        const Period4 = {}
-        const Period5 = {}
+            const IsNumeric = (val) => {
+                const testResult = Number(val)
+                return Number.isNaN(testResult) ? false : true
+            }
 
-        //https://git.loc.gov/ilspo/voyager-desktop-applications/-/blob/master/AutoDewey/AutoDewey.frm#L223
-        const _convertClassPgDrama = (sClassNo$) => {
-            if (Left(sClassNo$, 2) == "PG") {
+            let sDewey$
+            let sGenre$
+            let sCountry$
+            const Period1 = {}
+            const Period2 = {}
+            const Period3 = {}
+            const Period4 = {}
+            const Period5 = {}
+
+            //https://git.loc.gov/ilspo/voyager-desktop-applications/-/blob/master/AutoDewey/AutoDewey.frm#L223
+            const _convertClassPgDrama = (sClassNo$) => {
+                if (Left(sClassNo$, 2) == "PG") {
+                    if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
+                        sDewey$ = "891.72/1"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
+                        sDewey$ = "891.72/2"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
+                        sDewey$ = "891.72/3"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
+                        sDewey$ = "891.72/3"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
+                        // Call ButtonsToPeriod
+                        sDewey$ = "Period1917"
+                        Period1.Caption = "Period 1917-1945"
+                        Period2.Caption = "Period 1945-1991"
+                        sGenre$ = "Drama"
+                        sCountry$ = "Russia"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
+                        // Call ButtonsToPeriod
+                        sDewey$ = "Period1945"
+                        Period1.Caption = "Period 1945-1991"
+                        Period2.Caption = "Period 1991-"
+                        sGenre$ = "Drama"
+                        sCountry$ = "Russia"
+                    } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
+                        sDewey$ = "891.72/5"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
+                        // Call ButtonsToPeriod
+                        sDewey$ = "Period1800"
+                        Period1.Caption = "Period to 1799"
+                        Period2.Caption = "Period 1800-1899"
+                        Period3.Caption = "Period 1900-1991"
+                        sGenre$ = "Drama"
+                        sCountry$ = "Lithuania"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
+                        // Call ButtonsToPeriod
+                        sDewey$ = "Period1900"
+                        Period1.Caption = "Period 1900-1991"
+                        Period2.Caption = "Period 1991-"
+                        sGenre$ = "Drama"
+                        sCountry$ = "Lithuania"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
+                        sDewey$ = "891/.9224"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
+                        // Call ButtonsToPeriod
+                        sDewey$ = "Period1800"
+                        Period1.Caption = "To 1799"
+                        Period2.Caption = "Period 1800-1899"
+                        Period3.Caption = "Period 1900-1991"
+                        sGenre$ = "Drama"
+                        sCountry$ = "Latvia"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
+                        // Call ButtonsToPeriod
+                        sDewey$ = "Period1900"
+                        Period1.Caption = "Period 1900-1991"
+                        Period2.Caption = "Period 1991-"
+                        sGenre$ = "Drama"
+                        sCountry$ = "Latvia"
+                    } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
+                        sDewey$ = "891/.9324"
+                    }
+                }
+            }
+
+            const _convertClassPgFiction = (sClassNo$) => {
+
                 if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
-                    sDewey$ = "891.72/1"
+                    sDewey$ = "891.73/1"
                 } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
-                    sDewey$ = "891.72/2"
+                    sDewey$ = "891.73/2"
                 } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
-                    sDewey$ = "891.72/3"
+                    sDewey$ = "891.73/3"
                 } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
-                    sDewey$ = "891.72/3"
+                    sDewey$ = "891.73/3"
                 } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
-                    // Call ButtonsToPeriod
                     sDewey$ = "Period1917"
                     Period1.Caption = "Period 1917-1945"
                     Period2.Caption = "Period 1945-1991"
-                    sGenre$ = "Drama"
+                    sGenre$ = "Fiction"
                     sCountry$ = "Russia"
                 } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
-                    // Call ButtonsToPeriod
                     sDewey$ = "Period1945"
                     Period1.Caption = "Period 1945-1991"
                     Period2.Caption = "Period 1991-"
-                    sGenre$ = "Drama"
+                    sGenre$ = "Fiction"
                     sCountry$ = "Russia"
                 } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
-                    sDewey$ = "891.72/5"
+                    sDewey$ = "891.73/5"
                 } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
-                    // Call ButtonsToPeriod
-                    sDewey$ = "Period1800"
-                    Period1.Caption = "Period to 1799"
-                    Period2.Caption = "Period 1800-1899"
-                    Period3.Caption = "Period 1900-1991"
-                    sGenre$ = "Drama"
-                    sCountry$ = "Lithuania"
-                } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
-                    // Call ButtonsToPeriod
-                    sDewey$ = "Period1900"
-                    Period1.Caption = "Period 1900-1991"
-                    Period2.Caption = "Period 1991-"
-                    sGenre$ = "Drama"
-                    sCountry$ = "Lithuania"
-                } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
-                    sDewey$ = "891/.9224"
-                } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
-                    // Call ButtonsToPeriod
                     sDewey$ = "Period1800"
                     Period1.Caption = "To 1799"
                     Period2.Caption = "Period 1800-1899"
                     Period3.Caption = "Period 1900-1991"
-                    sGenre$ = "Drama"
-                    sCountry$ = "Latvia"
-                } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
-                    // Call ButtonsToPeriod
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Lithuania"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
                     sDewey$ = "Period1900"
                     Period1.Caption = "Period 1900-1991"
                     Period2.Caption = "Period 1991-"
-                    sGenre$ = "Drama"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Lithuania"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
+                    sDewey$ = "891/.9234"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "To 1799"
+                    Period2.Caption = "Period 1800-1899"
+                    Period3.Caption = "Period 1900-1991"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Latvia"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Fiction"
                     sCountry$ = "Latvia"
                 } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
-                    sDewey$ = "891/.9324"
+                    sDewey$ = "891/.9334"
                 }
             }
-        }
 
-        const _convertClassPgFiction = (sClassNo$) => {
-
-            if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
-                sDewey$ = "891.73/1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
-                sDewey$ = "891.73/2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
-                sDewey$ = "891.73/3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
-                sDewey$ = "891.73/3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
-                sDewey$ = "Period1917"
-                Period1.Caption = "Period 1917-1945"
-                Period2.Caption = "Period 1945-1991"
-                sGenre$ = "Fiction"
-                sCountry$ = "Russia"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1945-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Fiction"
-                sCountry$ = "Russia"
-            } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
-                sDewey$ = "891.73/5"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "To 1799"
-                Period2.Caption = "Period 1800-1899"
-                Period3.Caption = "Period 1900-1991"
-                sGenre$ = "Fiction"
-                sCountry$ = "Lithuania"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1900-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Fiction"
-                sCountry$ = "Lithuania"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
-                sDewey$ = "891/.9234"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "To 1799"
-                Period2.Caption = "Period 1800-1899"
-                Period3.Caption = "Period 1900-1991"
-                sGenre$ = "Fiction"
-                sCountry$ = "Latvia"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1900-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Fiction"
-                sCountry$ = "Latvia"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
-                sDewey$ = "891/.9334"
+            const _convertClassPgPoetry = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
+                    sDewey$ = "891.71/1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
+                    sDewey$ = "891.71/2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
+                    sDewey$ = "891.71/3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
+                    sDewey$ = "891.71/3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
+                    sDewey$ = "Period1917"
+                    Period1.Caption = "Period 1917-1945"
+                    Period2.Caption = "Period 1945-1991"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Russia"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1945-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Russia"
+                } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
+                    sDewey$ = "891.71/5"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "To 1799"
+                    Period2.Caption = "Period 1800-1899"
+                    Period3.Caption = "Period 1900-1991"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Lithuania"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Lithuania"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
+                    sDewey$ = "891/.9214"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "To 1799"
+                    Period2.Caption = "Period 1800-1899"
+                    Period3.Caption = "Period 1900-1991"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Latvia"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Latvia"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
+                    sDewey$ = "891/.9314"
+                }
             }
-        }
 
-        const _convertClassPgPoetry = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
-                sDewey$ = "891.71/1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
-                sDewey$ = "891.71/2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
-                sDewey$ = "891.71/3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
-                sDewey$ = "891.71/3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
-                sDewey$ = "Period1917"
-                Period1.Caption = "Period 1917-1945"
-                Period2.Caption = "Period 1945-1991"
-                sGenre$ = "Poetry"
-                sCountry$ = "Russia"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1945-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Poetry"
-                sCountry$ = "Russia"
-            } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
-                sDewey$ = "891.71/5"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "To 1799"
-                Period2.Caption = "Period 1800-1899"
-                Period3.Caption = "Period 1900-1991"
-                sGenre$ = "Poetry"
-                sCountry$ = "Lithuania"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1900-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Poetry"
-                sCountry$ = "Lithuania"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
-                sDewey$ = "891/.9214"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "To 1799"
-                Period2.Caption = "Period 1800-1899"
-                Period3.Caption = "Period 1900-1991"
-                sGenre$ = "Poetry"
-                sCountry$ = "Latvia"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1900-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Poetry"
-                sCountry$ = "Latvia"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
-                sDewey$ = "891/.9314"
+            const _convertClassPhDrama = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 3)) == 353) {
+                    sDewey$ = "894/.54121"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Finland"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
+                    sDewey$ = "894/.54124"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period to 1861"
+                    Period2.Caption = "Period 1861-1991"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Estonia"
+                } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1861-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Estonia"
+                } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
+                    sDewey$ = "894/.54523"
+                }
             }
-        }
 
-        const _convertClassPhDrama = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 3)) == 353) {
-                sDewey$ = "894/.54121"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Finland"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
-                sDewey$ = "894/.54124"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period to 1861"
-                Period2.Caption = "Period 1861-1991"
-                sGenre$ = "Drama"
-                sCountry$ = "Estonia"
-            } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1861-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Drama"
-                sCountry$ = "Estonia"
-            } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
-                sDewey$ = "894/.54523"
+            const _convertClassPhFiction = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 3)) == 353) {
+                    sDewey$ = "894/.54131"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Finland"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
+                    sDewey$ = "894/.54134"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period to 1861"
+                    Period2.Caption = "Period 1861-1991"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Estonia"
+                } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1861-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Estonia"
+                } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
+                    sDewey$ = "894/.54533"
+                }
             }
-        }
 
-        const _convertClassPhFiction = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 3)) == 353) {
-                sDewey$ = "894/.54131"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Finland"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
-                sDewey$ = "894/.54134"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period to 1861"
-                Period2.Caption = "Period 1861-1991"
-                sGenre$ = "Fiction"
-                sCountry$ = "Estonia"
-            } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1861-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Fiction"
-                sCountry$ = "Estonia"
-            } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
-                sDewey$ = "894/.54533"
+            const _convertClassPhPoetry = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 3)) == 353) {
+                    sDewey$ = "894/.54111"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Finland"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
+                    sDewey$ = "894/.54114"
+                } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period to 1861"
+                    Period2.Caption = "Period 1861-1991"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Estonia"
+                } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1861-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Estonia"
+                } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
+                    sDewey$ = "894/.54513"
+                }
             }
-        }
 
-        const _convertClassPhPoetry = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 3)) == 353) {
-                sDewey$ = "894/.54111"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Finland"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
-                sDewey$ = "894/.54114"
-            } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period to 1861"
-                Period2.Caption = "Period 1861-1991"
-                sGenre$ = "Poetry"
-                sCountry$ = "Estonia"
-            } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1861-1991"
-                Period2.Caption = "Period 1991-"
-                sGenre$ = "Poetry"
-                sCountry$ = "Estonia"
-            } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
-                sDewey$ = "894/.54513"
+            const _convertClassPqDrama = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
+                    sDewey$ = "842/.1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1400-1499"
+                    Period2.Caption = "Period 1500-1599"
+                    sGenre$ = "Drama"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
+                    sDewey$ = "842/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
+                    sDewey$ = "842/.4"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1600-1715"
+                    Period2.Caption = "Period 1715-1789"
+                    Period3.Caption = "Period 1789-1815"
+                    sGenre$ = "Drama"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1789-1815"
+                    Period2.Caption = "Period 1815-1848"
+                    Period3.Caption = "Period 1848-1889"
+                    sGenre$ = "Drama"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
+                    sDewey$ = "842/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
+                    sDewey$ = "842/.92"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
+                    sDewey$ = "842/.914"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
+                    sDewey$ = "842/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
+                    sDewey$ = "Period1300"
+                    Period1.Caption = "Period to 1375"
+                    Period2.Caption = "Period 1375-1492"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1375-1492"
+                    Period2.Caption = "Period 1492-1542"
+                    Period3.Caption = "Period 1542-1585"
+                    Period4.Caption = "Period 1585-1748"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1585-1748"
+                    Period2.Caption = "Period 1748-1814"
+                    Period3.Caption = "Period 1814-1859"
+                    Period4.Caption = "Period 1859-1899"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
+                    sDewey$ = "852/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
+                    sDewey$ = "852/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
+                    sDewey$ = "863/.2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
+                    sDewey$ = "862/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
+                    sDewey$ = "862/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
+                    sDewey$ = "861/.1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
+                    sDewey$ = "862/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
+                    sDewey$ = "862/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
+                    sDewey$ = "862/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1700-1799"
+                    Period2.Caption = "Period 1800-1899"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Spain"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Spain"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Mexico"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Argentina"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Chile"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Peru"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
+                    sDewey$ = "862/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
+                    sDewey$ = "862/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
+                    sDewey$ = "869.2/1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
+                    sDewey$ = "869.2/2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
+                    sDewey$ = "869.2/42"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
+                    sDewey$ = "869.2/5"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period to 1499"
+                    Period2.Caption = "Period 1500-1799"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Brazil"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Brazil"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
+                    sDewey$ = "869.2/42"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
+                    sDewey$ = "869.2/5"
+                }
             }
-        }
 
-        const _convertClassPqDrama = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
-                sDewey$ = "842/.1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1400-1499"
-                Period2.Caption = "Period 1500-1599"
-                sGenre$ = "Drama"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
-                sDewey$ = "842/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
-                sDewey$ = "842/.4"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1600-1715"
-                Period2.Caption = "Period 1715-1789"
-                Period3.Caption = "Period 1789-1815"
-                sGenre$ = "Drama"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1789-1815"
-                Period2.Caption = "Period 1815-1848"
-                Period3.Caption = "Period 1848-1889"
-                sGenre$ = "Drama"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
-                sDewey$ = "842/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
-                sDewey$ = "842/.92"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
-                sDewey$ = "842/.914"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
-                sDewey$ = "842/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
-                sDewey$ = "Period1300"
-                Period1.Caption = "Period to 1375"
-                Period2.Caption = "Period 1375-1492"
-                sGenre$ = "Drama"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1375-1492"
-                Period2.Caption = "Period 1492-1542"
-                Period3.Caption = "Period 1542-1585"
-                Period4.Caption = "Period 1585-1748"
-                sGenre$ = "Drama"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1585-1748"
-                Period2.Caption = "Period 1748-1814"
-                Period3.Caption = "Period 1814-1859"
-                Period4.Caption = "Period 1859-1899"
-                sGenre$ = "Drama"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
-                sDewey$ = "852/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
-                sDewey$ = "852/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
-                sDewey$ = "863/.2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
-                sDewey$ = "862/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
-                sDewey$ = "862/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
-                sDewey$ = "861/.1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
-                sDewey$ = "862/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
-                sDewey$ = "862/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
-                sDewey$ = "862/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1700-1799"
-                Period2.Caption = "Period 1800-1899"
-                sGenre$ = "Drama"
-                sCountry$ = "Spain"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Spain"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Mexico"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Argentina"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Chile"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Peru"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
-                sDewey$ = "862/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
-                sDewey$ = "862/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
-                sDewey$ = "869.2/1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
-                sDewey$ = "869.2/2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
-                sDewey$ = "869.2/42"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
-                sDewey$ = "869.2/5"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period to 1499"
-                Period2.Caption = "Period 1500-1799"
-                sGenre$ = "Drama"
-                sCountry$ = "Brazil"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Brazil"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
-                sDewey$ = "869.2/42"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
-                sDewey$ = "869.2/5"
+            const _convertClassPqFiction = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
+                    sDewey$ = "843/.1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1400-1499"
+                    Period2.Caption = "Period 1500-1599"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
+                    sDewey$ = "843/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
+                    sDewey$ = "843/.4"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1600-1715"
+                    Period2.Caption = "Period 1715-1789"
+                    Period3.Caption = "Period 1789-1815"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1789-1815"
+                    Period2.Caption = "Period 1815-1848"
+                    Period3.Caption = "Period 1848-1889"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
+                    sDewey$ = "843/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
+                    sDewey$ = "843/.92"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
+                    sDewey$ = "843/.914"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
+                    sDewey$ = "843/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
+                    sDewey$ = "Period1300"
+                    Period1.Caption = "Period to 1375"
+                    Period2.Caption = "Period 1375-1492"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1375-1492"
+                    Period2.Caption = "Period 1492-1542"
+                    Period3.Caption = "Period 1542-1585"
+                    Period4.Caption = "Period 1585-1748"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1585-1748"
+                    Period2.Caption = "Period 1748-1814"
+                    Period3.Caption = "Period 1814-1859"
+                    Period4.Caption = "Period 1859-1899"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
+                    sDewey$ = "853/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
+                    sDewey$ = "853/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
+                    sDewey$ = "863/.2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
+                    sDewey$ = "861/.1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1700-1799"
+                    Period2.Caption = "Period 1800-1899"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Spain"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Spain"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Mexico"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Argentina"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Chile"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Peru"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
+                    sDewey$ = "863/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
+                    sDewey$ = "863/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
+                    sDewey$ = "869.3/1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
+                    sDewey$ = "869.3/2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
+                    sDewey$ = "869.3/42"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
+                    sDewey$ = "869.3/5"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period to 1499"
+                    Period2.Caption = "Period 1500-1799"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Brazil"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Brazil"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
+                    sDewey$ = "869.3/42"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
+                    sDewey$ = "869.3/5"
+                }
             }
-        }
 
-        const _convertClassPqFiction = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
-                sDewey$ = "843/.1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1400-1499"
-                Period2.Caption = "Period 1500-1599"
-                sGenre$ = "Fiction"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
-                sDewey$ = "843/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
-                sDewey$ = "843/.4"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1600-1715"
-                Period2.Caption = "Period 1715-1789"
-                Period3.Caption = "Period 1789-1815"
-                sGenre$ = "Fiction"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1789-1815"
-                Period2.Caption = "Period 1815-1848"
-                Period3.Caption = "Period 1848-1889"
-                sGenre$ = "Fiction"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
-                sDewey$ = "843/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
-                sDewey$ = "843/.92"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
-                sDewey$ = "843/.914"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
-                sDewey$ = "843/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
-                sDewey$ = "Period1300"
-                Period1.Caption = "Period to 1375"
-                Period2.Caption = "Period 1375-1492"
-                sGenre$ = "Fiction"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1375-1492"
-                Period2.Caption = "Period 1492-1542"
-                Period3.Caption = "Period 1542-1585"
-                Period4.Caption = "Period 1585-1748"
-                sGenre$ = "Fiction"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1585-1748"
-                Period2.Caption = "Period 1748-1814"
-                Period3.Caption = "Period 1814-1859"
-                Period4.Caption = "Period 1859-1899"
-                sGenre$ = "Fiction"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
-                sDewey$ = "853/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
-                sDewey$ = "853/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
-                sDewey$ = "863/.2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
-                sDewey$ = "861/.1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1700-1799"
-                Period2.Caption = "Period 1800-1899"
-                sGenre$ = "Fiction"
-                sCountry$ = "Spain"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Spain"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Mexico"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Argentina"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Chile"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Peru"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
-                sDewey$ = "863/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
-                sDewey$ = "863/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
-                sDewey$ = "869.3/1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
-                sDewey$ = "869.3/2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
-                sDewey$ = "869.3/42"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
-                sDewey$ = "869.3/5"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period to 1499"
-                Period2.Caption = "Period 1500-1799"
-                sGenre$ = "Fiction"
-                sCountry$ = "Brazil"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Brazil"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
-                sDewey$ = "869.3/42"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
-                sDewey$ = "869.3/5"
+            const _convertClassPqPoetry = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
+                    sDewey$ = "841/.1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1400-1499"
+                    Period2.Caption = "Period 1500-1599"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
+                    sDewey$ = "841/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
+                    sDewey$ = "841/.4"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1600-1715"
+                    Period2.Caption = "Period 1715-1789"
+                    Period3.Caption = "Period 1789-1815"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1789-1815"
+                    Period2.Caption = "Period 1815-1848"
+                    Period3.Caption = "Period 1848-1889"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "France"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
+                    sDewey$ = "841/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
+                    sDewey$ = "841/.92"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
+                    sDewey$ = "841/.914"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
+                    sDewey$ = "841/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
+                    sDewey$ = "Period1300"
+                    Period1.Caption = "Period to 1375"
+                    Period2.Caption = "Period 1375-1492"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1375-1492"
+                    Period2.Caption = "Period 1492-1542"
+                    Period3.Caption = "Period 1542-1585"
+                    Period4.Caption = "Period 1585-1748"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1585-1748"
+                    Period2.Caption = "Period 1748-1814"
+                    Period3.Caption = "Period 1814-1859"
+                    Period4.Caption = "Period 1859-1899"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Italy"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
+                    sDewey$ = "851/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
+                    sDewey$ = "851/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
+                    sDewey$ = "863/.2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
+                    sDewey$ = "861/.1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
+                    sDewey$ = "863/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
+                    sDewey$ = "861/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1700-1799"
+                    Period2.Caption = "Period 1800-1899"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Spain"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Spain"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Mexico"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Argentina"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Chile"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Peru"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
+                    sDewey$ = "861/.64"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
+                    sDewey$ = "861/.7"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
+                    sDewey$ = "869.1/1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
+                    sDewey$ = "869.1/2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
+                    sDewey$ = "869.1/42"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
+                    sDewey$ = "869.1/5"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period to 1499"
+                    Period2.Caption = "Period 1500-1799"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Brazil"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1800-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Brazil"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
+                    sDewey$ = "869.1/42"
+                } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
+                    sDewey$ = "869.1/5"
+                }
             }
-        }
 
-        const _convertClassPqPoetry = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
-                sDewey$ = "841/.1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1400-1499"
-                Period2.Caption = "Period 1500-1599"
-                sGenre$ = "Poetry"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
-                sDewey$ = "841/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
-                sDewey$ = "841/.4"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1600-1715"
-                Period2.Caption = "Period 1715-1789"
-                Period3.Caption = "Period 1789-1815"
-                sGenre$ = "Poetry"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1789-1815"
-                Period2.Caption = "Period 1815-1848"
-                Period3.Caption = "Period 1848-1889"
-                sGenre$ = "Poetry"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "France"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
-                sDewey$ = "841/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
-                sDewey$ = "841/.92"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
-                sDewey$ = "841/.914"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
-                sDewey$ = "841/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
-                sDewey$ = "Period1300"
-                Period1.Caption = "Period to 1375"
-                Period2.Caption = "Period 1375-1492"
-                sGenre$ = "Poetry"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1375-1492"
-                Period2.Caption = "Period 1492-1542"
-                Period3.Caption = "Period 1542-1585"
-                Period4.Caption = "Period 1585-1748"
-                sGenre$ = "Poetry"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1585-1748"
-                Period2.Caption = "Period 1748-1814"
-                Period3.Caption = "Period 1814-1859"
-                Period4.Caption = "Period 1859-1899"
-                sGenre$ = "Poetry"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Italy"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
-                sDewey$ = "851/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
-                sDewey$ = "851/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
-                sDewey$ = "863/.2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
-                sDewey$ = "861/.1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
-                sDewey$ = "863/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
-                sDewey$ = "861/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1700-1799"
-                Period2.Caption = "Period 1800-1899"
-                sGenre$ = "Poetry"
-                sCountry$ = "Spain"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Spain"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Mexico"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Argentina"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Chile"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Peru"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
-                sDewey$ = "861/.64"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
-                sDewey$ = "861/.7"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
-                sDewey$ = "869.1/1"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
-                sDewey$ = "869.1/2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
-                sDewey$ = "869.1/42"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
-                sDewey$ = "869.1/5"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period to 1499"
-                Period2.Caption = "Period 1500-1799"
-                sGenre$ = "Poetry"
-                sCountry$ = "Brazil"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1800-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Brazil"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
-                sDewey$ = "869.1/42"
-            } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
-                sDewey$ = "869.1/5"
-            }
-        }
-
-        const _convertClassPrDrama = (sClassNo$) => {
-            //British
-            if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
-                sDewey$ = "829/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
-                sDewey$ = "829/.2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
-                sDewey$ = "829/.4"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1066-1400"
-                Period2.Caption = "Period 1400-1558"
-                sGenre$ = "Drama"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
-                sDewey$ = "Period1558"
-                Period1.Caption = "Period 1400-1558"
-                Period2.Caption = "Period 1558-1625"
-                Period3.Caption = "Period 1625-1702"
-                sGenre$ = "Drama"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
-                if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
-                    sDewey$ = ""
-                } else {
-                    sDewey$ = "Period1625"
+            const _convertClassPrDrama = (sClassNo$) => {
+                //British
+                if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
+                    sDewey$ = "829/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
+                    sDewey$ = "829/.2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
+                    sDewey$ = "829/.4"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1066-1400"
+                    Period2.Caption = "Period 1400-1558"
+                    sGenre$ = "Drama"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
+                    sDewey$ = "Period1558"
                     Period1.Caption = "Period 1400-1558"
                     Period2.Caption = "Period 1558-1625"
                     Period3.Caption = "Period 1625-1702"
                     sGenre$ = "Drama"
                     sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
+                    if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
+                        sDewey$ = ""
+                    } else {
+                        sDewey$ = "Period1625"
+                        Period1.Caption = "Period 1400-1558"
+                        Period2.Caption = "Period 1558-1625"
+                        Period3.Caption = "Period 1625-1702"
+                        sGenre$ = "Drama"
+                        sCountry$ = "UK"
+                    }
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
+                    sDewey$ = "Period1702"
+                    Period1.Caption = "Period 1625-1702"
+                    Period2.Caption = "Period 1702-1745"
+                    Period3.Caption = "Period 1745-1799"
+                    sGenre$ = "Drama"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1745-1799"
+                    Period2.Caption = "Period 1799-1837"
+                    Period3.Caption = "Period 1837-1899"
+                    sGenre$ = "Drama"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
+                    sDewey$ = "822/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
+                    sDewey$ = "822/.92"
+
+                    //Shakespeare drama
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2749 && Val(Mid(sClassNo$, 3, 4)) < 3113) {
+                    sDewey$ = "822.3/3"
+
+
+                    //Canadian gets same as U.S. below in PS...
+                } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
+                    sDewey$ = "Period1867"
+                    Period1.Caption = "Period to 1867"
+                    Period2.Caption = "Period 1867-1899"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Canada"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Canada"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.4) {
+                    sDewey$ = "812/.6"
+
+                    //South Africa
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "SoAf"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
+                    sDewey$ = "822/.92"
+
+                    //Australia
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Aust"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.4) {
+                    sDewey$ = "822/.92"
+
+                    //New Zealand
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "NZ"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
+                    sDewey$ = "822/.92"
                 }
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
-                sDewey$ = "Period1702"
-                Period1.Caption = "Period 1625-1702"
-                Period2.Caption = "Period 1702-1745"
-                Period3.Caption = "Period 1745-1799"
-                sGenre$ = "Drama"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1745-1799"
-                Period2.Caption = "Period 1799-1837"
-                Period3.Caption = "Period 1837-1899"
-                sGenre$ = "Drama"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
-                sDewey$ = "822/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
-                sDewey$ = "822/.92"
-
-                //Shakespeare drama
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2749 && Val(Mid(sClassNo$, 3, 4)) < 3113) {
-                sDewey$ = "822.3/3"
-
-
-                //Canadian gets same as U.S. below in PS...
-            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
-                sDewey$ = "Period1867"
-                Period1.Caption = "Period to 1867"
-                Period2.Caption = "Period 1867-1899"
-                sGenre$ = "Drama"
-                sCountry$ = "Canada"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Canada"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.4) {
-                sDewey$ = "812/.6"
-
-                //South Africa
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "SoAf"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
-                sDewey$ = "822/.92"
-
-                //Australia
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Aust"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.4) {
-                sDewey$ = "822/.92"
-
-                //New Zealand
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "NZ"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
-                sDewey$ = "822/.92"
             }
-        }
 
-        const _convertClassPrFiction = (sClassNo$) => {
-            //British
-            if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
-                sDewey$ = "829/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
-                sDewey$ = "829/.2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
-                sDewey$ = "829/.4"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1066-1400"
-                Period2.Caption = "Period 1400-1558"
-                sGenre$ = "Fiction"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
-                sDewey$ = "Period1558"
-                Period1.Caption = "Period 1400-1558"
-                Period2.Caption = "Period 1558-1625"
-                Period3.Caption = "Period 1625-1702"
-                sGenre$ = "Fiction"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
-                if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
-                    sDewey$ = ""
-                } else {
-                    sDewey$ = "Period1625"
+            const _convertClassPrFiction = (sClassNo$) => {
+                //British
+                if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
+                    sDewey$ = "829/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
+                    sDewey$ = "829/.2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
+                    sDewey$ = "829/.4"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1066-1400"
+                    Period2.Caption = "Period 1400-1558"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
+                    sDewey$ = "Period1558"
                     Period1.Caption = "Period 1400-1558"
                     Period2.Caption = "Period 1558-1625"
                     Period3.Caption = "Period 1625-1702"
                     sGenre$ = "Fiction"
                     sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
+                    if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
+                        sDewey$ = ""
+                    } else {
+                        sDewey$ = "Period1625"
+                        Period1.Caption = "Period 1400-1558"
+                        Period2.Caption = "Period 1558-1625"
+                        Period3.Caption = "Period 1625-1702"
+                        sGenre$ = "Fiction"
+                        sCountry$ = "UK"
+                    }
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
+                    sDewey$ = "Period1702"
+                    Period1.Caption = "Period 1625-1702"
+                    Period2.Caption = "Period 1702-1745"
+                    Period3.Caption = "Period 1745-1799"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1745-1799"
+                    Period2.Caption = "Period 1799-1837"
+                    Period3.Caption = "Period 1837-1899"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
+                    sDewey$ = "823/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
+                    sDewey$ = "823/.92"
+
+                    //Canadian gets same as U.S. below in PS...
+                } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
+                    sDewey$ = "Period1867"
+                    Period1.Caption = "Period to 1867"
+                    Period2.Caption = "Period 1867-1899"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Canada"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Canada"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.4) {
+                    sDewey$ = "813/.6"
+
+                    //South Africa
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "SoAf"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
+                    sDewey$ = "823/.92"
+
+
+                    //Australia
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Aust"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.4) {
+                    sDewey$ = "823/.92"
+
+                    //New Zealand
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "NZ"
+
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
+                    sDewey$ = "823/.92"
+
                 }
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
-                sDewey$ = "Period1702"
-                Period1.Caption = "Period 1625-1702"
-                Period2.Caption = "Period 1702-1745"
-                Period3.Caption = "Period 1745-1799"
-                sGenre$ = "Fiction"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1745-1799"
-                Period2.Caption = "Period 1799-1837"
-                Period3.Caption = "Period 1837-1899"
-                sGenre$ = "Fiction"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
-                sDewey$ = "823/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
-                sDewey$ = "823/.92"
-
-                //Canadian gets same as U.S. below in PS...
-            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
-                sDewey$ = "Period1867"
-                Period1.Caption = "Period to 1867"
-                Period2.Caption = "Period 1867-1899"
-                sGenre$ = "Fiction"
-                sCountry$ = "Canada"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Canada"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.4) {
-                sDewey$ = "813/.6"
-
-                //South Africa
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "SoAf"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
-                sDewey$ = "823/.92"
-
-
-                //Australia
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Aust"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.4) {
-                sDewey$ = "823/.92"
-
-                //New Zealand
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "NZ"
-
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
-                sDewey$ = "823/.92"
-
             }
-        }
 
-        const _convertClassPrPoetry = (sClassNo$) => {
-            //British
-            if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
-                sDewey$ = "829/.3"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
-                sDewey$ = "829/.2"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
-                sDewey$ = "829/.4"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period 1066-1400"
-                Period2.Caption = "Period 1400-1558"
-                sGenre$ = "Poetry"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
-                sDewey$ = "Period1558"
-                Period1.Caption = "Period 1400-1558"
-                Period2.Caption = "Period 1558-1625"
-                Period3.Caption = "Period 1625-1702"
-                sGenre$ = "Poetry"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
-                if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
-                    sDewey$ = ""
-                } else {
-                    sDewey$ = "Period1625"
+            const _convertClassPrPoetry = (sClassNo$) => {
+                //British
+                if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
+                    sDewey$ = "829/.3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
+                    sDewey$ = "829/.2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
+                    sDewey$ = "829/.4"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period 1066-1400"
+                    Period2.Caption = "Period 1400-1558"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
+                    sDewey$ = "Period1558"
                     Period1.Caption = "Period 1400-1558"
                     Period2.Caption = "Period 1558-1625"
                     Period3.Caption = "Period 1625-1702"
                     sGenre$ = "Poetry"
                     sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
+                    if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
+                        sDewey$ = ""
+                    } else {
+                        sDewey$ = "Period1625"
+                        Period1.Caption = "Period 1400-1558"
+                        Period2.Caption = "Period 1558-1625"
+                        Period3.Caption = "Period 1625-1702"
+                        sGenre$ = "Poetry"
+                        sCountry$ = "UK"
+                    }
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
+                    sDewey$ = "Period1702"
+                    Period1.Caption = "Period 1625-1702"
+                    Period2.Caption = "Period 1702-1745"
+                    Period3.Caption = "Period 1745-1799"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1745-1799"
+                    Period2.Caption = "Period 1799-1837"
+                    Period3.Caption = "Period 1837-1899"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "UK"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
+                    sDewey$ = "821/.914"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
+                    sDewey$ = "821/.92"
+                    //Shakespeare poetry
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2749 && Val(Mid(sClassNo$, 3, 4)) < 3113) {
+                    sDewey$ = "821/.3"
+                    //Canadian gets same as U.S. below in PS...
+                } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
+                    sDewey$ = "Period1867"
+                    Period1.Caption = "Period to 1867"
+                    Period2.Caption = "Period 1867-1899"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Canada"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Canada"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.4") {
+                    sDewey$ = "811/.6"
+                    //South Africa
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "SoAf"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
+                    sDewey$ = "821/.92"
+                    //Australia
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Aust"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == "9619.4") {
+                    sDewey$ = "821/.92"
+                    //New Zealand
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "NZ"
+                } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
+                    sDewey$ = "821/.92"
                 }
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
-                sDewey$ = "Period1702"
-                Period1.Caption = "Period 1625-1702"
-                Period2.Caption = "Period 1702-1745"
-                Period3.Caption = "Period 1745-1799"
-                sGenre$ = "Poetry"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1745-1799"
-                Period2.Caption = "Period 1799-1837"
-                Period3.Caption = "Period 1837-1899"
-                sGenre$ = "Poetry"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "UK"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
-                sDewey$ = "821/.914"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
-                sDewey$ = "821/.92"
-                //Shakespeare poetry
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2749 && Val(Mid(sClassNo$, 3, 4)) < 3113) {
-                sDewey$ = "821/.3"
-                //Canadian gets same as U.S. below in PS...
-            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
-                sDewey$ = "Period1867"
-                Period1.Caption = "Period to 1867"
-                Period2.Caption = "Period 1867-1899"
-                sGenre$ = "Poetry"
-                sCountry$ = "Canada"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Canada"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.4") {
-                sDewey$ = "811/.6"
-                //South Africa
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "SoAf"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
-                sDewey$ = "821/.92"
-                //Australia
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Aust"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == "9619.4") {
-                sDewey$ = "821/.92"
-                //New Zealand
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "NZ"
-            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
-                sDewey$ = "821/.92"
             }
+
+            const _convertClassPsDrama = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
+                    sDewey$ = "Period1776"
+                    Period1.Caption = "Period 1607-1776"
+                    Period2.Caption = "Period 1776-1829"
+                    sGenre$ = "Drama"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
+                    sDewey$ = "Period1830"
+                    Period1.Caption = "Period 1776-1830"
+                    Period2.Caption = "Period 1830-1861"
+                    Period3.Caption = "Period 1861-1899"
+                    sGenre$ = "Drama"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
+                    sDewey$ = "812/.54"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
+                    sDewey$ = "812/.6"
+                }
+            }
+
+            const _convertClassPsFiction = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
+                    sDewey$ = "Period1776"
+                    Period1.Caption = "Period 1607-1776"
+                    Period2.Caption = "Period 1776-1829"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
+                    sDewey$ = "Period1830"
+                    Period1.Caption = "Period 1776-1830"
+                    Period2.Caption = "Period 1830-1861"
+                    Period3.Caption = "Period 1861-1899"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
+                    sDewey$ = "813/.54"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
+                    sDewey$ = "813/.6"
+                }
+            }
+
+            const _convertClassPsPoetry = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
+                    sDewey$ = "Period1776"
+                    Period1.Caption = "Period 1607-1776"
+                    Period2.Caption = "Period 1776-1829"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
+                    sDewey$ = "Period1830"
+                    Period1.Caption = "Period 1776-1830"
+                    Period2.Caption = "Period 1830-1861"
+                    Period3.Caption = "Period 1861-1899"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "US"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
+                    sDewey$ = "811/.54"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
+                    sDewey$ = "811/.6"
+                }
+            }
+
+            const _convertClassPtDrama = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
+                    sDewey$ = "Period1100"
+                    Period1.Caption = "Period to 1099"
+                    Period2.Caption = "Period 1100-1249"
+                    Period3.Caption = "Period 1250-1349"
+                    Period4.Caption = "Period 1350-1517"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
+                    sDewey$ = "Period1300"
+                    Period1.Caption = "Period 1350-1517"
+                    Period2.Caption = "Period 1517-1625"
+                    Period3.Caption = "Period 1625-1749"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1625-1749"
+                    Period2.Caption = "Period 1750-1832"
+                    Period3.Caption = "Period 1832-1856"
+                    Period4.Caption = "Period 1856-1899"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1856-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1990"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1945-1990"
+                    Period2.Caption = "Period 1990-"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
+                    sDewey$ = "832/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1719"
+                    Period2.Caption = "Period 1720-1835"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Iceland"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
+                    sDewey$ = "Period1700"
+                    Period1.Caption = "Period 1720-1835"
+                    Period2.Caption = "Period 1835-1899"
+                    Period3.Caption = "Period 1900-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Iceland"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
+                    sDewey$ = "839/.6925"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period to 1499"
+                    Period2.Caption = "Period 1500-1559"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1559"
+                    Period2.Caption = "Period 1560-1699"
+                    Period3.Caption = "Period 1700-1749"
+                    Period4.Caption = "Period 1750-1799"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
+                    sDewey$ = "839.812/6"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
+                    sDewey$ = "839.812/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
+                    sDewey$ = "839.812/8"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1559"
+                    Period2.Caption = "Period 1560-1699"
+                    Period3.Caption = "Period 1700-1749"
+                    Period4.Caption = "Period 1750-1799"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Norway"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
+                    sDewey$ = "839.822/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
+                    sDewey$ = "839.822/8"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period to 1519"
+                    Period2.Caption = "Period 1520-1639"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period to 1519"
+                    Period2.Caption = "Period 1520-1639"
+                    Period3.Caption = "Period 1640-1739"
+                    Period4.Caption = "Period 1740-1779"
+                    Period5.Caption = "Period 1780-1809"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1780-1809"
+                    Period2.Caption = "Period 1809-1830"
+                    Period3.Caption = "Period 1830-1879"
+                    Period4.Caption = "Period 1879-1909"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1879-1909"
+                    Period2.Caption = "Period 1909-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
+                    sDewey$ = "839.72/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
+                    sDewey$ = "839.72/8"
+                }
+            }
+
+            const _convertClassPtFiction = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
+                    sDewey$ = "Period1100"
+                    Period1.Caption = "Period to 1099"
+                    Period2.Caption = "Period 1100-1249"
+                    Period3.Caption = "Period 1250-1349"
+                    Period4.Caption = "Period 1350-1517"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
+                    sDewey$ = "Period1300"
+                    Period1.Caption = "Period 1350-1517"
+                    Period2.Caption = "Period 1517-1625"
+                    Period3.Caption = "Period 1625-1749"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1625-1749"
+                    Period2.Caption = "Period 1750-1832"
+                    Period3.Caption = "Period 1832-1856"
+                    Period4.Caption = "Period 1856-1899"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1856-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1990"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1945-1990"
+                    Period2.Caption = "Period 1990-"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
+                    sDewey$ = "833/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1719"
+                    Period2.Caption = "Period 1720-1835"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Iceland"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
+                    sDewey$ = "Period1700"
+                    Period1.Caption = "Period 1720-1835"
+                    Period2.Caption = "Period 1835-1899"
+                    Period3.Caption = "Period 1900-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Iceland"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
+                    sDewey$ = "839/.6935"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period to 1499"
+                    Period2.Caption = "Period 1500-1559"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1559"
+                    Period2.Caption = "Period 1560-1699"
+                    Period3.Caption = "Period 1700-1749"
+                    Period4.Caption = "Period 1750-1799"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
+                    sDewey$ = "839.813/6"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
+                    sDewey$ = "839.813/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
+                    sDewey$ = "839.813/8"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1559"
+                    Period2.Caption = "Period 1560-1699"
+                    Period3.Caption = "Period 1700-1749"
+                    Period4.Caption = "Period 1750-1799"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Norway"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
+                    sDewey$ = "839.823/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
+                    sDewey$ = "839.823/8"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period to 1519"
+                    Period2.Caption = "Period 1520-1639"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period to 1519"
+                    Period2.Caption = "Period 1520-1639"
+                    Period3.Caption = "Period 1640-1739"
+                    Period4.Caption = "Period 1740-1779"
+                    Period5.Caption = "Period 1780-1809"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1780-1809"
+                    Period2.Caption = "Period 1809-1830"
+                    Period3.Caption = "Period 1830-1879"
+                    Period4.Caption = "Period 1879-1909"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1879-1909"
+                    Period2.Caption = "Period 1909-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
+                    sDewey$ = "839.73/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
+                    sDewey$ = "839.73/8"
+                }
+            }
+
+            const _convertClassPtPoetry = (sClassNo$) => {
+                if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
+                    sDewey$ = "Period1100"
+                    Period1.Caption = "Period to 1099"
+                    Period2.Caption = "Period 1100-1249"
+                    Period3.Caption = "Period 1250-1349"
+                    Period4.Caption = "Period 1350-1517"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
+                    sDewey$ = "Period1300"
+                    Period1.Caption = "Period 1350-1517"
+                    Period2.Caption = "Period 1517-1625"
+                    Period3.Caption = "Period 1625-1749"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period 1625-1749"
+                    Period2.Caption = "Period 1750-1832"
+                    Period3.Caption = "Period 1832-1856"
+                    Period4.Caption = "Period 1856-1899"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1856-1899"
+                    Period2.Caption = "Period 1900-1945"
+                    Period3.Caption = "Period 1945-1990"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1945-1990"
+                    Period2.Caption = "Period 1990-"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Germany"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
+                    sDewey$ = "831/.92"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1719"
+                    Period2.Caption = "Period 1720-1835"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Iceland"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
+                    sDewey$ = "Period1700"
+                    Period1.Caption = "Period 1720-1835"
+                    Period2.Caption = "Period 1835-1899"
+                    Period3.Caption = "Period 1900-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Iceland"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
+                    sDewey$ = "839/.6915"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
+                    sDewey$ = "Period1400"
+                    Period1.Caption = "Period to 1499"
+                    Period2.Caption = "Period 1500-1559"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1559"
+                    Period2.Caption = "Period 1560-1699"
+                    Period3.Caption = "Period 1700-1749"
+                    Period4.Caption = "Period 1750-1799"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
+                    sDewey$ = "839.811/6"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1945"
+                    Period2.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Denmark"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
+                    sDewey$ = "839.811/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
+                    sDewey$ = "839.811/8"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period 1500-1559"
+                    Period2.Caption = "Period 1560-1699"
+                    Period3.Caption = "Period 1700-1749"
+                    Period4.Caption = "Period 1750-1799"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Norway"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
+                    sDewey$ = "839.821/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
+                    sDewey$ = "839.821/8"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
+                    sDewey$ = "Period1500"
+                    Period1.Caption = "Period to 1519"
+                    Period2.Caption = "Period 1520-1639"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
+                    sDewey$ = "Period1600"
+                    Period1.Caption = "Period to 1519"
+                    Period2.Caption = "Period 1520-1639"
+                    Period3.Caption = "Period 1640-1739"
+                    Period4.Caption = "Period 1740-1779"
+                    Period5.Caption = "Period 1780-1809"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period 1780-1809"
+                    Period2.Caption = "Period 1809-1830"
+                    Period3.Caption = "Period 1830-1879"
+                    Period4.Caption = "Period 1879-1909"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1879-1909"
+                    Period2.Caption = "Period 1909-1945"
+                    Period3.Caption = "Period 1945-1999"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "Sweden"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
+                    sDewey$ = "839.71/74"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
+                    sDewey$ = "839.71/8"
+                }
+            }
+
+            //GV
+            const _convertClassGvSport = (sClassNo$) => {
+                if (Mid(sClassNo$, 3, 8) == "1003.62.") sDewey$ = "796.343092"
+                if (Mid(sClassNo$, 3, 8) == "1005.22.") sDewey$ = "796.34/6092"
+                if (Mid(sClassNo$, 3, 8) == "1006.52.") sDewey$ = "796.345092"
+                if (Mid(sClassNo$, 3, 8) == "1010.32.") sDewey$ = "796.35/3092"
+                if (Mid(sClassNo$, 3, 8) == "1015.26.") sDewey$ = "796.325092"
+                if (Mid(sClassNo$, 3, 5) == "1032." && Len(sClassNo$) > 8 && InStr(sClassNo$, "1032.A1") == 0) sDewey$ = "796.72092"
+                if (Mid(sClassNo$, 3, 5) == "1132.") sDewey$ = "796.83092"
+                if (Mid(sClassNo$, 3, 5) == "1186.") sDewey$ = "799.3/2092"
+                if (Mid(sClassNo$, 3, 5) == "1196." && Len(sClassNo$) > 8 && InStr(sClassNo$, "1196.A1") == 0) sDewey$ = "796.812092"
+                if (Mid(sClassNo$, 3, 7) == "545.52.") sDewey$ = "796.41092"
+                if (Mid(sClassNo$, 3, 6) == "848.5." && Len(sClassNo$) > 9 && InStr(sClassNo$, "848.5.A1") == 0) sDewey$ = "796.962092"
+                if (Mid(sClassNo$, 3, 4) == "850." && IsNumeric(Mid(sClassNo$, 7, 1)) == false && Len(sClassNo$) > 8 && (InStr(sClassNo$, "850.A1") == 0 && InStr(sClassNo$, "850.A2") == 0)) {
+                    sDewey$ = [
+                        {
+                            caption: 'Figure skating',
+                            dewey: '796.91/2092'
+                        },
+                        {
+                            caption: 'Speed skating',
+                            dewey: '796.91/4092'
+                        }
+                    ]
+                }
+                if (Mid(sClassNo$, 3, 4) == "865." && Len(sClassNo$) > 8 && InStr(sClassNo$, "865.A1") == 0) sDewey$ = "796.357092"
+                if (Mid(sClassNo$, 3, 4) == "884." && Len(sClassNo$) > 8 && InStr(sClassNo$, "884.A1") == 0) sDewey$ = "796.323092"
+                if (Mid(sClassNo$, 3, 4) == "915." && Len(sClassNo$) > 8 && InStr(sClassNo$, "915.A1") == 0) sDewey$ = "796.358092"
+                if (Mid(sClassNo$, 3, 4) == "939." && Len(sClassNo$) > 8 && InStr(sClassNo$, "939.A1") == 0) {
+                    sDewey$ = [
+                        {
+                            caption: 'American football',
+                            dewey: '796.332092'
+                        },
+                        {
+                            caption: 'Canadian football',
+                            dewey: '796.335092'
+                        }
+                    ]
+                }
+                if (Mid(sClassNo$, 3, 6) == "942.7." && Len(sClassNo$) > 9 && InStr(sClassNo$, "942.7.A1") == 0) sDewey$ = "796.334092"
+                if (Mid(sClassNo$, 3, 6) == "944.9." && Len(sClassNo$) > 9 && InStr(sClassNo$, "944.9.A1") == 0) sDewey$ = "796.333092"
+                if (Mid(sClassNo$, 3, 6) == "946.5." && Len(sClassNo$) > 9 && InStr(sClassNo$, "946.5.A1") == 0) sDewey$ = "796.33/6092"
+                if (Mid(sClassNo$, 3, 6) == "948.6." && Len(sClassNo$) > 9 && InStr(sClassNo$, "948.6.A1") == 0) sDewey$ = "796.33"
+                if (Mid(sClassNo$, 3, 4) == "964." && Len(sClassNo$) > 8 && InStr(sClassNo$, "964.A1") == 0) sDewey$ = "796.352092"
+                if (Mid(sClassNo$, 3, 4) == "994." && Len(sClassNo$) > 8 && InStr(sClassNo$, "994.A1") == 0) sDewey$ = "796.342092"
+            }
+
+            if (letter == 'PG') {
+                if (autoDeweyGenre == 'fiction') {
+                    _convertClassPgFiction(letter + number)
+                } else if (autoDeweyGenre == 'poetry') {
+                    _convertClassPgPoetry(letter + number)
+                } else if (autoDeweyGenre == 'drama') {
+                    _convertClassPgDrama(letter + number)
+                }
+            } else if (letter == 'PH') {
+                if (autoDeweyGenre == 'fiction') {
+                    _convertClassPhFiction(letter + number)
+                } else if (autoDeweyGenre == 'poetry') {
+                    _convertClassPhPoetry(letter + number)
+                } else if (autoDeweyGenre == 'drama') {
+                    _convertClassPhDrama(letter + number)
+                }
+            } else if (letter == 'PQ') {
+                if (autoDeweyGenre == 'fiction') {
+                    _convertClassPqFiction(letter + number)
+                } else if (autoDeweyGenre == 'poetry') {
+                    _convertClassPqPoetry(letter + number)
+                } else if (autoDeweyGenre == 'drama') {
+                    _convertClassPqDrama(letter + number)
+                }
+            } else if (letter == 'PR') {
+                if (autoDeweyGenre == 'fiction') {
+                    _convertClassPrFiction(letter + number)
+                } else if (autoDeweyGenre == 'poetry') {
+                    _convertClassPrPoetry(letter + number)
+                } else if (autoDeweyGenre == 'drama') {
+                    _convertClassPrDrama(letter + number)
+                }
+            } else if (letter == 'PS') {
+                console.info("!! PS !!", autoDeweyGenre)
+                if (autoDeweyGenre == 'fiction') {
+                    _convertClassPsFiction(letter + number)
+                } else if (autoDeweyGenre == 'poetry') {
+                    _convertClassPsPoetry(letter + number)
+                } else if (autoDeweyGenre == 'drama') {
+                    _convertClassPsDrama(letter + number)
+                }
+            } else if (letter == 'PT') {
+                if (autoDeweyGenre == 'fiction') {
+                    _convertClassPtFiction(letter + number)
+                } else if (autoDeweyGenre == 'poetry') {
+                    _convertClassPtPoetry(letter + number)
+                } else if (autoDeweyGenre == 'drama') {
+                    _convertClassPtDrama(letter + number)
+                }
+            } else if (letter == 'GV') {
+                _convertClassGvSport(letter + number)
+            }
+
+            if (autoDeweyGenre && !sDewey$) return [
+                false,
+                {
+                    error: 'autoDewey mode cannot convert this LCC'
+                }
+            ]
+
+            const deweyInfo = {
+                mode: 'autoDewey',
+                dewey: sDewey$,
+                genre: sGenre$,
+                country: sCountry$,
+                periods: []
+            }
+
+            if (Period1.Caption) deweyInfo.periods.push(Period1.Caption)
+            if (Period2.Caption) deweyInfo.periods.push(Period2.Caption)
+            if (Period3.Caption) deweyInfo.periods.push(Period3.Caption)
+            if (Period4.Caption) deweyInfo.periods.push(Period4.Caption)
+            if (Period5.Caption) deweyInfo.periods.push(Period5.Caption)
+
+            return [
+                sDewey$,
+                deweyInfo
+            ]
+
         }
 
-        const _convertClassPsDrama = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
-                sDewey$ = "Period1776"
-                Period1.Caption = "Period 1607-1776"
-                Period2.Caption = "Period 1776-1829"
-                sGenre$ = "Drama"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
-                sDewey$ = "Period1830"
-                Period1.Caption = "Period 1776-1830"
-                Period2.Caption = "Period 1830-1861"
-                Period3.Caption = "Period 1861-1899"
-                sGenre$ = "Drama"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
-                sDewey$ = "812/.54"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
-                sDewey$ = "812/.6"
+        const convertLccBasic = (letter, number) => {
+            const ruleMatches = lccDeweyMap.filter(rule => rule.LCC == letter)
+            console.info('convertLccBasic', letter, ruleMatches)
+            if (ruleMatches.length == 1) {
+                ruleMatches[0].mode = 'basic'
+                return [ruleMatches[0].dewey, ruleMatches[0]]
             }
-        }
 
-        const _convertClassPsFiction = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
-                sDewey$ = "Period1776"
-                Period1.Caption = "Period 1607-1776"
-                Period2.Caption = "Period 1776-1829"
-                sGenre$ = "Fiction"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
-                sDewey$ = "Period1830"
-                Period1.Caption = "Period 1776-1830"
-                Period2.Caption = "Period 1830-1861"
-                Period3.Caption = "Period 1861-1899"
-                sGenre$ = "Fiction"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
-                sDewey$ = "813/.54"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
-                sDewey$ = "813/.6"
-            }
-        }
-
-        const _convertClassPsPoetry = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
-                sDewey$ = "Period1776"
-                Period1.Caption = "Period 1607-1776"
-                Period2.Caption = "Period 1776-1829"
-                sGenre$ = "Poetry"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
-                sDewey$ = "Period1830"
-                Period1.Caption = "Period 1776-1830"
-                Period2.Caption = "Period 1830-1861"
-                Period3.Caption = "Period 1861-1899"
-                sGenre$ = "Poetry"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
-                sDewey$ = "Period1945"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "US"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
-                sDewey$ = "811/.54"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
-                sDewey$ = "811/.6"
-            }
-        }
-
-        const _convertClassPtDrama = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
-                sDewey$ = "Period1100"
-                Period1.Caption = "Period to 1099"
-                Period2.Caption = "Period 1100-1249"
-                Period3.Caption = "Period 1250-1349"
-                Period4.Caption = "Period 1350-1517"
-                sGenre$ = "Drama"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
-                sDewey$ = "Period1300"
-                Period1.Caption = "Period 1350-1517"
-                Period2.Caption = "Period 1517-1625"
-                Period3.Caption = "Period 1625-1749"
-                sGenre$ = "Drama"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1625-1749"
-                Period2.Caption = "Period 1750-1832"
-                Period3.Caption = "Period 1832-1856"
-                Period4.Caption = "Period 1856-1899"
-                sGenre$ = "Drama"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1856-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1990"
-                sGenre$ = "Drama"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1945-1990"
-                Period2.Caption = "Period 1990-"
-                sGenre$ = "Drama"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
-                sDewey$ = "832/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1719"
-                Period2.Caption = "Period 1720-1835"
-                sGenre$ = "Drama"
-                sCountry$ = "Iceland"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
-                sDewey$ = "Period1700"
-                Period1.Caption = "Period 1720-1835"
-                Period2.Caption = "Period 1835-1899"
-                Period3.Caption = "Period 1900-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Iceland"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
-                sDewey$ = "839/.6925"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period to 1499"
-                Period2.Caption = "Period 1500-1559"
-                sGenre$ = "Drama"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1559"
-                Period2.Caption = "Period 1560-1699"
-                Period3.Caption = "Period 1700-1749"
-                Period4.Caption = "Period 1750-1799"
-                sGenre$ = "Drama"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
-                sDewey$ = "839.812/6"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
-                sDewey$ = "839.812/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
-                sDewey$ = "839.812/8"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1559"
-                Period2.Caption = "Period 1560-1699"
-                Period3.Caption = "Period 1700-1749"
-                Period4.Caption = "Period 1750-1799"
-                sGenre$ = "Drama"
-                sCountry$ = "Norway"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
-                sDewey$ = "839.822/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
-                sDewey$ = "839.822/8"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period to 1519"
-                Period2.Caption = "Period 1520-1639"
-                sGenre$ = "Drama"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period to 1519"
-                Period2.Caption = "Period 1520-1639"
-                Period3.Caption = "Period 1640-1739"
-                Period4.Caption = "Period 1740-1779"
-                Period5.Caption = "Period 1780-1809"
-                sGenre$ = "Drama"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1780-1809"
-                Period2.Caption = "Period 1809-1830"
-                Period3.Caption = "Period 1830-1879"
-                Period4.Caption = "Period 1879-1909"
-                sGenre$ = "Drama"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1879-1909"
-                Period2.Caption = "Period 1909-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Drama"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
-                sDewey$ = "839.72/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
-                sDewey$ = "839.72/8"
-            }
-        }
-
-        const _convertClassPtFiction = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
-                sDewey$ = "Period1100"
-                Period1.Caption = "Period to 1099"
-                Period2.Caption = "Period 1100-1249"
-                Period3.Caption = "Period 1250-1349"
-                Period4.Caption = "Period 1350-1517"
-                sGenre$ = "Fiction"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
-                sDewey$ = "Period1300"
-                Period1.Caption = "Period 1350-1517"
-                Period2.Caption = "Period 1517-1625"
-                Period3.Caption = "Period 1625-1749"
-                sGenre$ = "Fiction"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1625-1749"
-                Period2.Caption = "Period 1750-1832"
-                Period3.Caption = "Period 1832-1856"
-                Period4.Caption = "Period 1856-1899"
-                sGenre$ = "Fiction"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1856-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1990"
-                sGenre$ = "Fiction"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1945-1990"
-                Period2.Caption = "Period 1990-"
-                sGenre$ = "Fiction"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
-                sDewey$ = "833/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1719"
-                Period2.Caption = "Period 1720-1835"
-                sGenre$ = "Fiction"
-                sCountry$ = "Iceland"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
-                sDewey$ = "Period1700"
-                Period1.Caption = "Period 1720-1835"
-                Period2.Caption = "Period 1835-1899"
-                Period3.Caption = "Period 1900-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Iceland"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
-                sDewey$ = "839/.6935"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period to 1499"
-                Period2.Caption = "Period 1500-1559"
-                sGenre$ = "Fiction"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1559"
-                Period2.Caption = "Period 1560-1699"
-                Period3.Caption = "Period 1700-1749"
-                Period4.Caption = "Period 1750-1799"
-                sGenre$ = "Fiction"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
-                sDewey$ = "839.813/6"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
-                sDewey$ = "839.813/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
-                sDewey$ = "839.813/8"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1559"
-                Period2.Caption = "Period 1560-1699"
-                Period3.Caption = "Period 1700-1749"
-                Period4.Caption = "Period 1750-1799"
-                sGenre$ = "Fiction"
-                sCountry$ = "Norway"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
-                sDewey$ = "839.823/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
-                sDewey$ = "839.823/8"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period to 1519"
-                Period2.Caption = "Period 1520-1639"
-                sGenre$ = "Fiction"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period to 1519"
-                Period2.Caption = "Period 1520-1639"
-                Period3.Caption = "Period 1640-1739"
-                Period4.Caption = "Period 1740-1779"
-                Period5.Caption = "Period 1780-1809"
-                sGenre$ = "Fiction"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1780-1809"
-                Period2.Caption = "Period 1809-1830"
-                Period3.Caption = "Period 1830-1879"
-                Period4.Caption = "Period 1879-1909"
-                sGenre$ = "Fiction"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1879-1909"
-                Period2.Caption = "Period 1909-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Fiction"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
-                sDewey$ = "839.73/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
-                sDewey$ = "839.73/8"
-            }
-        }
-
-        const _convertClassPtPoetry = (sClassNo$) => {
-            if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
-                sDewey$ = "Period1100"
-                Period1.Caption = "Period to 1099"
-                Period2.Caption = "Period 1100-1249"
-                Period3.Caption = "Period 1250-1349"
-                Period4.Caption = "Period 1350-1517"
-                sGenre$ = "Poetry"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
-                sDewey$ = "Period1300"
-                Period1.Caption = "Period 1350-1517"
-                Period2.Caption = "Period 1517-1625"
-                Period3.Caption = "Period 1625-1749"
-                sGenre$ = "Poetry"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period 1625-1749"
-                Period2.Caption = "Period 1750-1832"
-                Period3.Caption = "Period 1832-1856"
-                Period4.Caption = "Period 1856-1899"
-                sGenre$ = "Poetry"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1856-1899"
-                Period2.Caption = "Period 1900-1945"
-                Period3.Caption = "Period 1945-1990"
-                sGenre$ = "Poetry"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1945-1990"
-                Period2.Caption = "Period 1990-"
-                sGenre$ = "Poetry"
-                sCountry$ = "Germany"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
-                sDewey$ = "831/.92"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1719"
-                Period2.Caption = "Period 1720-1835"
-                sGenre$ = "Poetry"
-                sCountry$ = "Iceland"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
-                sDewey$ = "Period1700"
-                Period1.Caption = "Period 1720-1835"
-                Period2.Caption = "Period 1835-1899"
-                Period3.Caption = "Period 1900-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Iceland"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
-                sDewey$ = "839/.6915"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
-                sDewey$ = "Period1400"
-                Period1.Caption = "Period to 1499"
-                Period2.Caption = "Period 1500-1559"
-                sGenre$ = "Poetry"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1559"
-                Period2.Caption = "Period 1560-1699"
-                Period3.Caption = "Period 1700-1749"
-                Period4.Caption = "Period 1750-1799"
-                sGenre$ = "Poetry"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
-                sDewey$ = "839.811/6"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1900-1945"
-                Period2.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Denmark"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
-                sDewey$ = "839.811/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
-                sDewey$ = "839.811/8"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period 1500-1559"
-                Period2.Caption = "Period 1560-1699"
-                Period3.Caption = "Period 1700-1749"
-                Period4.Caption = "Period 1750-1799"
-                sGenre$ = "Poetry"
-                sCountry$ = "Norway"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
-                sDewey$ = "839.821/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
-                sDewey$ = "839.821/8"
-            } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
-                sDewey$ = "Period1500"
-                Period1.Caption = "Period to 1519"
-                Period2.Caption = "Period 1520-1639"
-                sGenre$ = "Poetry"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
-                sDewey$ = "Period1600"
-                Period1.Caption = "Period to 1519"
-                Period2.Caption = "Period 1520-1639"
-                Period3.Caption = "Period 1640-1739"
-                Period4.Caption = "Period 1740-1779"
-                Period5.Caption = "Period 1780-1809"
-                sGenre$ = "Poetry"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
-                sDewey$ = "Period1800"
-                Period1.Caption = "Period 1780-1809"
-                Period2.Caption = "Period 1809-1830"
-                Period3.Caption = "Period 1830-1879"
-                Period4.Caption = "Period 1879-1909"
-                sGenre$ = "Poetry"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
-                sDewey$ = "Period1900"
-                Period1.Caption = "Period 1879-1909"
-                Period2.Caption = "Period 1909-1945"
-                Period3.Caption = "Period 1945-1999"
-                sGenre$ = "Poetry"
-                sCountry$ = "Sweden"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
-                sDewey$ = "839.71/74"
-            } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
-                sDewey$ = "839.71/8"
-            }
-        }
-
-        //GV
-        const _convertClassGvSport = (sClassNo$) => {
-            if (Mid(sClassNo$, 3, 8) == "1003.62.") sDewey$ = "796.343092"
-            if (Mid(sClassNo$, 3, 8) == "1005.22.") sDewey$ = "796.34/6092"
-            if (Mid(sClassNo$, 3, 8) == "1006.52.") sDewey$ = "796.345092"
-            if (Mid(sClassNo$, 3, 8) == "1010.32.") sDewey$ = "796.35/3092"
-            if (Mid(sClassNo$, 3, 8) == "1015.26.") sDewey$ = "796.325092"
-            if (Mid(sClassNo$, 3, 5) == "1032." && Len(sClassNo$) > 8 && InStr(sClassNo$, "1032.A1") == 0) sDewey$ = "796.72092"
-            if (Mid(sClassNo$, 3, 5) == "1132.") sDewey$ = "796.83092"
-            if (Mid(sClassNo$, 3, 5) == "1186.") sDewey$ = "799.3/2092"
-            if (Mid(sClassNo$, 3, 5) == "1196." && Len(sClassNo$) > 8 && InStr(sClassNo$, "1196.A1") == 0) sDewey$ = "796.812092"
-            if (Mid(sClassNo$, 3, 7) == "545.52.") sDewey$ = "796.41092"
-            if (Mid(sClassNo$, 3, 6) == "848.5." && Len(sClassNo$) > 9 && InStr(sClassNo$, "848.5.A1") == 0) sDewey$ = "796.962092"
-            if (Mid(sClassNo$, 3, 4) == "850." && IsNumeric(Mid(sClassNo$, 7, 1)) == false && Len(sClassNo$) > 8 && (InStr(sClassNo$, "850.A1") == 0 && InStr(sClassNo$, "850.A2") == 0)) {
-                sDewey$ = [
-                    {
-                        caption: 'Figure skating',
-                        dewey: '796.91/2092'
-                    },
-                    {
-                        caption: 'Speed skating',
-                        dewey: '796.91/4092'
+            if (ruleMatches.length > 1) {
+                for (const rule of ruleMatches) {
+                    let range = rule['LCC Range'].replace(rule.LCC, '').trim()
+                    if (range.charAt(range.length - 1) == '+') {
+                        range = range.replace('+', ' - 999999999')
                     }
-                ]
-            }
-            if (Mid(sClassNo$, 3, 4) == "865." && Len(sClassNo$) > 8 && InStr(sClassNo$, "865.A1") == 0) sDewey$ = "796.357092"
-            if (Mid(sClassNo$, 3, 4) == "884." && Len(sClassNo$) > 8 && InStr(sClassNo$, "884.A1") == 0) sDewey$ = "796.323092"
-            if (Mid(sClassNo$, 3, 4) == "915." && Len(sClassNo$) > 8 && InStr(sClassNo$, "915.A1") == 0) sDewey$ = "796.358092"
-            if (Mid(sClassNo$, 3, 4) == "939." && Len(sClassNo$) > 8 && InStr(sClassNo$, "939.A1") == 0) {
-                sDewey$ = [
-                    {
-                        caption: 'American football',
-                        dewey: '796.332092'
-                    },
-                    {
-                        caption: 'Canadian football',
-                        dewey: '796.335092'
+                    const [rangeStart, rangeEnd] = range.split(' - ')
+                    console.log('range', range, rangeStart, rangeEnd)
+                    console.log('number', number)
+                    if (number * 1 >= rangeStart * 1 && number * 1 <= rangeEnd * 1) {
+                        // console.log('number WITHIN range', number)
+                        rule.mode = 'basic'
+                        return [rule.dewey, rule]
                     }
-                ]
+                }
+
+                //if no range found just use first (generic) one
+                return [ruleMatches[0].dewey, ruleMatches[0]]
             }
-            if (Mid(sClassNo$, 3, 6) == "942.7." && Len(sClassNo$) > 9 && InStr(sClassNo$, "942.7.A1") == 0) sDewey$ = "796.334092"
-            if (Mid(sClassNo$, 3, 6) == "944.9." && Len(sClassNo$) > 9 && InStr(sClassNo$, "944.9.A1") == 0) sDewey$ = "796.333092"
-            if (Mid(sClassNo$, 3, 6) == "946.5." && Len(sClassNo$) > 9 && InStr(sClassNo$, "946.5.A1") == 0) sDewey$ = "796.33/6092"
-            if (Mid(sClassNo$, 3, 6) == "948.6." && Len(sClassNo$) > 9 && InStr(sClassNo$, "948.6.A1") == 0) sDewey$ = "796.33"
-            if (Mid(sClassNo$, 3, 4) == "964." && Len(sClassNo$) > 8 && InStr(sClassNo$, "964.A1") == 0) sDewey$ = "796.352092"
-            if (Mid(sClassNo$, 3, 4) == "994." && Len(sClassNo$) > 8 && InStr(sClassNo$, "994.A1") == 0) sDewey$ = "796.342092"
+
+            return [false, { error: 'Unable to convert this LCC' }]
+
+
         }
 
-        if (letter == 'PG') {
-            if (autoDeweyGenre == 'fiction') {
-                _convertClassPgFiction(letter + number)
-            } else if (autoDeweyGenre == 'poetry') {
-                _convertClassPgPoetry(letter + number)
-            } else if (autoDeweyGenre == 'drama') {
-                _convertClassPgDrama(letter + number)
-            }
-        } else if (letter == 'PH') {
-            if (autoDeweyGenre == 'fiction') {
-                _convertClassPhFiction(letter + number)
-            } else if (autoDeweyGenre == 'poetry') {
-                _convertClassPhPoetry(letter + number)
-            } else if (autoDeweyGenre == 'drama') {
-                _convertClassPhDrama(letter + number)
-            }
-        } else if (letter == 'PQ') {
-            if (autoDeweyGenre == 'fiction') {
-                _convertClassPqFiction(letter + number)
-            } else if (autoDeweyGenre == 'poetry') {
-                _convertClassPqPoetry(letter + number)
-            } else if (autoDeweyGenre == 'drama') {
-                _convertClassPqDrama(letter + number)
-            }
-        } else if (letter == 'PR') {
-            if (autoDeweyGenre == 'fiction') {
-                _convertClassPrFiction(letter + number)
-            } else if (autoDeweyGenre == 'poetry') {
-                _convertClassPrPoetry(letter + number)
-            } else if (autoDeweyGenre == 'drama') {
-                _convertClassPrDrama(letter + number)
-            }
-        } else if (letter == 'PS') {
-            console.info("!! PS !!", autoDeweyGenre)
-            if (autoDeweyGenre == 'fiction') {
-                _convertClassPsFiction(letter + number)
-            } else if (autoDeweyGenre == 'poetry') {
-                _convertClassPsPoetry(letter + number)
-            } else if (autoDeweyGenre == 'drama') {
-                _convertClassPsDrama(letter + number)
-            }
-        } else if (letter == 'PT') {
-            if (autoDeweyGenre == 'fiction') {
-                _convertClassPtFiction(letter + number)
-            } else if (autoDeweyGenre == 'poetry') {
-                _convertClassPtPoetry(letter + number)
-            } else if (autoDeweyGenre == 'drama') {
-                _convertClassPtDrama(letter + number)
-            }
-        } else if (letter == 'GV') {
-            _convertClassGvSport(letter + number)
-        }
+        const [match, letter, number] = lcCall.trim().match(/^([A-Z]*)(.*)/)
+        const deweys = lccDeweyMap.filter(ddc => ddc.LCC == letter)
 
-        if (autoDeweyGenre && !sDewey$) return [
-            false,
-            {
-                error: 'autoDewey mode cannot convert this LCC'
-            }
-        ]
+        console.info('letter', letter)
+        console.info(lccDeweyMap)
+        console.info(deweys)
 
-        const deweyInfo = {
-            mode: 'autoDewey',
-            dewey: sDewey$,
-            genre: sGenre$,
-            country: sCountry$,
-            periods: []
-        }
+        const [dewey, deweyInfo] = lccsWithLocalLogics.includes(letter) ? convertLccWithLocalLogics(letter, number) : convertLccBasic(letter, number)
 
-        if (Period1.Caption) deweyInfo.periods.push(Period1.Caption)
-        if (Period2.Caption) deweyInfo.periods.push(Period2.Caption)
-        if (Period3.Caption) deweyInfo.periods.push(Period3.Caption)
-        if (Period4.Caption) deweyInfo.periods.push(Period4.Caption)
-        if (Period5.Caption) deweyInfo.periods.push(Period5.Caption)
+        console.info("lcCall: ", lcCall, dewey, deweyInfo)
+        console.info("dewey: ", dewey)
+        console.info("deweyInfo: ", deweyInfo)
 
-        return [
-            sDewey$,
+        if (deweyInfo.mode == 'autoDewey') return (
             deweyInfo
-        ]
+            // <div style={{ background: 'lavender', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
+            //     <div>LCC: {lcCall}</div>
+            //     {!lcCall.startsWith('GV') && (
+            //         <>
+            //             <div>Please choose genre of this item</div>
+            //             <ButtonGroup>
+            //                 {autoDeweyGenres.map((genre, i) => (
+            //                     <Button
+            //                         key={`genre-${i}`}
+            //                         onClick={() => onAutoDeweyGenreClick(genre)}
+            //                         buttonStyle={
+            //                             genre === autoDeweyGenre
+            //                                 ? 'primary'
+            //                                 : 'default'
+            //                         }
+            //                     >
+            //                         <span style={{ textTransform: 'capitalize' }}>{genre}</span>
+            //                     </Button>
+            //                 )
+            //                 )}
+            //             </ButtonGroup>
+            //         </>
+            //     )}
+            //     <>
+            //         {(deweyInfo.periods.length > 0) ? (
+            //             <>
+            //                 <div>
+            //                     Please choose time period of this item
+            //                     <br />
+            //                     {deweyInfo.periods.map((period, i) => (
+            //                         <Button
+            //                             key={`period-${i}`}
+            //                             onClick={() => onPeriodClicked(i + 1, dewey, deweyInfo.genre, deweyInfo.country)}
+            //                         >
+            //                             {period}
+            //                         </Button>
+            //                     )
+            //                     )}
+            //                 </div>
+
+            //                 {autoDeweyResult && (
+            //                     <>
+            //                     <div>
+            //                         {autoDeweyResult}
+            //                     </div>
+            //                     <div>
+            //                         <Button onClick={() => parentPhone({action: 'copyToClipboard', value: autoDeweyResult})}>Copy</Button>
+            //                     </div>
+            //                     </>
+            //                 )}
+            //             </>
+            //         ) : (
+            //             dewey ? (
+            //                 <>
+            //                     {Array.isArray(dewey) ? (
+            //                         <>
+            //                             <div>Dewies:</div>
+            //                             <ul>
+            //                                 {dewey.map(result => <li key={result.dewey}>{result.caption}: {result.dewey}</li>)}
+            //                             </ul>
+            //                         </>
+            //                     ) : (
+            //                         <>
+            //                         <div>Dewey: {dewey}</div>
+            //                         <div>
+            //                         <Button onClick={() => parentPhone({action: 'copyToClipboard', value: dewey})}>Copy</Button>
+            //                         </div>
+            //                         </>
+
+            //                     )}
+
+            //                 </>
+            //             ) : (
+            //                 (dewey === false) && (
+            //                     <>
+            //                         <div>Can't convert this LCC to Dewey 😔</div>
+            //                     </>
+            //                 )
+            //             )
+            //         )}
+            //     </>
+
+            // </div>
+        )
+
+
+        //basic mode
+        return ( deweyInfo
+
+            // <div style={{ background: 'antiquewhite', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
+            //     <div>LC Call#: {lcCall}
+            //             {deweyInfo && (
+            //                 <Badge>
+            //                     <small>{deweyInfo['LCC Caption']}</small>
+            //                 </Badge>
+            //             )}
+            //     </div>
+
+            //     {dewey && (
+            //         <>
+            //             <div>Dewey: <strong>{dewey}</strong>
+            //                 {deweyInfo && (
+            //                     <Badge>
+            //                         <small>{deweyInfo['DDC Caption']}</small>
+            //                     </Badge>
+            //                 )}
+            //             </div>
+            //         </>
+            //     )}
+
+            //     {dewey === false && (
+            //         <div>Can't convert this LCC to Dewey 😔</div>
+            //     )}
+
+            // </div>
+        )
 
     }
 
-    const onPeriodClicked = (periodNumber, sDewey$, sGenre$, sCountry$) => {
+    export function onPeriodClicked(periodNumber, sDewey$, sGenre$, sCountry$){
 
         console.log('onPeriodClicked', periodNumber, sDewey$, sGenre$, sCountry$)
 
@@ -2442,177 +2610,5 @@ export default function LcCallToDewey(lcCall, genre=null) {  //{ lcCall, parentP
             if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.72/5"
         }
 
-
-
-        setAutoDeweyResult(dewey)
-        // return dewey
-
+        return dewey
     }
-
-    const convertLccBasic = (letter, number) => {
-        const ruleMatches = lccDeweyMap.filter(rule => rule.LCC == letter)
-        console.info('convertLccBasic', letter, ruleMatches)
-        if (ruleMatches.length == 1) {
-            ruleMatches[0].mode = 'basic'
-            return [ruleMatches[0].dewey, ruleMatches[0]]
-        }
-
-        if (ruleMatches.length > 1) {
-            for (const rule of ruleMatches) {
-                let range = rule['LCC Range'].replace(rule.LCC, '').trim()
-                if (range.charAt(range.length - 1) == '+') {
-                    range = range.replace('+', ' - 999999999')
-                }
-                const [rangeStart, rangeEnd] = range.split(' - ')
-                console.log('range', range, rangeStart, rangeEnd)
-                console.log('number', number)
-                if (number * 1 >= rangeStart * 1 && number * 1 <= rangeEnd * 1) {
-                    // console.log('number WITHIN range', number)
-                    rule.mode = 'basic'
-                    return [rule.dewey, rule]
-                }
-            }
-
-            //if no range found just use first (generic) one
-            return [ruleMatches[0].dewey, ruleMatches[0]]
-        }
-
-        return [false, { error: 'Unable to convert this LCC' }]
-
-
-    }
-
-    const [match, letter, number] = lcCall.trim().match(/^([A-Z]*)(.*)/)
-    const deweys = lccDeweyMap.filter(ddc => ddc.LCC == letter)
-
-    console.info('letter', letter)
-    console.info(lccDeweyMap)
-    console.info(deweys)
-
-    const [dewey, deweyInfo] = lccsWithLocalLogics.includes(letter) ? convertLccWithLocalLogics(letter, number) : convertLccBasic(letter, number)
-
-    console.info("lcCall: ", lcCall, dewey, deweyInfo)
-    console.info("dewey: ", dewey)
-    console.info("deweyInfo: ", deweyInfo)
-
-    if (deweyInfo.mode == 'autoDewey') return (
-        deweyInfo
-        // <div style={{ background: 'lavender', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
-        //     <div>LCC: {lcCall}</div>
-        //     {!lcCall.startsWith('GV') && (
-        //         <>
-        //             <div>Please choose genre of this item</div>
-        //             <ButtonGroup>
-        //                 {autoDeweyGenres.map((genre, i) => (
-        //                     <Button
-        //                         key={`genre-${i}`}
-        //                         onClick={() => onAutoDeweyGenreClick(genre)}
-        //                         buttonStyle={
-        //                             genre === autoDeweyGenre
-        //                                 ? 'primary'
-        //                                 : 'default'
-        //                         }
-        //                     >
-        //                         <span style={{ textTransform: 'capitalize' }}>{genre}</span>
-        //                     </Button>
-        //                 )
-        //                 )}
-        //             </ButtonGroup>
-        //         </>
-        //     )}
-        //     <>
-        //         {(deweyInfo.periods.length > 0) ? (
-        //             <>
-        //                 <div>
-        //                     Please choose time period of this item
-        //                     <br />
-        //                     {deweyInfo.periods.map((period, i) => (
-        //                         <Button
-        //                             key={`period-${i}`}
-        //                             onClick={() => onPeriodClicked(i + 1, dewey, deweyInfo.genre, deweyInfo.country)}
-        //                         >
-        //                             {period}
-        //                         </Button>
-        //                     )
-        //                     )}
-        //                 </div>
-
-        //                 {autoDeweyResult && (
-        //                     <>
-        //                     <div>
-        //                         {autoDeweyResult}
-        //                     </div>
-        //                     <div>
-        //                         <Button onClick={() => parentPhone({action: 'copyToClipboard', value: autoDeweyResult})}>Copy</Button>
-        //                     </div>
-        //                     </>
-        //                 )}
-        //             </>
-        //         ) : (
-        //             dewey ? (
-        //                 <>
-        //                     {Array.isArray(dewey) ? (
-        //                         <>
-        //                             <div>Dewies:</div>
-        //                             <ul>
-        //                                 {dewey.map(result => <li key={result.dewey}>{result.caption}: {result.dewey}</li>)}
-        //                             </ul>
-        //                         </>
-        //                     ) : (
-        //                         <>
-        //                         <div>Dewey: {dewey}</div>
-        //                         <div>
-        //                         <Button onClick={() => parentPhone({action: 'copyToClipboard', value: dewey})}>Copy</Button>
-        //                         </div>
-        //                         </>
-
-        //                     )}
-
-        //                 </>
-        //             ) : (
-        //                 (dewey === false) && (
-        //                     <>
-        //                         <div>Can't convert this LCC to Dewey 😔</div>
-        //                     </>
-        //                 )
-        //             )
-        //         )}
-        //     </>
-
-        // </div>
-    )
-
-
-    //basic mode
-    return ( deweyInfo
-
-        // <div style={{ background: 'antiquewhite', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
-        //     <div>LC Call#: {lcCall}
-        //             {deweyInfo && (
-        //                 <Badge>
-        //                     <small>{deweyInfo['LCC Caption']}</small>
-        //                 </Badge>
-        //             )}
-        //     </div>
-
-        //     {dewey && (
-        //         <>
-        //             <div>Dewey: <strong>{dewey}</strong>
-        //                 {deweyInfo && (
-        //                     <Badge>
-        //                         <small>{deweyInfo['DDC Caption']}</small>
-        //                     </Badge>
-        //                 )}
-        //             </div>
-        //         </>
-        //     )}
-
-        //     {dewey === false && (
-        //         <div>Can't convert this LCC to Dewey 😔</div>
-        //     )}
-
-        // </div>
-    )
-
-}
-

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -1871,6 +1871,8 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
             //GV
             const _convertClassGvSport = (sClassNo$) => {
+                console.info("converting sport")
+                console.info(Mid(sClassNo$, 3, 8))
                 if (Mid(sClassNo$, 3, 8) == "1003.62.") sDewey$ = "796.343092"
                 if (Mid(sClassNo$, 3, 8) == "1005.22.") sDewey$ = "796.34/6092"
                 if (Mid(sClassNo$, 3, 8) == "1006.52.") sDewey$ = "796.345092"
@@ -2032,6 +2034,11 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
         }
 
         const [match, letter, number] = lcCall.trim().match(/^([A-Z]*)(.*)/)
+
+        console.info("!! match: ", match)
+        console.info("!! letter: ", letter)
+        console.info("!! number: ", number)
+
         const deweys = lccDeweyMap.filter(ddc => ddc.LCC == letter)
 
         console.info('letter', letter)

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -1,6 +1,7 @@
 //from https://git.loc.gov/lcap/aws-lcap/ui-lcap-productivity-tools/-/blob/issue-001/lcap-productivity-tools/src/components/auto-dewey/instance-selected/lccall-to-dewey.js?ref_type=heads
 
-import {lccDeweyMap} from 'LCCtoDewey.json';
+import lccDeweyMap from "@/lib/LCCtoDewey.json"
+
 
 export default function LcCallToDewey({ lcCall, parentPhone }) {
 
@@ -2505,120 +2506,122 @@ export default function LcCallToDewey({ lcCall, parentPhone }) {
     console.log(lcCall, dewey, deweyInfo)
 
     if (deweyInfo.mode == 'autoDewey') return (
-        <div style={{ background: 'lavender', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
-            <div>LCC: {lcCall}</div>
-            {!lcCall.startsWith('GV') && (
-                <>
-                    <div>Please choose genre of this item</div>
-                    <ButtonGroup>
-                        {autoDeweyGenres.map((genre, i) => (
-                            <Button
-                                key={`genre-${i}`}
-                                onClick={() => onAutoDeweyGenreClick(genre)}
-                                buttonStyle={
-                                    genre === autoDeweyGenre
-                                        ? 'primary'
-                                        : 'default'
-                                }
-                            >
-                                <span style={{ textTransform: 'capitalize' }}>{genre}</span>
-                            </Button>
-                        )
-                        )}
-                    </ButtonGroup>
-                </>
-            )}
-            <>
-                {(deweyInfo.periods.length > 0) ? (
-                    <>
-                        <div>
-                            Please choose time period of this item
-                            <br />
-                            {deweyInfo.periods.map((period, i) => (
-                                <Button
-                                    key={`period-${i}`}
-                                    onClick={() => onPeriodClicked(i + 1, dewey, deweyInfo.genre, deweyInfo.country)}
-                                >
-                                    {period}
-                                </Button>
-                            )
-                            )}
-                        </div>
+        deweyInfo
+        // <div style={{ background: 'lavender', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
+        //     <div>LCC: {lcCall}</div>
+        //     {!lcCall.startsWith('GV') && (
+        //         <>
+        //             <div>Please choose genre of this item</div>
+        //             <ButtonGroup>
+        //                 {autoDeweyGenres.map((genre, i) => (
+        //                     <Button
+        //                         key={`genre-${i}`}
+        //                         onClick={() => onAutoDeweyGenreClick(genre)}
+        //                         buttonStyle={
+        //                             genre === autoDeweyGenre
+        //                                 ? 'primary'
+        //                                 : 'default'
+        //                         }
+        //                     >
+        //                         <span style={{ textTransform: 'capitalize' }}>{genre}</span>
+        //                     </Button>
+        //                 )
+        //                 )}
+        //             </ButtonGroup>
+        //         </>
+        //     )}
+        //     <>
+        //         {(deweyInfo.periods.length > 0) ? (
+        //             <>
+        //                 <div>
+        //                     Please choose time period of this item
+        //                     <br />
+        //                     {deweyInfo.periods.map((period, i) => (
+        //                         <Button
+        //                             key={`period-${i}`}
+        //                             onClick={() => onPeriodClicked(i + 1, dewey, deweyInfo.genre, deweyInfo.country)}
+        //                         >
+        //                             {period}
+        //                         </Button>
+        //                     )
+        //                     )}
+        //                 </div>
 
-                        {autoDeweyResult && (
-                            <>
-                            <div>
-                                {autoDeweyResult}
-                            </div>
-                            <div>
-                                <Button onClick={() => parentPhone({action: 'copyToClipboard', value: autoDeweyResult})}>Copy</Button>
-                            </div>
-                            </>
-                        )}
-                    </>
-                ) : (
-                    dewey ? (
-                        <>
-                            {Array.isArray(dewey) ? (
-                                <>
-                                    <div>Dewies:</div>
-                                    <ul>
-                                        {dewey.map(result => <li key={result.dewey}>{result.caption}: {result.dewey}</li>)}
-                                    </ul>
-                                </>
-                            ) : (
-                                <>
-                                <div>Dewey: {dewey}</div>
-                                <div>
-                                <Button onClick={() => parentPhone({action: 'copyToClipboard', value: dewey})}>Copy</Button>
-                                </div>
-                                </>
+        //                 {autoDeweyResult && (
+        //                     <>
+        //                     <div>
+        //                         {autoDeweyResult}
+        //                     </div>
+        //                     <div>
+        //                         <Button onClick={() => parentPhone({action: 'copyToClipboard', value: autoDeweyResult})}>Copy</Button>
+        //                     </div>
+        //                     </>
+        //                 )}
+        //             </>
+        //         ) : (
+        //             dewey ? (
+        //                 <>
+        //                     {Array.isArray(dewey) ? (
+        //                         <>
+        //                             <div>Dewies:</div>
+        //                             <ul>
+        //                                 {dewey.map(result => <li key={result.dewey}>{result.caption}: {result.dewey}</li>)}
+        //                             </ul>
+        //                         </>
+        //                     ) : (
+        //                         <>
+        //                         <div>Dewey: {dewey}</div>
+        //                         <div>
+        //                         <Button onClick={() => parentPhone({action: 'copyToClipboard', value: dewey})}>Copy</Button>
+        //                         </div>
+        //                         </>
 
-                            )}
+        //                     )}
 
-                        </>
-                    ) : (
-                        (dewey === false) && (
-                            <>
-                                <div>Can't convert this LCC to Dewey 😔</div>
-                            </>
-                        )
-                    )
-                )}
-            </>
+        //                 </>
+        //             ) : (
+        //                 (dewey === false) && (
+        //                     <>
+        //                         <div>Can't convert this LCC to Dewey 😔</div>
+        //                     </>
+        //                 )
+        //             )
+        //         )}
+        //     </>
 
-        </div>
+        // </div>
     )
 
 
     //basic mode
-    return (
-        <div style={{ background: 'antiquewhite', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
-            <div>LC Call#: {lcCall}
-                    {deweyInfo && (
-                        <Badge>
-                            <small>{deweyInfo['LCC Caption']}</small>
-                        </Badge>
-                    )}
-            </div>
+    return ( deweyInfo
 
-            {dewey && (
-                <>
-                    <div>Dewey: <strong>{dewey}</strong>
-                        {deweyInfo && (
-                            <Badge>
-                                <small>{deweyInfo['DDC Caption']}</small>
-                            </Badge>
-                        )}
-                    </div>
-                </>
-            )}
+        // <div style={{ background: 'antiquewhite', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
+        //     <div>LC Call#: {lcCall}
+        //             {deweyInfo && (
+        //                 <Badge>
+        //                     <small>{deweyInfo['LCC Caption']}</small>
+        //                 </Badge>
+        //             )}
+        //     </div>
 
-            {dewey === false && (
-                <div>Can't convert this LCC to Dewey 😔</div>
-            )}
+        //     {dewey && (
+        //         <>
+        //             <div>Dewey: <strong>{dewey}</strong>
+        //                 {deweyInfo && (
+        //                     <Badge>
+        //                         <small>{deweyInfo['DDC Caption']}</small>
+        //                     </Badge>
+        //                 )}
+        //             </div>
+        //         </>
+        //     )}
 
-        </div>
+        //     {dewey === false && (
+        //         <div>Can't convert this LCC to Dewey 😔</div>
+        //     )}
+
+        // </div>
     )
 
 }

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -1,0 +1,2625 @@
+//from https://git.loc.gov/lcap/aws-lcap/ui-lcap-productivity-tools/-/blob/issue-001/lcap-productivity-tools/src/components/auto-dewey/instance-selected/lccall-to-dewey.js?ref_type=heads
+
+import {lccDeweyMap} from 'LCCtoDewey.json';
+
+export default function LcCallToDewey({ lcCall, parentPhone }) {
+
+    if (!lcCall) return
+
+    //this if for Px class, for GV uses 'GV Bio'
+    const autoDeweyGenres = ['fiction', 'poetry', 'drama']
+    const [autoDeweyGenre, setAutoDeweyGenre] = useState();
+    const [autoDeweyResult, setAutoDeweyResult] = useState();
+
+    const lccsWithLocalLogics = ['PG', 'PH', 'PQ', 'PR', 'PS', 'PT', 'GV']
+
+    //autoDewey mode
+    const convertLccWithLocalLogics = (letter, number) => {
+        //these are basically copy and pasted form VBA
+
+        const Left = (str, numChars) => {
+            return str.substring(0, numChars)
+        }
+
+        const Mid = (str, start, numChars) => {
+            const indexStart = start - 1
+            const indexEnd = indexStart + numChars
+            return str.substring(indexStart, indexEnd)
+        }
+
+        const Val = (val) => {
+            return Number(val)
+        }
+
+        const Len = (str) => {
+            return str.length
+        }
+
+        const InStr = (str, subStr) => {
+            return str.includes(subStr) ? 1 : 0
+        }
+
+        const IsNumeric = (val) => {
+            const testResult = Number(val)
+            return Number.isNaN(testResult) ? false : true
+        }
+
+        let sDewey$
+        let sGenre$
+        let sCountry$
+        const Period1 = {}
+        const Period2 = {}
+        const Period3 = {}
+        const Period4 = {}
+        const Period5 = {}
+
+        //https://git.loc.gov/ilspo/voyager-desktop-applications/-/blob/master/AutoDewey/AutoDewey.frm#L223
+        const _convertClassPgDrama = (sClassNo$) => {
+            if (Left(sClassNo$, 2) == "PG") {
+                if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
+                    sDewey$ = "891.72/1"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
+                    sDewey$ = "891.72/2"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
+                    sDewey$ = "891.72/3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
+                    sDewey$ = "891.72/3"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
+                    // Call ButtonsToPeriod
+                    sDewey$ = "Period1917"
+                    Period1.Caption = "Period 1917-1945"
+                    Period2.Caption = "Period 1945-1991"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Russia"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
+                    // Call ButtonsToPeriod
+                    sDewey$ = "Period1945"
+                    Period1.Caption = "Period 1945-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Russia"
+                } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
+                    sDewey$ = "891.72/5"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
+                    // Call ButtonsToPeriod
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "Period to 1799"
+                    Period2.Caption = "Period 1800-1899"
+                    Period3.Caption = "Period 1900-1991"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Lithuania"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
+                    // Call ButtonsToPeriod
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Lithuania"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
+                    sDewey$ = "891/.9224"
+                } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
+                    // Call ButtonsToPeriod
+                    sDewey$ = "Period1800"
+                    Period1.Caption = "To 1799"
+                    Period2.Caption = "Period 1800-1899"
+                    Period3.Caption = "Period 1900-1991"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Latvia"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
+                    // Call ButtonsToPeriod
+                    sDewey$ = "Period1900"
+                    Period1.Caption = "Period 1900-1991"
+                    Period2.Caption = "Period 1991-"
+                    sGenre$ = "Drama"
+                    sCountry$ = "Latvia"
+                } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
+                    sDewey$ = "891/.9324"
+                }
+            }
+        }
+
+        const _convertClassPgFiction = (sClassNo$) => {
+
+            if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
+                sDewey$ = "891.73/1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
+                sDewey$ = "891.73/2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
+                sDewey$ = "891.73/3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
+                sDewey$ = "891.73/3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
+                sDewey$ = "Period1917"
+                Period1.Caption = "Period 1917-1945"
+                Period2.Caption = "Period 1945-1991"
+                sGenre$ = "Fiction"
+                sCountry$ = "Russia"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1945-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Fiction"
+                sCountry$ = "Russia"
+            } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
+                sDewey$ = "891.73/5"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "To 1799"
+                Period2.Caption = "Period 1800-1899"
+                Period3.Caption = "Period 1900-1991"
+                sGenre$ = "Fiction"
+                sCountry$ = "Lithuania"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1900-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Fiction"
+                sCountry$ = "Lithuania"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
+                sDewey$ = "891/.9234"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "To 1799"
+                Period2.Caption = "Period 1800-1899"
+                Period3.Caption = "Period 1900-1991"
+                sGenre$ = "Fiction"
+                sCountry$ = "Latvia"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1900-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Fiction"
+                sCountry$ = "Latvia"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
+                sDewey$ = "891/.9334"
+            }
+        }
+
+        const _convertClassPgPoetry = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3309) {
+                sDewey$ = "891.71/1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3309 && Val(Mid(sClassNo$, 3, 4)) < 3320) {
+                sDewey$ = "891.71/2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3319 && Val(Mid(sClassNo$, 3, 4)) < 3448) {
+                sDewey$ = "891.71/3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3449 && Val(Mid(sClassNo$, 3, 4)) < 3471) {
+                sDewey$ = "891.71/3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3474 && Val(Mid(sClassNo$, 3, 4)) < 3477) {
+                sDewey$ = "Period1917"
+                Period1.Caption = "Period 1917-1945"
+                Period2.Caption = "Period 1945-1991"
+                sGenre$ = "Poetry"
+                sCountry$ = "Russia"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3476 && Val(Mid(sClassNo$, 3, 4)) < 3491) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1945-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Poetry"
+                sCountry$ = "Russia"
+            } else if (Val(Mid(sClassNo$, 3, 6)) > 3491.1 && Val(Mid(sClassNo$, 3, 7)) < 3493.97) {
+                sDewey$ = "891.71/5"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8721) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "To 1799"
+                Period2.Caption = "Period 1800-1899"
+                Period3.Caption = "Period 1900-1991"
+                sGenre$ = "Poetry"
+                sCountry$ = "Lithuania"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8721 && Val(Mid(sClassNo$, 3, 6)) < 8722.37) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1900-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Poetry"
+                sCountry$ = "Lithuania"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8722 && Val(Mid(sClassNo$, 3, 6)) < 8723.37) {
+                sDewey$ = "891/.9214"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9048) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "To 1799"
+                Period2.Caption = "Period 1800-1899"
+                Period3.Caption = "Period 1900-1991"
+                sGenre$ = "Poetry"
+                sCountry$ = "Latvia"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9048 && Val(Mid(sClassNo$, 3, 6)) < 9049.37) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1900-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Poetry"
+                sCountry$ = "Latvia"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9049 && Val(Mid(sClassNo$, 3, 6)) < 9050.37) {
+                sDewey$ = "891/.9314"
+            }
+        }
+
+        const _convertClassPhDrama = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 3)) == 353) {
+                sDewey$ = "894/.54121"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Finland"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
+                sDewey$ = "894/.54124"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period to 1861"
+                Period2.Caption = "Period 1861-1991"
+                sGenre$ = "Drama"
+                sCountry$ = "Estonia"
+            } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1861-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Drama"
+                sCountry$ = "Estonia"
+            } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
+                sDewey$ = "894/.54523"
+            }
+        }
+
+        const _convertClassPhFiction = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 3)) == 353) {
+                sDewey$ = "894/.54131"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Finland"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
+                sDewey$ = "894/.54134"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period to 1861"
+                Period2.Caption = "Period 1861-1991"
+                sGenre$ = "Fiction"
+                sCountry$ = "Estonia"
+            } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1861-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Fiction"
+                sCountry$ = "Estonia"
+            } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
+                sDewey$ = "894/.54533"
+            }
+        }
+
+        const _convertClassPhPoetry = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 3)) == 353) {
+                sDewey$ = "894/.54111"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 355) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Finland"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 356) {
+                sDewey$ = "894/.54114"
+            } else if (Val(Mid(sClassNo$, 3, 3)) == 665) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period to 1861"
+                Period2.Caption = "Period 1861-1991"
+                sGenre$ = "Poetry"
+                sCountry$ = "Estonia"
+            } else if (Val(Mid(sClassNo$, 3, 3)) > 665 && Val(Mid(sClassNo$, 3, 5)) < 666.37) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1861-1991"
+                Period2.Caption = "Period 1991-"
+                sGenre$ = "Poetry"
+                sCountry$ = "Estonia"
+            } else if (Val(Mid(sClassNo$, 3, 3)) > 666 && Val(Mid(sClassNo$, 3, 5)) < 667.37) {
+                sDewey$ = "894/.54513"
+            }
+        }
+
+        const _convertClassPqDrama = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
+                sDewey$ = "842/.1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1400-1499"
+                Period2.Caption = "Period 1500-1599"
+                sGenre$ = "Drama"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
+                sDewey$ = "842/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
+                sDewey$ = "842/.4"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1600-1715"
+                Period2.Caption = "Period 1715-1789"
+                Period3.Caption = "Period 1789-1815"
+                sGenre$ = "Drama"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1789-1815"
+                Period2.Caption = "Period 1815-1848"
+                Period3.Caption = "Period 1848-1889"
+                sGenre$ = "Drama"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
+                sDewey$ = "842/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
+                sDewey$ = "842/.92"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
+                sDewey$ = "842/.914"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
+                sDewey$ = "842/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
+                sDewey$ = "Period1300"
+                Period1.Caption = "Period to 1375"
+                Period2.Caption = "Period 1375-1492"
+                sGenre$ = "Drama"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1375-1492"
+                Period2.Caption = "Period 1492-1542"
+                Period3.Caption = "Period 1542-1585"
+                Period4.Caption = "Period 1585-1748"
+                sGenre$ = "Drama"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1585-1748"
+                Period2.Caption = "Period 1748-1814"
+                Period3.Caption = "Period 1814-1859"
+                Period4.Caption = "Period 1859-1899"
+                sGenre$ = "Drama"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
+                sDewey$ = "852/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
+                sDewey$ = "852/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
+                sDewey$ = "863/.2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
+                sDewey$ = "862/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
+                sDewey$ = "862/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
+                sDewey$ = "861/.1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
+                sDewey$ = "862/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
+                sDewey$ = "862/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
+                sDewey$ = "862/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1700-1799"
+                Period2.Caption = "Period 1800-1899"
+                sGenre$ = "Drama"
+                sCountry$ = "Spain"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Spain"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Mexico"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Argentina"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Chile"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Peru"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
+                sDewey$ = "862/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
+                sDewey$ = "862/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
+                sDewey$ = "869.2/1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
+                sDewey$ = "869.2/2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
+                sDewey$ = "869.2/42"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
+                sDewey$ = "869.2/5"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period to 1499"
+                Period2.Caption = "Period 1500-1799"
+                sGenre$ = "Drama"
+                sCountry$ = "Brazil"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Brazil"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
+                sDewey$ = "869.2/42"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
+                sDewey$ = "869.2/5"
+            }
+        }
+
+        const _convertClassPqFiction = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
+                sDewey$ = "843/.1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1400-1499"
+                Period2.Caption = "Period 1500-1599"
+                sGenre$ = "Fiction"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
+                sDewey$ = "843/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
+                sDewey$ = "843/.4"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1600-1715"
+                Period2.Caption = "Period 1715-1789"
+                Period3.Caption = "Period 1789-1815"
+                sGenre$ = "Fiction"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1789-1815"
+                Period2.Caption = "Period 1815-1848"
+                Period3.Caption = "Period 1848-1889"
+                sGenre$ = "Fiction"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
+                sDewey$ = "843/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
+                sDewey$ = "843/.92"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
+                sDewey$ = "843/.914"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
+                sDewey$ = "843/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
+                sDewey$ = "Period1300"
+                Period1.Caption = "Period to 1375"
+                Period2.Caption = "Period 1375-1492"
+                sGenre$ = "Fiction"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1375-1492"
+                Period2.Caption = "Period 1492-1542"
+                Period3.Caption = "Period 1542-1585"
+                Period4.Caption = "Period 1585-1748"
+                sGenre$ = "Fiction"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1585-1748"
+                Period2.Caption = "Period 1748-1814"
+                Period3.Caption = "Period 1814-1859"
+                Period4.Caption = "Period 1859-1899"
+                sGenre$ = "Fiction"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
+                sDewey$ = "853/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
+                sDewey$ = "853/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
+                sDewey$ = "863/.2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
+                sDewey$ = "861/.1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1700-1799"
+                Period2.Caption = "Period 1800-1899"
+                sGenre$ = "Fiction"
+                sCountry$ = "Spain"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Spain"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Mexico"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Argentina"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Chile"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Peru"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
+                sDewey$ = "863/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
+                sDewey$ = "863/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
+                sDewey$ = "869.3/1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
+                sDewey$ = "869.3/2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
+                sDewey$ = "869.3/42"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
+                sDewey$ = "869.3/5"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period to 1499"
+                Period2.Caption = "Period 1500-1799"
+                sGenre$ = "Fiction"
+                sCountry$ = "Brazil"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Brazil"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
+                sDewey$ = "869.3/42"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
+                sDewey$ = "869.3/5"
+            }
+        }
+
+        const _convertClassPqPoetry = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 6)) > 1410.1 && Val(Mid(sClassNo$, 3, 4)) < 1546) {
+                sDewey$ = "841/.1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1550 && Val(Mid(sClassNo$, 3, 4)) < 1596) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1400-1499"
+                Period2.Caption = "Period 1500-1599"
+                sGenre$ = "Poetry"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1710) {
+                sDewey$ = "841/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1709 && Val(Mid(sClassNo$, 3, 4)) < 1936) {
+                sDewey$ = "841/.4"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1946 && Val(Mid(sClassNo$, 3, 4)) < 2148) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1600-1715"
+                Period2.Caption = "Period 1715-1789"
+                Period3.Caption = "Period 1789-1815"
+                sGenre$ = "Poetry"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2148 && Val(Mid(sClassNo$, 3, 4)) < 2552) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1789-1815"
+                Period2.Caption = "Period 1815-1848"
+                Period3.Caption = "Period 1848-1889"
+                sGenre$ = "Poetry"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2652) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "France"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2687) {
+                sDewey$ = "841/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2727) {
+                sDewey$ = "841/.92"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.2) { //Canada
+                sDewey$ = "841/.914"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 3919.3) { //Canada
+                sDewey$ = "841/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4264 && Val(Mid(sClassNo$, 3, 4)) < 4557) {
+                sDewey$ = "Period1300"
+                Period1.Caption = "Period to 1375"
+                Period2.Caption = "Period 1375-1492"
+                sGenre$ = "Poetry"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4560 && Val(Mid(sClassNo$, 3, 4)) < 4665) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1375-1492"
+                Period2.Caption = "Period 1492-1542"
+                Period3.Caption = "Period 1542-1585"
+                Period4.Caption = "Period 1585-1748"
+                sGenre$ = "Poetry"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4674 && Val(Mid(sClassNo$, 3, 4)) < 4735) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1585-1748"
+                Period2.Caption = "Period 1748-1814"
+                Period3.Caption = "Period 1814-1859"
+                Period4.Caption = "Period 1859-1899"
+                sGenre$ = "Poetry"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4799 && Val(Mid(sClassNo$, 3, 4)) < 4852) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Italy"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4859 && Val(Mid(sClassNo$, 3, 4)) < 4887) {
+                sDewey$ = "851/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 4899 && Val(Mid(sClassNo$, 3, 4)) < 4927) {
+                sDewey$ = "851/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6273 && Val(Mid(sClassNo$, 3, 4)) < 6278) { //Spain
+                sDewey$ = "863/.2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6279 && Val(Mid(sClassNo$, 3, 4)) < 6320) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6321 && Val(Mid(sClassNo$, 3, 4)) < 6362) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6365 && Val(Mid(sClassNo$, 3, 4)) < 6387) { //Spain
+                sDewey$ = "861/.1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6390 && Val(Mid(sClassNo$, 3, 4)) < 6393) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6393 && Val(Mid(sClassNo$, 3, 4)) < 6396) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6406 && Val(Mid(sClassNo$, 3, 4)) < 6410) { //Spain
+                sDewey$ = "863/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6433 && Val(Mid(sClassNo$, 3, 4)) < 6437) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6437 && Val(Mid(sClassNo$, 3, 4)) < 6493) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 6496) { //Spain
+                sDewey$ = "861/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6499 && Val(Mid(sClassNo$, 3, 4)) < 6577) { //Spain
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1700-1799"
+                Period2.Caption = "Period 1800-1899"
+                sGenre$ = "Poetry"
+                sCountry$ = "Spain"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6599 && Val(Mid(sClassNo$, 3, 4)) < 6648) { //Spain
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Spain"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6649 && Val(Mid(sClassNo$, 3, 4)) < 6677) { //Spain
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6699 && Val(Mid(sClassNo$, 3, 4)) < 6727) { //Spain
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.2) { //US & Canada
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7079.3) { //US & Canada
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7297) { //Mexico
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Mexico"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7297 && Val(Mid(sClassNo$, 3, 7)) < 7298.37) { //Mexico
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 7298.36 && Val(Mid(sClassNo$, 3, 7)) < 7298.437) { //Mexico
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7390) { //Cuba
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7392) { //Cuba
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.2) { //Dom. Rep.
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7409.3) { //Dom. Rep.
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7440) { //P.R.
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7442) { //P.R.
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.2) { //Costa Rica
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7489.3) { //Costa Rica
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.2) { //Guatemala
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7499.3) { //Guatemala
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.2) { //Honduras
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7509.3) { //Honduras
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.2) { //Nicaragua
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7519.3) { //Nicaragua
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.2) { //Panama
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7529.3) { //Panama
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.2) { //Salvador
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7539.3) { //Salvador
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7797) { //Argentina
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Argentina"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7797 && Val(Mid(sClassNo$, 3, 7)) < 7798.37) { //Argentina
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 7798.36 && Val(Mid(sClassNo$, 3, 7)) < 7798.437) { //Argentina
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7820) { //Bolivia
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 7822) { //Bolivia
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.2) { //Brazil
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 7889.3) { //Brazil
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8097) { //Chile
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Chile"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8097 && Val(Mid(sClassNo$, 3, 7)) < 8098.37) { //Chile
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8098.36 && Val(Mid(sClassNo$, 3, 7)) < 8098.437) { //Chile
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8179 && Val(Mid(sClassNo$, 3, 7)) < 8180.37) { //Colombia
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8180.36 && Val(Mid(sClassNo$, 3, 7)) < 8180.437) { //Colombia
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8219 && Val(Mid(sClassNo$, 3, 7)) < 8220.37) { //Ecuador
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8220.36 && Val(Mid(sClassNo$, 3, 7)) < 8220.437) { //Ecuador
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.2) { //Paraguay
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 8259.3) { //Paraguay
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8497) { //Peru
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Peru"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8497 && Val(Mid(sClassNo$, 3, 7)) < 8498.37) { //Peru
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8498.36 && Val(Mid(sClassNo$, 3, 7)) < 8498.437) { //Peru
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8519 && Val(Mid(sClassNo$, 3, 7)) < 8520.37) { //Uruguay
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8520.36 && Val(Mid(sClassNo$, 3, 7)) < 8520.437) { //Uruguay
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8549 && Val(Mid(sClassNo$, 3, 7)) < 8550.37) { //Venezuela
+                sDewey$ = "861/.64"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 8550.36 && Val(Mid(sClassNo$, 3, 7)) < 8550.437) { //Venezuela
+                sDewey$ = "861/.7"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9189) { //Portugal
+                sDewey$ = "869.1/1"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9190 && Val(Mid(sClassNo$, 3, 4)) < 9256) { //Portugal
+                sDewey$ = "869.1/2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9261 && Val(Mid(sClassNo$, 3, 4)) < 9289) { //Portugal
+                sDewey$ = "869.1/42"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9299 && Val(Mid(sClassNo$, 3, 4)) < 9327) { //Portugal
+                sDewey$ = "869.1/5"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9696) { //Brazil
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period to 1499"
+                Period2.Caption = "Period 1500-1799"
+                sGenre$ = "Poetry"
+                sCountry$ = "Brazil"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9697) { //Brazil
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1800-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Brazil"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9697 && Val(Mid(sClassNo$, 3, 7)) < 9698.37) { //Brazil
+                sDewey$ = "869.1/42"
+            } else if (Val(Mid(sClassNo$, 3, 7)) > 9698.36 && Val(Mid(sClassNo$, 3, 7)) < 9698.437) { //Brazil
+                sDewey$ = "869.1/5"
+            }
+        }
+
+        const _convertClassPrDrama = (sClassNo$) => {
+            //British
+            if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
+                sDewey$ = "829/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
+                sDewey$ = "829/.2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
+                sDewey$ = "829/.4"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1066-1400"
+                Period2.Caption = "Period 1400-1558"
+                sGenre$ = "Drama"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
+                sDewey$ = "Period1558"
+                Period1.Caption = "Period 1400-1558"
+                Period2.Caption = "Period 1558-1625"
+                Period3.Caption = "Period 1625-1702"
+                sGenre$ = "Drama"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
+                if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
+                    sDewey$ = ""
+                } else {
+                    sDewey$ = "Period1625"
+                    Period1.Caption = "Period 1400-1558"
+                    Period2.Caption = "Period 1558-1625"
+                    Period3.Caption = "Period 1625-1702"
+                    sGenre$ = "Drama"
+                    sCountry$ = "UK"
+                }
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
+                sDewey$ = "Period1702"
+                Period1.Caption = "Period 1625-1702"
+                Period2.Caption = "Period 1702-1745"
+                Period3.Caption = "Period 1745-1799"
+                sGenre$ = "Drama"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1745-1799"
+                Period2.Caption = "Period 1799-1837"
+                Period3.Caption = "Period 1837-1899"
+                sGenre$ = "Drama"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
+                sDewey$ = "822/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
+                sDewey$ = "822/.92"
+
+                //Shakespeare drama
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2749 && Val(Mid(sClassNo$, 3, 4)) < 3113) {
+                sDewey$ = "822.3/3"
+
+
+                //Canadian gets same as U.S. below in PS...
+            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
+                sDewey$ = "Period1867"
+                Period1.Caption = "Period to 1867"
+                Period2.Caption = "Period 1867-1899"
+                sGenre$ = "Drama"
+                sCountry$ = "Canada"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Canada"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.4) {
+                sDewey$ = "812/.6"
+
+                //South Africa
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "SoAf"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
+                sDewey$ = "822/.92"
+
+                //Australia
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Aust"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.4) {
+                sDewey$ = "822/.92"
+
+                //New Zealand
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "NZ"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
+                sDewey$ = "822/.92"
+            }
+        }
+
+        const _convertClassPrFiction = (sClassNo$) => {
+            //British
+            if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
+                sDewey$ = "829/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
+                sDewey$ = "829/.2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
+                sDewey$ = "829/.4"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1066-1400"
+                Period2.Caption = "Period 1400-1558"
+                sGenre$ = "Fiction"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
+                sDewey$ = "Period1558"
+                Period1.Caption = "Period 1400-1558"
+                Period2.Caption = "Period 1558-1625"
+                Period3.Caption = "Period 1625-1702"
+                sGenre$ = "Fiction"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
+                if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
+                    sDewey$ = ""
+                } else {
+                    sDewey$ = "Period1625"
+                    Period1.Caption = "Period 1400-1558"
+                    Period2.Caption = "Period 1558-1625"
+                    Period3.Caption = "Period 1625-1702"
+                    sGenre$ = "Fiction"
+                    sCountry$ = "UK"
+                }
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
+                sDewey$ = "Period1702"
+                Period1.Caption = "Period 1625-1702"
+                Period2.Caption = "Period 1702-1745"
+                Period3.Caption = "Period 1745-1799"
+                sGenre$ = "Fiction"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1745-1799"
+                Period2.Caption = "Period 1799-1837"
+                Period3.Caption = "Period 1837-1899"
+                sGenre$ = "Fiction"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
+                sDewey$ = "823/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
+                sDewey$ = "823/.92"
+
+                //Canadian gets same as U.S. below in PS...
+            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
+                sDewey$ = "Period1867"
+                Period1.Caption = "Period to 1867"
+                Period2.Caption = "Period 1867-1899"
+                sGenre$ = "Fiction"
+                sCountry$ = "Canada"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Canada"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.4) {
+                sDewey$ = "813/.6"
+
+                //South Africa
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "SoAf"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
+                sDewey$ = "823/.92"
+
+
+                //Australia
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Aust"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.4) {
+                sDewey$ = "823/.92"
+
+                //New Zealand
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "NZ"
+
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
+                sDewey$ = "823/.92"
+
+            }
+        }
+
+        const _convertClassPrPoetry = (sClassNo$) => {
+            //British
+            if (Val(Mid(sClassNo$, 3, 4)) > 1579 && Val(Mid(sClassNo$, 3, 4)) < 1589) {
+                sDewey$ = "829/.3"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1599 && Val(Mid(sClassNo$, 3, 4)) < 1629) {
+                sDewey$ = "829/.2"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1638 && Val(Mid(sClassNo$, 3, 4)) < 1669) {
+                sDewey$ = "829/.4"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1802 && Val(Mid(sClassNo$, 3, 4)) < 2166) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period 1066-1400"
+                Period2.Caption = "Period 1400-1558"
+                sGenre$ = "Poetry"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2198 && Val(Mid(sClassNo$, 3, 4)) < 2750) {
+                sDewey$ = "Period1558"
+                Period1.Caption = "Period 1400-1558"
+                Period2.Caption = "Period 1558-1625"
+                Period3.Caption = "Period 1625-1702"
+                sGenre$ = "Poetry"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3134 && Val(Mid(sClassNo$, 3, 4)) < 3196) {
+                if (Val(Mid(sClassNo$, 3, 6)) == 3195.2) {
+                    sDewey$ = ""
+                } else {
+                    sDewey$ = "Period1625"
+                    Period1.Caption = "Period 1400-1558"
+                    Period2.Caption = "Period 1558-1625"
+                    Period3.Caption = "Period 1625-1702"
+                    sGenre$ = "Poetry"
+                    sCountry$ = "UK"
+                }
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3299 && Val(Mid(sClassNo$, 3, 4)) < 3786) {
+                sDewey$ = "Period1702"
+                Period1.Caption = "Period 1625-1702"
+                Period2.Caption = "Period 1702-1745"
+                Period3.Caption = "Period 1745-1799"
+                sGenre$ = "Poetry"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3990 && Val(Mid(sClassNo$, 3, 4)) < 5991) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1745-1799"
+                Period2.Caption = "Period 1799-1837"
+                Period3.Caption = "Period 1837-1899"
+                sGenre$ = "Poetry"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 5999 && Val(Mid(sClassNo$, 3, 4)) < 6050) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "UK"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6049 && Val(Mid(sClassNo$, 3, 4)) < 6077) {
+                sDewey$ = "821/.914"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 6100 && Val(Mid(sClassNo$, 3, 4)) < 6127) {
+                sDewey$ = "821/.92"
+                //Shakespeare poetry
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2749 && Val(Mid(sClassNo$, 3, 4)) < 3113) {
+                sDewey$ = "821/.3"
+                //Canadian gets same as U.S. below in PS...
+            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.2") {
+                sDewey$ = "Period1867"
+                Period1.Caption = "Period to 1867"
+                Period2.Caption = "Period 1867-1899"
+                sGenre$ = "Poetry"
+                sCountry$ = "Canada"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9199.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Canada"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == "9199.4") {
+                sDewey$ = "811/.6"
+                //South Africa
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "SoAf"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9369.4) {
+                sDewey$ = "821/.92"
+                //Australia
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9619.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Aust"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == "9619.4") {
+                sDewey$ = "821/.92"
+                //New Zealand
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.3) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "NZ"
+            } else if (Val(Mid(sClassNo$, 3, 6)) == 9639.4) {
+                sDewey$ = "821/.92"
+            }
+        }
+
+        const _convertClassPsDrama = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
+                sDewey$ = "Period1776"
+                Period1.Caption = "Period 1607-1776"
+                Period2.Caption = "Period 1776-1829"
+                sGenre$ = "Drama"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
+                sDewey$ = "Period1830"
+                Period1.Caption = "Period 1776-1830"
+                Period2.Caption = "Period 1830-1861"
+                Period3.Caption = "Period 1861-1899"
+                sGenre$ = "Drama"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
+                sDewey$ = "812/.54"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
+                sDewey$ = "812/.6"
+            }
+        }
+
+        const _convertClassPsFiction = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
+                sDewey$ = "Period1776"
+                Period1.Caption = "Period 1607-1776"
+                Period2.Caption = "Period 1776-1829"
+                sGenre$ = "Fiction"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
+                sDewey$ = "Period1830"
+                Period1.Caption = "Period 1776-1830"
+                Period2.Caption = "Period 1830-1861"
+                Period3.Caption = "Period 1861-1899"
+                sGenre$ = "Fiction"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
+                sDewey$ = "813/.54"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
+                sDewey$ = "813/.6"
+            }
+        }
+
+        const _convertClassPsPoetry = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 3)) > 699 && Val(Mid(sClassNo$, 3, 3)) < 894) {
+                sDewey$ = "Period1776"
+                Period1.Caption = "Period 1607-1776"
+                Period2.Caption = "Period 1776-1829"
+                sGenre$ = "Poetry"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 990 && Val(Mid(sClassNo$, 3, 4)) < 3391) {
+                sDewey$ = "Period1830"
+                Period1.Caption = "Period 1776-1830"
+                Period2.Caption = "Period 1830-1861"
+                Period3.Caption = "Period 1861-1899"
+                sGenre$ = "Poetry"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3499 && Val(Mid(sClassNo$, 3, 4)) < 3550) {
+                sDewey$ = "Period1945"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "US"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3549 && Val(Mid(sClassNo$, 3, 4)) < 3577) {
+                sDewey$ = "811/.54"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 3599 && Val(Mid(sClassNo$, 3, 4)) < 3627) {
+                sDewey$ = "811/.6"
+            }
+        }
+
+        const _convertClassPtDrama = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
+                sDewey$ = "Period1100"
+                Period1.Caption = "Period to 1099"
+                Period2.Caption = "Period 1100-1249"
+                Period3.Caption = "Period 1250-1349"
+                Period4.Caption = "Period 1350-1517"
+                sGenre$ = "Drama"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
+                sDewey$ = "Period1300"
+                Period1.Caption = "Period 1350-1517"
+                Period2.Caption = "Period 1517-1625"
+                Period3.Caption = "Period 1625-1749"
+                sGenre$ = "Drama"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1625-1749"
+                Period2.Caption = "Period 1750-1832"
+                Period3.Caption = "Period 1832-1856"
+                Period4.Caption = "Period 1856-1899"
+                sGenre$ = "Drama"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1856-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1990"
+                sGenre$ = "Drama"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1945-1990"
+                Period2.Caption = "Period 1990-"
+                sGenre$ = "Drama"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
+                sDewey$ = "832/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1719"
+                Period2.Caption = "Period 1720-1835"
+                sGenre$ = "Drama"
+                sCountry$ = "Iceland"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
+                sDewey$ = "Period1700"
+                Period1.Caption = "Period 1720-1835"
+                Period2.Caption = "Period 1835-1899"
+                Period3.Caption = "Period 1900-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Iceland"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
+                sDewey$ = "839/.6925"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period to 1499"
+                Period2.Caption = "Period 1500-1559"
+                sGenre$ = "Drama"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1559"
+                Period2.Caption = "Period 1560-1699"
+                Period3.Caption = "Period 1700-1749"
+                Period4.Caption = "Period 1750-1799"
+                sGenre$ = "Drama"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
+                sDewey$ = "839.812/6"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
+                sDewey$ = "839.812/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
+                sDewey$ = "839.812/8"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1559"
+                Period2.Caption = "Period 1560-1699"
+                Period3.Caption = "Period 1700-1749"
+                Period4.Caption = "Period 1750-1799"
+                sGenre$ = "Drama"
+                sCountry$ = "Norway"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
+                sDewey$ = "839.822/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
+                sDewey$ = "839.822/8"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period to 1519"
+                Period2.Caption = "Period 1520-1639"
+                sGenre$ = "Drama"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period to 1519"
+                Period2.Caption = "Period 1520-1639"
+                Period3.Caption = "Period 1640-1739"
+                Period4.Caption = "Period 1740-1779"
+                Period5.Caption = "Period 1780-1809"
+                sGenre$ = "Drama"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1780-1809"
+                Period2.Caption = "Period 1809-1830"
+                Period3.Caption = "Period 1830-1879"
+                Period4.Caption = "Period 1879-1909"
+                sGenre$ = "Drama"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1879-1909"
+                Period2.Caption = "Period 1909-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Drama"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
+                sDewey$ = "839.72/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
+                sDewey$ = "839.72/8"
+            }
+        }
+
+        const _convertClassPtFiction = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
+                sDewey$ = "Period1100"
+                Period1.Caption = "Period to 1099"
+                Period2.Caption = "Period 1100-1249"
+                Period3.Caption = "Period 1250-1349"
+                Period4.Caption = "Period 1350-1517"
+                sGenre$ = "Fiction"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
+                sDewey$ = "Period1300"
+                Period1.Caption = "Period 1350-1517"
+                Period2.Caption = "Period 1517-1625"
+                Period3.Caption = "Period 1625-1749"
+                sGenre$ = "Fiction"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1625-1749"
+                Period2.Caption = "Period 1750-1832"
+                Period3.Caption = "Period 1832-1856"
+                Period4.Caption = "Period 1856-1899"
+                sGenre$ = "Fiction"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1856-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1990"
+                sGenre$ = "Fiction"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1945-1990"
+                Period2.Caption = "Period 1990-"
+                sGenre$ = "Fiction"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
+                sDewey$ = "833/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1719"
+                Period2.Caption = "Period 1720-1835"
+                sGenre$ = "Fiction"
+                sCountry$ = "Iceland"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
+                sDewey$ = "Period1700"
+                Period1.Caption = "Period 1720-1835"
+                Period2.Caption = "Period 1835-1899"
+                Period3.Caption = "Period 1900-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Iceland"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
+                sDewey$ = "839/.6935"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period to 1499"
+                Period2.Caption = "Period 1500-1559"
+                sGenre$ = "Fiction"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1559"
+                Period2.Caption = "Period 1560-1699"
+                Period3.Caption = "Period 1700-1749"
+                Period4.Caption = "Period 1750-1799"
+                sGenre$ = "Fiction"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
+                sDewey$ = "839.813/6"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
+                sDewey$ = "839.813/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
+                sDewey$ = "839.813/8"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1559"
+                Period2.Caption = "Period 1560-1699"
+                Period3.Caption = "Period 1700-1749"
+                Period4.Caption = "Period 1750-1799"
+                sGenre$ = "Fiction"
+                sCountry$ = "Norway"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
+                sDewey$ = "839.823/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
+                sDewey$ = "839.823/8"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period to 1519"
+                Period2.Caption = "Period 1520-1639"
+                sGenre$ = "Fiction"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period to 1519"
+                Period2.Caption = "Period 1520-1639"
+                Period3.Caption = "Period 1640-1739"
+                Period4.Caption = "Period 1740-1779"
+                Period5.Caption = "Period 1780-1809"
+                sGenre$ = "Fiction"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1780-1809"
+                Period2.Caption = "Period 1809-1830"
+                Period3.Caption = "Period 1830-1879"
+                Period4.Caption = "Period 1879-1909"
+                sGenre$ = "Fiction"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1879-1909"
+                Period2.Caption = "Period 1909-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Fiction"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
+                sDewey$ = "839.73/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
+                sDewey$ = "839.73/8"
+            }
+        }
+
+        const _convertClassPtPoetry = (sClassNo$) => {
+            if (Val(Mid(sClassNo$, 3, 4)) > 1500 && Val(Mid(sClassNo$, 3, 4)) < 1696) {
+                sDewey$ = "Period1100"
+                Period1.Caption = "Period to 1099"
+                Period2.Caption = "Period 1100-1249"
+                Period3.Caption = "Period 1250-1349"
+                Period4.Caption = "Period 1350-1517"
+                sGenre$ = "Poetry"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1700 && Val(Mid(sClassNo$, 3, 4)) < 1798) {
+                sDewey$ = "Period1300"
+                Period1.Caption = "Period 1350-1517"
+                Period2.Caption = "Period 1517-1625"
+                Period3.Caption = "Period 1625-1749"
+                sGenre$ = "Poetry"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 1798 && Val(Mid(sClassNo$, 3, 4)) < 2593) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period 1625-1749"
+                Period2.Caption = "Period 1750-1832"
+                Period3.Caption = "Period 1832-1856"
+                Period4.Caption = "Period 1856-1899"
+                sGenre$ = "Poetry"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2599 && Val(Mid(sClassNo$, 3, 4)) < 2654) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1856-1899"
+                Period2.Caption = "Period 1900-1945"
+                Period3.Caption = "Period 1945-1990"
+                sGenre$ = "Poetry"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2659 && Val(Mid(sClassNo$, 3, 4)) < 2689) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1945-1990"
+                Period2.Caption = "Period 1990-"
+                sGenre$ = "Poetry"
+                sCountry$ = "Germany"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 2699 && Val(Mid(sClassNo$, 3, 4)) < 2729) {
+                sDewey$ = "831/.92"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7499 && Val(Mid(sClassNo$, 3, 4)) < 7502) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1719"
+                Period2.Caption = "Period 1720-1835"
+                sGenre$ = "Poetry"
+                sCountry$ = "Iceland"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7509 && Val(Mid(sClassNo$, 3, 4)) < 7512) {
+                sDewey$ = "Period1700"
+                Period1.Caption = "Period 1720-1835"
+                Period2.Caption = "Period 1835-1899"
+                Period3.Caption = "Period 1900-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Iceland"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 7511 && Val(Mid(sClassNo$, 3, 4)) < 7514) {
+                sDewey$ = "839/.6915"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 8050) {
+                sDewey$ = "Period1400"
+                Period1.Caption = "Period to 1499"
+                Period2.Caption = "Period 1500-1559"
+                sGenre$ = "Poetry"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8059 && Val(Mid(sClassNo$, 3, 4)) < 8099) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1559"
+                Period2.Caption = "Period 1560-1699"
+                Period3.Caption = "Period 1700-1749"
+                Period4.Caption = "Period 1750-1799"
+                sGenre$ = "Poetry"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8099 && Val(Mid(sClassNo$, 3, 4)) < 8168) {
+                sDewey$ = "839.811/6"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8173 && Val(Mid(sClassNo$, 3, 4)) < 8176) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1900-1945"
+                Period2.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Denmark"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8175 && Val(Mid(sClassNo$, 3, 4)) < 8176.37) {
+                sDewey$ = "839.811/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8176 && Val(Mid(sClassNo$, 3, 4)) < 8177.37) {
+                sDewey$ = "839.811/8"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8749 && Val(Mid(sClassNo$, 3, 4)) < 8776) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period 1500-1559"
+                Period2.Caption = "Period 1560-1699"
+                Period3.Caption = "Period 1700-1749"
+                Period4.Caption = "Period 1750-1799"
+                sGenre$ = "Poetry"
+                sCountry$ = "Norway"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8950 && Val(Mid(sClassNo$, 3, 4)) < 8951.37) {
+                sDewey$ = "839.821/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 8951 && Val(Mid(sClassNo$, 3, 4)) < 8952.37) {
+                sDewey$ = "839.821/8"
+            } else if (Val(Mid(sClassNo$, 3, 4)) == 9651) {
+                sDewey$ = "Period1500"
+                Period1.Caption = "Period to 1519"
+                Period2.Caption = "Period 1520-1639"
+                sGenre$ = "Poetry"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9673 && Val(Mid(sClassNo$, 3, 4)) < 9711) {
+                sDewey$ = "Period1600"
+                Period1.Caption = "Period to 1519"
+                Period2.Caption = "Period 1520-1639"
+                Period3.Caption = "Period 1640-1739"
+                Period4.Caption = "Period 1740-1779"
+                Period5.Caption = "Period 1780-1809"
+                sGenre$ = "Poetry"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9724 && Val(Mid(sClassNo$, 3, 4)) < 9851) {
+                sDewey$ = "Period1800"
+                Period1.Caption = "Period 1780-1809"
+                Period2.Caption = "Period 1809-1830"
+                Period3.Caption = "Period 1830-1879"
+                Period4.Caption = "Period 1879-1909"
+                sGenre$ = "Poetry"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9869 && Val(Mid(sClassNo$, 3, 4)) < 9876) {
+                sDewey$ = "Period1900"
+                Period1.Caption = "Period 1879-1909"
+                Period2.Caption = "Period 1909-1945"
+                Period3.Caption = "Period 1945-1999"
+                sGenre$ = "Poetry"
+                sCountry$ = "Sweden"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9875 && Val(Mid(sClassNo$, 3, 4)) < 9876.37) {
+                sDewey$ = "839.71/74"
+            } else if (Val(Mid(sClassNo$, 3, 4)) > 9876 && Val(Mid(sClassNo$, 3, 4)) < 9877.37) {
+                sDewey$ = "839.71/8"
+            }
+        }
+
+        //GV
+        const _convertClassGvSport = (sClassNo$) => {
+            if (Mid(sClassNo$, 3, 8) == "1003.62.") sDewey$ = "796.343092"
+            if (Mid(sClassNo$, 3, 8) == "1005.22.") sDewey$ = "796.34/6092"
+            if (Mid(sClassNo$, 3, 8) == "1006.52.") sDewey$ = "796.345092"
+            if (Mid(sClassNo$, 3, 8) == "1010.32.") sDewey$ = "796.35/3092"
+            if (Mid(sClassNo$, 3, 8) == "1015.26.") sDewey$ = "796.325092"
+            if (Mid(sClassNo$, 3, 5) == "1032." && Len(sClassNo$) > 8 && InStr(sClassNo$, "1032.A1") == 0) sDewey$ = "796.72092"
+            if (Mid(sClassNo$, 3, 5) == "1132.") sDewey$ = "796.83092"
+            if (Mid(sClassNo$, 3, 5) == "1186.") sDewey$ = "799.3/2092"
+            if (Mid(sClassNo$, 3, 5) == "1196." && Len(sClassNo$) > 8 && InStr(sClassNo$, "1196.A1") == 0) sDewey$ = "796.812092"
+            if (Mid(sClassNo$, 3, 7) == "545.52.") sDewey$ = "796.41092"
+            if (Mid(sClassNo$, 3, 6) == "848.5." && Len(sClassNo$) > 9 && InStr(sClassNo$, "848.5.A1") == 0) sDewey$ = "796.962092"
+            if (Mid(sClassNo$, 3, 4) == "850." && IsNumeric(Mid(sClassNo$, 7, 1)) == false && Len(sClassNo$) > 8 && (InStr(sClassNo$, "850.A1") == 0 && InStr(sClassNo$, "850.A2") == 0)) {
+                sDewey$ = [
+                    {
+                        caption: 'Figure skating',
+                        dewey: '796.91/2092'
+                    },
+                    {
+                        caption: 'Speed skating',
+                        dewey: '796.91/4092'
+                    }
+                ]
+            }
+            if (Mid(sClassNo$, 3, 4) == "865." && Len(sClassNo$) > 8 && InStr(sClassNo$, "865.A1") == 0) sDewey$ = "796.357092"
+            if (Mid(sClassNo$, 3, 4) == "884." && Len(sClassNo$) > 8 && InStr(sClassNo$, "884.A1") == 0) sDewey$ = "796.323092"
+            if (Mid(sClassNo$, 3, 4) == "915." && Len(sClassNo$) > 8 && InStr(sClassNo$, "915.A1") == 0) sDewey$ = "796.358092"
+            if (Mid(sClassNo$, 3, 4) == "939." && Len(sClassNo$) > 8 && InStr(sClassNo$, "939.A1") == 0) {
+                sDewey$ = [
+                    {
+                        caption: 'American football',
+                        dewey: '796.332092'
+                    },
+                    {
+                        caption: 'Canadian football',
+                        dewey: '796.335092'
+                    }
+                ]
+            }
+            if (Mid(sClassNo$, 3, 6) == "942.7." && Len(sClassNo$) > 9 && InStr(sClassNo$, "942.7.A1") == 0) sDewey$ = "796.334092"
+            if (Mid(sClassNo$, 3, 6) == "944.9." && Len(sClassNo$) > 9 && InStr(sClassNo$, "944.9.A1") == 0) sDewey$ = "796.333092"
+            if (Mid(sClassNo$, 3, 6) == "946.5." && Len(sClassNo$) > 9 && InStr(sClassNo$, "946.5.A1") == 0) sDewey$ = "796.33/6092"
+            if (Mid(sClassNo$, 3, 6) == "948.6." && Len(sClassNo$) > 9 && InStr(sClassNo$, "948.6.A1") == 0) sDewey$ = "796.33"
+            if (Mid(sClassNo$, 3, 4) == "964." && Len(sClassNo$) > 8 && InStr(sClassNo$, "964.A1") == 0) sDewey$ = "796.352092"
+            if (Mid(sClassNo$, 3, 4) == "994." && Len(sClassNo$) > 8 && InStr(sClassNo$, "994.A1") == 0) sDewey$ = "796.342092"
+        }
+
+        if (letter == 'PG') {
+            if (autoDeweyGenre == 'fiction') {
+                _convertClassPgFiction(letter + number)
+            } else if (autoDeweyGenre == 'poetry') {
+                _convertClassPgPoetry(letter + number)
+            } else if (autoDeweyGenre == 'drama') {
+                _convertClassPgDrama(letter + number)
+            }
+        } else if (letter == 'PH') {
+            if (autoDeweyGenre == 'fiction') {
+                _convertClassPhFiction(letter + number)
+            } else if (autoDeweyGenre == 'poetry') {
+                _convertClassPhPoetry(letter + number)
+            } else if (autoDeweyGenre == 'drama') {
+                _convertClassPhDrama(letter + number)
+            }
+        } else if (letter == 'PQ') {
+            if (autoDeweyGenre == 'fiction') {
+                _convertClassPqFiction(letter + number)
+            } else if (autoDeweyGenre == 'poetry') {
+                _convertClassPqPoetry(letter + number)
+            } else if (autoDeweyGenre == 'drama') {
+                _convertClassPqDrama(letter + number)
+            }
+        } else if (letter == 'PR') {
+            if (autoDeweyGenre == 'fiction') {
+                _convertClassPrFiction(letter + number)
+            } else if (autoDeweyGenre == 'poetry') {
+                _convertClassPrPoetry(letter + number)
+            } else if (autoDeweyGenre == 'drama') {
+                _convertClassPrDrama(letter + number)
+            }
+        } else if (letter == 'PS') {
+            if (autoDeweyGenre == 'fiction') {
+                _convertClassPsFiction(letter + number)
+            } else if (autoDeweyGenre == 'poetry') {
+                _convertClassPsPoetry(letter + number)
+            } else if (autoDeweyGenre == 'drama') {
+                _convertClassPsDrama(letter + number)
+            }
+        } else if (letter == 'PT') {
+            if (autoDeweyGenre == 'fiction') {
+                _convertClassPtFiction(letter + number)
+            } else if (autoDeweyGenre == 'poetry') {
+                _convertClassPtPoetry(letter + number)
+            } else if (autoDeweyGenre == 'drama') {
+                _convertClassPtDrama(letter + number)
+            }
+        } else if (letter == 'GV') {
+            _convertClassGvSport(letter + number)
+        }
+
+        if (autoDeweyGenre && !sDewey$) return [
+            false,
+            {
+                error: 'autoDewey mode cannot convert this LCC'
+            }
+        ]
+
+        const deweyInfo = {
+            mode: 'autoDewey',
+            dewey: sDewey$,
+            genre: sGenre$,
+            country: sCountry$,
+            periods: []
+        }
+
+        if (Period1.Caption) deweyInfo.periods.push(Period1.Caption)
+        if (Period2.Caption) deweyInfo.periods.push(Period2.Caption)
+        if (Period3.Caption) deweyInfo.periods.push(Period3.Caption)
+        if (Period4.Caption) deweyInfo.periods.push(Period4.Caption)
+        if (Period5.Caption) deweyInfo.periods.push(Period5.Caption)
+
+        return [
+            sDewey$,
+            deweyInfo
+        ]
+
+    }
+
+    const onAutoDeweyGenreClick = (genre) => {
+        if (genre == autoDeweyGenre) return
+
+        setAutoDeweyResult()
+        setAutoDeweyGenre(genre)
+
+    }
+
+    const onPeriodClicked = (periodNumber, sDewey$, sGenre$, sCountry$) => {
+
+        console.log('onPeriodClicked', periodNumber, sDewey$, sGenre$, sCountry$)
+
+        let dewey
+
+        if (periodNumber == 1) {
+            if (sGenre$ == "Fiction" && sCountry$ == "US" && sDewey$ == "Period1945") dewey = "813/.52"
+            if (sGenre$ == "Poetry" && sCountry$ == "US" && sDewey$ == "Period1945") dewey = "811/.52"
+            if (sGenre$ == "Drama" && sCountry$ == "US" && sDewey$ == "Period1945") dewey = "812/.52"
+            if (sGenre$ == "Fiction" && sCountry$ == "US" && sDewey$ == "Period1776") dewey = "813/.1"
+            if (sGenre$ == "Poetry" && sCountry$ == "US" && sDewey$ == "Period1776") dewey = "811/.1"
+            if (sGenre$ == "Drama" && sCountry$ == "US" && sDewey$ == "Period1776") dewey = "812/.1"
+            if (sGenre$ == "Fiction" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "813/.2"
+            if (sGenre$ == "Poetry" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "811/.2"
+            if (sGenre$ == "Drama" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "812/.2"
+            if (sGenre$ == "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1400") dewey = "823/.1"
+            if (sGenre$ == "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1400") dewey = "821/.1"
+            if (sGenre$ == "Drama" && sCountry$ == "UK" && sDewey$ == "Period1400") dewey = "822/.1"
+            if (sGenre$ == "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "823/.2"
+            if (sGenre$ == "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "821/.2"
+            if (sGenre$ == "Drama" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "822/.2"
+            if (sGenre$ == "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "823/.2"
+            if (sGenre$ == "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "821/.2"
+            if (sGenre$ == "Drama" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "822/.2"
+            if (sGenre$ == "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "823/.4"
+            if (sGenre$ == "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "821/.4"
+            if (sGenre$ == "Drama" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "822/.4"
+            if (sGenre$ == "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "823/.6"
+            if (sGenre$ == "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "821/.6"
+            if (sGenre$ == "Drama" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "822/.6"
+            if (sGenre$ == "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1945") dewey = "823/.912"
+            if (sGenre$ == "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1945") dewey = "821/.912"
+            if (sGenre$ == "Drama" && sCountry$ == "UK" && sDewey$ == "Period1945") dewey = "822/.912"
+            if (sGenre$ == "Fiction" && sCountry$ == "Canada" && sDewey$ == "Period1867") dewey = "813/.3"
+            if (sGenre$ == "Poetry" && sCountry$ == "Canada" && sDewey$ == "Period1867") dewey = "811/.3"
+            if (sGenre$ == "Drama" && sCountry$ == "Canada" && sDewey$ == "Period1867") dewey = "812/.3"
+            if (sGenre$ == "Fiction" && sCountry$ == "Canada" && sDewey$ == "Period1945") dewey = "813/.52"
+            if (sGenre$ == "Poetry" && sCountry$ == "Canada" && sDewey$ == "Period1945") dewey = "811/.52"
+            if (sGenre$ == "Drama" && sCountry$ == "Canada" && sDewey$ == "Period1945") dewey = "812/.52"
+            if (sGenre$ == "Fiction" && sCountry$ == "SoAf" && sDewey$ == "Period1945") dewey = "823/.912"
+            if (sGenre$ == "Poetry" && sCountry$ == "SoAf" && sDewey$ == "Period1945") dewey = "821/.912"
+            if (sGenre$ == "Drama" && sCountry$ == "SoAf" && sDewey$ == "Period1945") dewey = "822/.912"
+            if (sGenre$ == "Fiction" && sCountry$ == "NZ" && sDewey$ == "Period1945") dewey = "823/.912"
+            if (sGenre$ == "Poetry" && sCountry$ == "NZ" && sDewey$ == "Period1945") dewey = "821/.912"
+            if (sGenre$ == "Drama" && sCountry$ == "NZ" && sDewey$ == "Period1945") dewey = "822/.912"
+            if (sGenre$ == "Fiction" && sCountry$ == "France" && sDewey$ == "Period1400") dewey = "843/.2"
+            if (sGenre$ == "Poetry" && sCountry$ == "France" && sDewey$ == "Period1400") dewey = "841/.2"
+            if (sGenre$ == "Drama" && sCountry$ == "France" && sDewey$ == "Period1400") dewey = "842/.2"
+            if (sGenre$ == "Fiction" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "843/.4"
+            if (sGenre$ == "Poetry" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "841/.4"
+            if (sGenre$ == "Drama" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "842/.4"
+            if (sGenre$ == "Fiction" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "843/.6"
+            if (sGenre$ == "Poetry" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "841/.6"
+            if (sGenre$ == "Drama" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "842/.6"
+            if (sGenre$ == "Fiction" && sCountry$ == "France" && sDewey$ == "Period1945") dewey = "843/.912"
+            if (sGenre$ == "Poetry" && sCountry$ == "France" && sDewey$ == "Period1945") dewey = "841/.912"
+            if (sGenre$ == "Drama" && sCountry$ == "France" && sDewey$ == "Period1945") dewey = "842/.912"
+            if (sGenre$ == "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "833/.1"
+            if (sGenre$ == "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "831/.1"
+            if (sGenre$ == "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "832/.1"
+            if (sGenre$ == "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "833/.3"
+            if (sGenre$ == "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "831/.3"
+            if (sGenre$ == "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "832/.3"
+            if (sGenre$ == "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "833/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "831/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "832/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "833/.8"
+            if (sGenre$ == "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "831/.8"
+            if (sGenre$ == "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "832/.8"
+            if (sGenre$ == "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1900") dewey = "833/.914"
+            if (sGenre$ == "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1900") dewey = "831/.914"
+            if (sGenre$ == "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1900") dewey = "832/.914"
+            if (sGenre$ == "Fiction" && sCountry$ == "Icel&&" && sDewey$ == "Period1500") dewey = "839/.6931"
+            if (sGenre$ == "Poetry" && sCountry$ == "Icel&&" && sDewey$ == "Period1500") dewey = "839/.6911"
+            if (sGenre$ == "Drama" && sCountry$ == "Icel&&" && sDewey$ == "Period1500") dewey = "839/.6921"
+            if (sGenre$ == "Fiction" && sCountry$ == "Icel&&" && sDewey$ == "Period1700") dewey = "839/.6932"
+            if (sGenre$ == "Poetry" && sCountry$ == "Icel&&" && sDewey$ == "Period1700") dewey = "839/.6912"
+            if (sGenre$ == "Drama" && sCountry$ == "Icel&&" && sDewey$ == "Period1700") dewey = "839/.6922"
+            if (sGenre$ == "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1500") dewey = "839.73/1"
+            if (sGenre$ == "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1500") dewey = "839.71/1"
+            if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1500") dewey = "839.72/1"
+            if (sGenre$ == "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.73/1"
+            if (sGenre$ == "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.71/1"
+            if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.72/1"
+            if (sGenre$ == "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.73/5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.71/5"
+            if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.72/5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.73/67"
+            if (sGenre$ == "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.71/67"
+            if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.72/67"
+            if (sGenre$ == "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1400") dewey = "839.813/1"
+            if (sGenre$ == "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1400") dewey = "839.811/1"
+            if (sGenre$ == "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1400") dewey = "839.812/1"
+            if (sGenre$ == "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.813/2"
+            if (sGenre$ == "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.811/2"
+            if (sGenre$ == "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.812/2"
+            if (sGenre$ == "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1900") dewey = "839.813/72"
+            if (sGenre$ == "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1900") dewey = "839.811/72"
+            if (sGenre$ == "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1900") dewey = "839.812/72"
+            if (sGenre$ == "Fiction" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.823/2"
+            if (sGenre$ == "Poetry" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.821/2"
+            if (sGenre$ == "Drama" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.822/2"
+            if (sGenre$ == "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1300") dewey = "853/.1"
+            if (sGenre$ == "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1300") dewey = "851/.1"
+            if (sGenre$ == "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1300") dewey = "852/.1"
+            if (sGenre$ == "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "853/.2"
+            if (sGenre$ == "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "851/.2"
+            if (sGenre$ == "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "852/.2"
+            if (sGenre$ == "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "853/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "851/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "852/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1945") dewey = "853/.912"
+            if (sGenre$ == "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1945") dewey = "851/.912"
+            if (sGenre$ == "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1945") dewey = "852/.912"
+            if (sGenre$ == "Fiction" && sCountry$ == "Aust" && sDewey$ == "Period1945") dewey = "823/.912"
+            if (sGenre$ == "Poetry" && sCountry$ == "Aust" && sDewey$ == "Period1945") dewey = "821/.912"
+            if (sGenre$ == "Drama" && sCountry$ == "Aust" && sDewey$ == "Period1945") dewey = "822/.912"
+            if (sGenre$ == "Fiction" && sCountry$ == "Spain" && sDewey$ == "Period1800") dewey = "863/.4"
+            if (sGenre$ == "Poetry" && sCountry$ == "Spain" && sDewey$ == "Period1800") dewey = "861/.4"
+            if (sGenre$ == "Drama" && sCountry$ == "Spain" && sDewey$ == "Period1800") dewey = "862/.4"
+            if (sGenre$ == "Fiction" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "863/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "861/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "862/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "863/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "861/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "862/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "863/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "861/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "862/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "863/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "861/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "862/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "863/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "861/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "862/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Brazil" && sDewey$ == "Period1500") dewey = "869.3/1"
+            if (sGenre$ == "Poetry" && sCountry$ == "Brazil" && sDewey$ == "Period1500") dewey = "869.1/1"
+            if (sGenre$ == "Drama" && sCountry$ == "Brazil" && sDewey$ == "Period1500") dewey = "869.2/1"
+            if (sGenre$ == "Fiction" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.3/3"
+            if (sGenre$ == "Poetry" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.1/3"
+            if (sGenre$ == "Drama" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.2/3"
+            if (sGenre$ == "Fiction" && sCountry$ == "Russia" && sDewey$ == "Period1917") dewey = "891.73/42"
+            if (sGenre$ == "Poetry" && sCountry$ == "Russia" && sDewey$ == "Period1917") dewey = "891.71/42"
+            if (sGenre$ == "Drama" && sCountry$ == "Russia" && sDewey$ == "Period1917") dewey = "891.72/42"
+            if (sGenre$ == "Fiction" && sCountry$ == "Russia" && sDewey$ == "Period1945") dewey = "891.73/44"
+            if (sGenre$ == "Poetry" && sCountry$ == "Russia" && sDewey$ == "Period1945") dewey = "891.71/44"
+            if (sGenre$ == "Drama" && sCountry$ == "Russia" && sDewey$ == "Period1945") dewey = "891.72/44"
+            if (sGenre$ == "Fiction" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9231"
+            if (sGenre$ == "Poetry" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9211"
+            if (sGenre$ == "Drama" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9221"
+            if (sGenre$ == "Fiction" && sCountry$ == "Lithuania" && sDewey$ == "Period1900") dewey = "891/.9233"
+            if (sGenre$ == "Poetry" && sCountry$ == "Lithuania" && sDewey$ == "Period1900") dewey = "891/.9213"
+            if (sGenre$ == "Drama" && sCountry$ == "Lithuania" && sDewey$ == "Period1900") dewey = "891/.9223"
+            if (sGenre$ == "Fiction" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9331"
+            if (sGenre$ == "Poetry" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9311"
+            if (sGenre$ == "Drama" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9321"
+            if (sGenre$ == "Fiction" && sCountry$ == "Latvia" && sDewey$ == "Period1900") dewey = "891/.9333"
+            if (sGenre$ == "Poetry" && sCountry$ == "Latvia" && sDewey$ == "Period1900") dewey = "891/.9313"
+            if (sGenre$ == "Drama" && sCountry$ == "Latvia" && sDewey$ == "Period1900") dewey = "891/.9323"
+            if (sGenre$ == "Fiction" && sCountry$ == "Finland" && sDewey$ == "Period1800") dewey = "894/.54132"
+            if (sGenre$ == "Poetry" && sCountry$ == "Finland" && sDewey$ == "Period1800") dewey = "894/.54112"
+            if (sGenre$ == "Drama" && sCountry$ == "Finland" && sDewey$ == "Period1800") dewey = "894/.54122"
+            if (sGenre$ == "Fiction" && sCountry$ == "Estonia" && sDewey$ == "Period1800") dewey = "894/.54531"
+            if (sGenre$ == "Poetry" && sCountry$ == "Estonia" && sDewey$ == "Period1800") dewey = "894/.54511"
+            if (sGenre$ == "Drama" && sCountry$ == "Estonia" && sDewey$ == "Period1800") dewey = "894/.54521"
+            if (sGenre$ == "Fiction" && sCountry$ == "Estonia" && sDewey$ == "Period1900") dewey = "894/.54532"
+            if (sGenre$ == "Poetry" && sCountry$ == "Estonia" && sDewey$ == "Period1900") dewey = "894/.54512"
+            if (sGenre$ == "Drama" && sCountry$ == "Estonia" && sDewey$ == "Period1900") dewey = "894/.54522"
+        } else if (periodNumber == 2) {
+            if (sGenre$ = "Fiction" && sCountry$ == "US" && sDewey$ == "Period1945") dewey = "813/.54"
+            if (sGenre$ = "Poetry" && sCountry$ == "US" && sDewey$ == "Period1945") dewey = "811/.54"
+            if (sGenre$ = "Drama" && sCountry$ == "US" && sDewey$ == "Period1945") dewey = "812/.54"
+            if (sGenre$ = "Fiction" && sCountry$ == "US" && sDewey$ == "Period1776") dewey = "813/.2"
+            if (sGenre$ = "Poetry" && sCountry$ == "US" && sDewey$ == "Period1776") dewey = "811/.2"
+            if (sGenre$ = "Drama" && sCountry$ == "US" && sDewey$ == "Period1776") dewey = "812/.2"
+            if (sGenre$ = "Fiction" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "813/.3"
+            if (sGenre$ = "Poetry" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "811/.3"
+            if (sGenre$ = "Drama" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "812/.3"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1400") dewey = "823/.2"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1400") dewey = "821/.2"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1400") dewey = "822/.2"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "823/.3"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "821/.3"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "822/.3"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "823/.3"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "821/.3"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "822/.3"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "823/.5"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "821/.5"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "822/.5"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "823/.7"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "821/.7"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "822/.7"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1945") dewey = "823/.914"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1945") dewey = "821/.914"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1945") dewey = "822/.914"
+            if (sGenre$ = "Fiction" && sCountry$ == "Canada" && sDewey$ == "Period1867") dewey = "813/.4"
+            if (sGenre$ = "Poetry" && sCountry$ == "Canada" && sDewey$ == "Period1867") dewey = "811/.4"
+            if (sGenre$ = "Drama" && sCountry$ == "Canada" && sDewey$ == "Period1867") dewey = "812/.4"
+            if (sGenre$ = "Fiction" && sCountry$ == "Canada" && sDewey$ == "Period1945") dewey = "813/.54"
+            if (sGenre$ = "Poetry" && sCountry$ == "Canada" && sDewey$ == "Period1945") dewey = "811/.54"
+            if (sGenre$ = "Drama" && sCountry$ == "Canada" && sDewey$ == "Period1945") dewey = "812/.54"
+            if (sGenre$ = "Fiction" && sCountry$ == "SoAf" && sDewey$ == "Period1945") dewey = "823/.914"
+            if (sGenre$ = "Poetry" && sCountry$ == "SoAf" && sDewey$ == "Period1945") dewey = "821/.914"
+            if (sGenre$ = "Drama" && sCountry$ == "SoAf" && sDewey$ == "Period1945") dewey = "822/.914"
+            if (sGenre$ = "Fiction" && sCountry$ == "NZ" && sDewey$ == "Period1945") dewey = "823/.914"
+            if (sGenre$ = "Poetry" && sCountry$ == "NZ" && sDewey$ == "Period1945") dewey = "821/.914"
+            if (sGenre$ = "Drama" && sCountry$ == "NZ" && sDewey$ == "Period1945") dewey = "822/.914"
+            if (sGenre$ = "Fiction" && sCountry$ == "France" && sDewey$ == "Period1400") dewey = "843/.3"
+            if (sGenre$ = "Poetry" && sCountry$ == "France" && sDewey$ == "Period1400") dewey = "841/.3"
+            if (sGenre$ = "Drama" && sCountry$ == "France" && sDewey$ == "Period1400") dewey = "842/.3"
+            if (sGenre$ = "Fiction" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "843/.5"
+            if (sGenre$ = "Poetry" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "841/.5"
+            if (sGenre$ = "Drama" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "842/.5"
+            if (sGenre$ = "Fiction" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "843/.7"
+            if (sGenre$ = "Poetry" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "841/.7"
+            if (sGenre$ = "Drama" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "842/.7"
+            if (sGenre$ = "Fiction" && sCountry$ == "France" && sDewey$ == "Period1945") dewey = "843/.914"
+            if (sGenre$ = "Poetry" && sCountry$ == "France" && sDewey$ == "Period1945") dewey = "841/.914"
+            if (sGenre$ = "Drama" && sCountry$ == "France" && sDewey$ == "Period1945") dewey = "842/.914"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "833/.21"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "831/.21"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "832/.21"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "833/.4"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "831/.4"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "832/.4"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "833/.6"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "831/.6"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "832/.6"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "833/.912"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "831/.912"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "832/.912"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1900") dewey = "833/.92"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1900") dewey = "831/.92"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1900") dewey = "832/.92"
+            if (sGenre$ = "Fiction" && sCountry$ == "Iceland" && sDewey$ == "Period1500") dewey = "839/.6932"
+            if (sGenre$ = "Poetry" && sCountry$ == "Iceland" && sDewey$ == "Period1500") dewey = "839/.6912"
+            if (sGenre$ = "Drama" && sCountry$ == "Iceland" && sDewey$ == "Period1500") dewey = "839/.6922"
+            if (sGenre$ = "Fiction" && sCountry$ == "Iceland" && sDewey$ == "Period1700") dewey = "839/.6933"
+            if (sGenre$ = "Poetry" && sCountry$ == "Iceland" && sDewey$ == "Period1700") dewey = "839/.6913"
+            if (sGenre$ = "Drama" && sCountry$ == "Iceland" && sDewey$ == "Period1700") dewey = "839/.6923"
+            if (sGenre$ = "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1500") dewey = "839.73/2"
+            if (sGenre$ = "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1500") dewey = "839.71/2"
+            if (sGenre$ = "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1500") dewey = "839.72/2"
+            if (sGenre$ = "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.73/2"
+            if (sGenre$ = "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.71/2"
+            if (sGenre$ = "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.72/2"
+            if (sGenre$ = "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.73/62"
+            if (sGenre$ = "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.71/62"
+            if (sGenre$ = "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.72/62"
+            if (sGenre$ = "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.73/72"
+            if (sGenre$ = "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.71/72"
+            if (sGenre$ = "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.72/72"
+            if (sGenre$ = "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1400") dewey = "839.813/2"
+            if (sGenre$ = "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1400") dewey = "839.811/2"
+            if (sGenre$ = "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1400") dewey = "839.812/2"
+            if (sGenre$ = "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.813/3"
+            if (sGenre$ = "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.811/3"
+            if (sGenre$ = "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.812/3"
+            if (sGenre$ = "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1900") dewey = "839.813/74"
+            if (sGenre$ = "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1900") dewey = "839.811/74"
+            if (sGenre$ = "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1900") dewey = "839.812/74"
+            if (sGenre$ = "Fiction" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.823/3"
+            if (sGenre$ = "Poetry" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.821/3"
+            if (sGenre$ = "Drama" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.822/3"
+            if (sGenre$ = "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1300") dewey = "853/.2"
+            if (sGenre$ = "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1300") dewey = "851/.2"
+            if (sGenre$ = "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1300") dewey = "852/.2"
+            if (sGenre$ = "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "853/.3"
+            if (sGenre$ = "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "851/.3"
+            if (sGenre$ = "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "852/.3"
+            if (sGenre$ = "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "853/.6"
+            if (sGenre$ = "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "851/.6"
+            if (sGenre$ = "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "852/.6"
+            if (sGenre$ = "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1945") dewey = "853/.914"
+            if (sGenre$ = "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1945") dewey = "851/.914"
+            if (sGenre$ = "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1945") dewey = "852/.914"
+            if (sGenre$ = "Fiction" && sCountry$ == "Aust" && sDewey$ == "Period1945") dewey = "823/.914"
+            if (sGenre$ = "Poetry" && sCountry$ == "Aust" && sDewey$ == "Period1945") dewey = "821/.914"
+            if (sGenre$ = "Drama" && sCountry$ == "Aust" && sDewey$ == "Period1945") dewey = "822/.914"
+            if (sGenre$ = "Fiction" && sCountry$ == "Spain" && sDewey$ == "Period1800") dewey = "863/.5"
+            if (sGenre$ = "Poetry" && sCountry$ == "Spain" && sDewey$ == "Period1800") dewey = "861/.5"
+            if (sGenre$ = "Drama" && sCountry$ == "Spain" && sDewey$ == "Period1800") dewey = "862/.5"
+            if (sGenre$ = "Fiction" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "863/.62"
+            if (sGenre$ = "Poetry" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "861/.62"
+            if (sGenre$ = "Drama" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "862/.62"
+            if (sGenre$ = "Fiction" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "863/.62"
+            if (sGenre$ = "Poetry" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "861/.62"
+            if (sGenre$ = "Drama" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "862/.62"
+            if (sGenre$ = "Fiction" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "863/.62"
+            if (sGenre$ = "Poetry" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "861/.62"
+            if (sGenre$ = "Drama" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "862/.62"
+            if (sGenre$ = "Fiction" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "863/.62"
+            if (sGenre$ = "Poetry" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "861/.62"
+            if (sGenre$ = "Drama" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "862/.62"
+            if (sGenre$ = "Fiction" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "863/.62"
+            if (sGenre$ = "Poetry" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "861/.62"
+            if (sGenre$ = "Drama" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "862/.62"
+            if (sGenre$ = "Fiction" && sCountry$ == "Brazil" && sDewey$ == "Period1500") dewey = "869.3/2"
+            if (sGenre$ = "Poetry" && sCountry$ == "Brazil" && sDewey$ == "Period1500") dewey = "869.1/2"
+            if (sGenre$ = "Drama" && sCountry$ == "Brazil" && sDewey$ == "Period1500") dewey = "869.2/2"
+            if (sGenre$ = "Fiction" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.3/41"
+            if (sGenre$ = "Poetry" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.1/41"
+            if (sGenre$ = "Drama" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.2/41"
+            if (sGenre$ = "Fiction" && sCountry$ == "Russia" && sDewey$ == "Period1917") dewey = "891.73/44"
+            if (sGenre$ = "Poetry" && sCountry$ == "Russia" && sDewey$ == "Period1917") dewey = "891.71/44"
+            if (sGenre$ = "Drama" && sCountry$ == "Russia" && sDewey$ == "Period1917") dewey = "891.72/44"
+            if (sGenre$ = "Fiction" && sCountry$ == "Russia" && sDewey$ == "Period1945") dewey = "891.73/5"
+            if (sGenre$ = "Poetry" && sCountry$ == "Russia" && sDewey$ == "Period1945") dewey = "891.71/5"
+            if (sGenre$ = "Drama" && sCountry$ == "Russia" && sDewey$ == "Period1945") dewey = "891.72/5"
+            if (sGenre$ = "Fiction" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9232"
+            if (sGenre$ = "Poetry" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9212"
+            if (sGenre$ = "Drama" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9222"
+            if (sGenre$ = "Fiction" && sCountry$ == "Lithuania" && sDewey$ == "Period1900") dewey = "891/.9234"
+            if (sGenre$ = "Poetry" && sCountry$ == "Lithuania" && sDewey$ == "Period1900") dewey = "891/.9214"
+            if (sGenre$ = "Drama" && sCountry$ == "Lithuania" && sDewey$ == "Period1900") dewey = "891/.9224"
+            if (sGenre$ = "Fiction" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9332"
+            if (sGenre$ = "Poetry" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9312"
+            if (sGenre$ = "Drama" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9322"
+            if (sGenre$ = "Fiction" && sCountry$ == "Latvia" && sDewey$ == "Period1900") dewey = "891/.9334"
+            if (sGenre$ = "Poetry" && sCountry$ == "Latvia" && sDewey$ == "Period1900") dewey = "891/.9314"
+            if (sGenre$ = "Drama" && sCountry$ == "Latvia" && sDewey$ == "Period1900") dewey = "891/.9324"
+            if (sGenre$ = "Fiction" && sCountry$ == "Finland" && sDewey$ == "Period1800") dewey = "894/.54133"
+            if (sGenre$ = "Poetry" && sCountry$ == "Finland" && sDewey$ == "Period1800") dewey = "894/.54113"
+            if (sGenre$ = "Drama" && sCountry$ == "Finland" && sDewey$ == "Period1800") dewey = "894/.54123"
+            if (sGenre$ = "Fiction" && sCountry$ == "Estonia" && sDewey$ == "Period1800") dewey = "894/.54532"
+            if (sGenre$ = "Poetry" && sCountry$ == "Estonia" && sDewey$ == "Period1800") dewey = "894/.54512"
+            if (sGenre$ = "Drama" && sCountry$ == "Estonia" && sDewey$ == "Period1800") dewey = "894/.54522"
+            if (sGenre$ = "Fiction" && sCountry$ == "Estonia" && sDewey$ == "Period1900") dewey = "894/.54533"
+            if (sGenre$ = "Poetry" && sCountry$ == "Estonia" && sDewey$ == "Period1900") dewey = "894/.54513"
+            if (sGenre$ = "Drama" && sCountry$ == "Estonia" && sDewey$ == "Period1900") dewey = "894/.54523"
+        } else if (periodNumber == 3) {
+            if (sGenre$ = "Fiction" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "813/.4"
+            if (sGenre$ = "Poetry" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "811/.4"
+            if (sGenre$ = "Drama" && sCountry$ == "US" && sDewey$ == "Period1830") dewey = "812/.4"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "823/.4"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "821/.4"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1558") dewey = "822/.4"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "823/.4"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "821/.4"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1625") dewey = "822/.4"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "823/.6"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "821/.6"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1702") dewey = "822/.6"
+            if (sGenre$ = "Fiction" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "823/.8"
+            if (sGenre$ = "Poetry" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "821/.8"
+            if (sGenre$ = "Drama" && sCountry$ == "UK" && sDewey$ == "Period1800") dewey = "822/.8"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "833/.22"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "831/.22"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "832/.22"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "833/.5"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "831/.5"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1300") dewey = "832/.5"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "833/.7"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "831/.7"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "832/.7"
+            if (sGenre$ = "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "833/.914"
+            if (sGenre$ = "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "831/.914"
+            if (sGenre$ = "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1800") dewey = "832/.914"
+            if (sGenre$ = "Fiction" && sCountry$ == "Iceland" && sDewey$ == "Period1700") dewey = "839/.6934"
+            if (sGenre$ = "Poetry" && sCountry$ == "Iceland" && sDewey$ == "Period1700") dewey = "839/.6914"
+            if (sGenre$ = "Drama" && sCountry$ == "Iceland" && sDewey$ == "Period1700") dewey = "839/.6924"
+            if (sGenre$ = "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.73/3"
+            if (sGenre$ = "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.71/3"
+            if (sGenre$ = "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.72/3"
+            if (sGenre$ = "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.73/64"
+            if (sGenre$ = "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.71/64"
+            if (sGenre$ = "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.72/64"
+            if (sGenre$ = "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.73/74"
+            if (sGenre$ = "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.71/74"
+            if (sGenre$ = "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1900") dewey = "839.72/74"
+            if (sGenre$ = "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.813/4"
+            if (sGenre$ = "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.811/4"
+            if (sGenre$ = "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.812/4"
+            if (sGenre$ = "Fiction" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.823/4"
+            if (sGenre$ = "Poetry" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.821/4"
+            if (sGenre$ = "Drama" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.822/4"
+            if (sGenre$ = "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "853/.4"
+            if (sGenre$ = "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "851/.4"
+            if (sGenre$ = "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "852/.4"
+            if (sGenre$ = "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "853/.7"
+            if (sGenre$ = "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "851/.7"
+            if (sGenre$ = "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "852/.7"
+            if (sGenre$ = "Fiction" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "863/.64"
+            if (sGenre$ = "Poetry" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "861/.64"
+            if (sGenre$ = "Drama" && sCountry$ == "Spain" && sDewey$ == "Period1900") dewey = "862/.64"
+            if (sGenre$ = "Fiction" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "863/.64"
+            if (sGenre$ = "Poetry" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "861/.64"
+            if (sGenre$ = "Drama" && sCountry$ == "Mexico" && sDewey$ == "Period1900") dewey = "862/.64"
+            if (sGenre$ = "Fiction" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "863/.64"
+            if (sGenre$ = "Poetry" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "861/.64"
+            if (sGenre$ = "Drama" && sCountry$ == "Argentina" && sDewey$ == "Period1900") dewey = "862/.64"
+            if (sGenre$ = "Fiction" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "863/.64"
+            if (sGenre$ = "Poetry" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "861/.64"
+            if (sGenre$ = "Drama" && sCountry$ == "Chile" && sDewey$ == "Period1900") dewey = "862/.64"
+            if (sGenre$ = "Fiction" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "863/.64"
+            if (sGenre$ = "Poetry" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "861/.64"
+            if (sGenre$ = "Drama" && sCountry$ == "Peru" && sDewey$ == "Period1900") dewey = "862/.64"
+            if (sGenre$ = "Fiction" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.3/42"
+            if (sGenre$ = "Poetry" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.1/42"
+            if (sGenre$ = "Drama" && sCountry$ == "Brazil" && sDewey$ == "Period1900") dewey = "869.2/42"
+            if (sGenre$ = "Fiction" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9233"
+            if (sGenre$ = "Poetry" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9213"
+            if (sGenre$ = "Drama" && sCountry$ == "Lithuania" && sDewey$ == "Period1800") dewey = "891/.9223"
+            if (sGenre$ = "Fiction" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9333"
+            if (sGenre$ = "Poetry" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9313"
+            if (sGenre$ = "Drama" && sCountry$ == "Latvia" && sDewey$ == "Period1800") dewey = "891/.9323"
+            if (sGenre$ = "Fiction" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "843/.6"
+            if (sGenre$ = "Poetry" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "841/.6"
+            if (sGenre$ = "Drama" && sCountry$ == "France" && sDewey$ == "Period1600") dewey = "842/.6"
+            if (sGenre$ = "Fiction" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "843/.8"
+            if (sGenre$ = "Poetry" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "841/.8"
+            if (sGenre$ = "Drama" && sCountry$ == "France" && sDewey$ == "Period1800") dewey = "842/.8"
+        } else if (periodNumber == 4) {
+            if (sGenre$ == "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "833/.3"
+            if (sGenre$ == "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "831/.3"
+            if (sGenre$ == "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1100") dewey = "832/.3"
+            if (sGenre$ == "Fiction" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "833/.8"
+            if (sGenre$ == "Poetry" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "831/.8"
+            if (sGenre$ == "Drama" && sCountry$ == "Germany" && sDewey$ == "Period1600") dewey = "832/.8"
+            if (sGenre$ == "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.73/4"
+            if (sGenre$ == "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.71/4"
+            if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.72/4"
+            if (sGenre$ == "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.73/67"
+            if (sGenre$ == "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.71/67"
+            if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1800") dewey = "839.72/67"
+            if (sGenre$ == "Fiction" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.813/5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.811/5"
+            if (sGenre$ == "Drama" && sCountry$ == "Denmark" && sDewey$ == "Period1500") dewey = "839.812/5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.823/5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.821/5"
+            if (sGenre$ == "Drama" && sCountry$ == "Norway" && sDewey$ == "Period1500") dewey = "839.822/5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "853/.5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "851/.5"
+            if (sGenre$ == "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1400") dewey = "852/.5"
+            if (sGenre$ == "Fiction" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "853/.8"
+            if (sGenre$ == "Poetry" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "851/.8"
+            if (sGenre$ == "Drama" && sCountry$ == "Italy" && sDewey$ == "Period1600") dewey = "852/.8"
+        } else if (periodNumber == 5) {
+            if (sGenre$ == "Fiction" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.73/5"
+            if (sGenre$ == "Poetry" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.71/5"
+            if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.72/5"
+        }
+
+
+
+        setAutoDeweyResult(dewey)
+        // return dewey
+
+    }
+
+    const convertLccBasic = (letter, number) => {
+        const ruleMatches = lccDeweyMap.filter(rule => rule.LCC == letter)
+        console.log('convertLccBasic', letter, ruleMatches)
+        if (ruleMatches.length == 1) {
+            ruleMatches[0].mode = 'basic'
+            return [ruleMatches[0].DDC, ruleMatches[0]]
+        }
+
+        if (ruleMatches.length > 1) {
+            for (const rule of ruleMatches) {
+                let range = rule['LCC Range'].replace(rule.LCC, '').trim()
+                if (range.charAt(range.length - 1) == '+') {
+                    range = range.replace('+', ' - 999999999')
+                }
+                const [rangeStart, rangeEnd] = range.split(' - ')
+                console.log('range', range, rangeStart, rangeEnd)
+                console.log('number', number)
+                if (number * 1 >= rangeStart * 1 && number * 1 <= rangeEnd * 1) {
+                    // console.log('number WITHIN range', number)
+                    rule.mode = 'basic'
+                    return [rule.DDC, rule]
+                }
+            }
+
+            //if no range found just use first (generic) one
+            return [ruleMatches[0].DDC, ruleMatches[0]]
+        }
+
+        return [false, { error: 'Unable to convert this LCC' }]
+
+
+    }
+
+    const [dewey, deweyInfo] = useMemo(
+        () => {
+            const [match, letter, number] = lcCall.trim().match(/^([A-Z]*)(.*)/)
+            // console.log('letter', letter)
+            // console.log(lccDeweyMap)
+            const deweys = lccDeweyMap.filter(ddc => ddc.LCC == letter)
+            // console.log(deweys)
+
+            if (lccsWithLocalLogics.includes(letter)) {
+                return convertLccWithLocalLogics(letter, number)
+            }
+
+            return convertLccBasic(letter, number)
+        },
+        [lcCall, autoDeweyGenre]
+    )
+
+    console.log(lcCall, dewey, deweyInfo)
+
+    if (deweyInfo.mode == 'autoDewey') return (
+        <div style={{ background: 'lavender', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
+            <div>LCC: {lcCall}</div>
+            {!lcCall.startsWith('GV') && (
+                <>
+                    <div>Please choose genre of this item</div>
+                    <ButtonGroup>
+                        {autoDeweyGenres.map((genre, i) => (
+                            <Button
+                                key={`genre-${i}`}
+                                onClick={() => onAutoDeweyGenreClick(genre)}
+                                buttonStyle={
+                                    genre === autoDeweyGenre
+                                        ? 'primary'
+                                        : 'default'
+                                }
+                            >
+                                <span style={{ textTransform: 'capitalize' }}>{genre}</span>
+                            </Button>
+                        )
+                        )}
+                    </ButtonGroup>
+                </>
+            )}
+            <>
+                {(deweyInfo.periods.length > 0) ? (
+                    <>
+                        <div>
+                            Please choose time period of this item
+                            <br />
+                            {deweyInfo.periods.map((period, i) => (
+                                <Button
+                                    key={`period-${i}`}
+                                    onClick={() => onPeriodClicked(i + 1, dewey, deweyInfo.genre, deweyInfo.country)}
+                                >
+                                    {period}
+                                </Button>
+                            )
+                            )}
+                        </div>
+
+                        {autoDeweyResult && (
+                            <>
+                            <div>
+                                {autoDeweyResult}
+                            </div>
+                            <div>
+                                <Button onClick={() => parentPhone({action: 'copyToClipboard', value: autoDeweyResult})}>Copy</Button>
+                            </div>
+                            </>
+                        )}
+                    </>
+                ) : (
+                    dewey ? (
+                        <>
+                            {Array.isArray(dewey) ? (
+                                <>
+                                    <div>Dewies:</div>
+                                    <ul>
+                                        {dewey.map(result => <li key={result.dewey}>{result.caption}: {result.dewey}</li>)}
+                                    </ul>
+                                </>
+                            ) : (
+                                <>
+                                <div>Dewey: {dewey}</div>
+                                <div>
+                                <Button onClick={() => parentPhone({action: 'copyToClipboard', value: dewey})}>Copy</Button>
+                                </div>
+                                </>
+
+                            )}
+
+                        </>
+                    ) : (
+                        (dewey === false) && (
+                            <>
+                                <div>Can't convert this LCC to Dewey 😔</div>
+                            </>
+                        )
+                    )
+                )}
+            </>
+
+        </div>
+    )
+
+
+    //basic mode
+    return (
+        <div style={{ background: 'antiquewhite', padding: '1em', marginTop: '1em', marginBottom: '1em' }}>
+            <div>LC Call#: {lcCall}
+                    {deweyInfo && (
+                        <Badge>
+                            <small>{deweyInfo['LCC Caption']}</small>
+                        </Badge>
+                    )}
+            </div>
+
+            {dewey && (
+                <>
+                    <div>Dewey: <strong>{dewey}</strong>
+                        {deweyInfo && (
+                            <Badge>
+                                <small>{deweyInfo['DDC Caption']}</small>
+                            </Badge>
+                        )}
+                    </div>
+                </>
+            )}
+
+            {dewey === false && (
+                <div>Can't convert this LCC to Dewey 😔</div>
+            )}
+
+        </div>
+    )
+
+}
+

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -11,7 +11,7 @@ export default function LcCallToDewey(lcCall, genre=null) {  //{ lcCall, parentP
 
     //this if for Px class, for GV uses 'GV Bio'
     const autoDeweyGenres = ['fiction', 'poetry', 'drama']
-    const autoDeweyGenre = null
+    const autoDeweyGenre = genre
     const autoDeweyResult = null
 
     const lccsWithLocalLogics = ['PG', 'PH', 'PQ', 'PR', 'PS', 'PT', 'GV']
@@ -2454,7 +2454,7 @@ export default function LcCallToDewey(lcCall, genre=null) {  //{ lcCall, parentP
         console.info('convertLccBasic', letter, ruleMatches)
         if (ruleMatches.length == 1) {
             ruleMatches[0].mode = 'basic'
-            return [ruleMatches[0].DDC, ruleMatches[0]]
+            return [ruleMatches[0].dewey, ruleMatches[0]]
         }
 
         if (ruleMatches.length > 1) {
@@ -2469,12 +2469,12 @@ export default function LcCallToDewey(lcCall, genre=null) {  //{ lcCall, parentP
                 if (number * 1 >= rangeStart * 1 && number * 1 <= rangeEnd * 1) {
                     // console.log('number WITHIN range', number)
                     rule.mode = 'basic'
-                    return [rule.DDC, rule]
+                    return [rule.dewey, rule]
                 }
             }
 
             //if no range found just use first (generic) one
-            return [ruleMatches[0].DDC, ruleMatches[0]]
+            return [ruleMatches[0].dewey, ruleMatches[0]]
         }
 
         return [false, { error: 'Unable to convert this LCC' }]

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -7,7 +7,6 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
 
     export function LcCallToDewey(lcCall, genre=null){  //{ lcCall, parentPhone }
-        console.info("Dewing it", lcCall, "--", genre)
         if (!lcCall) return
 
         //this if for Px class, for GV uses 'GV Bio'
@@ -19,7 +18,6 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
         //autoDewey mode
         const convertLccWithLocalLogics = (letter, number) => {
-            console.info("convertLccWithLocalLogics", letter, "--", number)
             //these are basically copy and pasted form VBA
 
             const Left = (str, numChars) => {
@@ -1871,8 +1869,6 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
             //GV
             const _convertClassGvSport = (sClassNo$) => {
-                console.info("converting sport")
-                console.info(Mid(sClassNo$, 3, 8))
                 if (Mid(sClassNo$, 3, 8) == "1003.62.") sDewey$ = "796.343092"
                 if (Mid(sClassNo$, 3, 8) == "1005.22.") sDewey$ = "796.34/6092"
                 if (Mid(sClassNo$, 3, 8) == "1006.52.") sDewey$ = "796.345092"
@@ -1952,7 +1948,6 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
                     _convertClassPrDrama(letter + number)
                 }
             } else if (letter == 'PS') {
-                console.info("!! PS !!", autoDeweyGenre)
                 if (autoDeweyGenre == 'fiction') {
                     _convertClassPsFiction(letter + number)
                 } else if (autoDeweyGenre == 'poetry') {
@@ -2002,7 +1997,6 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
         const convertLccBasic = (letter, number) => {
             const ruleMatches = lccDeweyMap.filter(rule => rule.LCC == letter)
-            console.info('convertLccBasic', letter, ruleMatches)
             if (ruleMatches.length == 1) {
                 ruleMatches[0].mode = 'basic'
                 return [ruleMatches[0].dewey, ruleMatches[0]]
@@ -2034,22 +2028,8 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
         }
 
         const [match, letter, number] = lcCall.trim().match(/^([A-Z]*)(.*)/)
-
-        console.info("!! match: ", match)
-        console.info("!! letter: ", letter)
-        console.info("!! number: ", number)
-
         const deweys = lccDeweyMap.filter(ddc => ddc.LCC == letter)
-
-        console.info('letter', letter)
-        console.info(lccDeweyMap)
-        console.info(deweys)
-
         const [dewey, deweyInfo] = lccsWithLocalLogics.includes(letter) ? convertLccWithLocalLogics(letter, number) : convertLccBasic(letter, number)
-
-        console.info("lcCall: ", lcCall, dewey, deweyInfo)
-        console.info("dewey: ", dewey)
-        console.info("deweyInfo: ", deweyInfo)
 
         if (deweyInfo.mode == 'autoDewey') return (
             deweyInfo

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -1,21 +1,24 @@
 //from https://git.loc.gov/lcap/aws-lcap/ui-lcap-productivity-tools/-/blob/issue-001/lcap-productivity-tools/src/components/auto-dewey/instance-selected/lccall-to-dewey.js?ref_type=heads
 
+//import { useMemoize } from '@vueuse/core'
+
 import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
 
-export default function LcCallToDewey({ lcCall, parentPhone }) {
-
+export default function LcCallToDewey(lcCall, genre=null) {  //{ lcCall, parentPhone }
+    console.info("Dewing it", lcCall, "--", genre)
     if (!lcCall) return
 
     //this if for Px class, for GV uses 'GV Bio'
     const autoDeweyGenres = ['fiction', 'poetry', 'drama']
-    const [autoDeweyGenre, setAutoDeweyGenre] = useState();
-    const [autoDeweyResult, setAutoDeweyResult] = useState();
+    const autoDeweyGenre = null
+    const autoDeweyResult = null
 
     const lccsWithLocalLogics = ['PG', 'PH', 'PQ', 'PR', 'PS', 'PT', 'GV']
 
     //autoDewey mode
     const convertLccWithLocalLogics = (letter, number) => {
+        console.info("convertLccWithLocalLogics", letter, "--", number)
         //these are basically copy and pasted form VBA
 
         const Left = (str, numChars) => {
@@ -1946,6 +1949,7 @@ export default function LcCallToDewey({ lcCall, parentPhone }) {
                 _convertClassPrDrama(letter + number)
             }
         } else if (letter == 'PS') {
+            console.info("!! PS !!", autoDeweyGenre)
             if (autoDeweyGenre == 'fiction') {
                 _convertClassPsFiction(letter + number)
             } else if (autoDeweyGenre == 'poetry') {
@@ -1990,14 +1994,6 @@ export default function LcCallToDewey({ lcCall, parentPhone }) {
             sDewey$,
             deweyInfo
         ]
-
-    }
-
-    const onAutoDeweyGenreClick = (genre) => {
-        if (genre == autoDeweyGenre) return
-
-        setAutoDeweyResult()
-        setAutoDeweyGenre(genre)
 
     }
 
@@ -2455,7 +2451,7 @@ export default function LcCallToDewey({ lcCall, parentPhone }) {
 
     const convertLccBasic = (letter, number) => {
         const ruleMatches = lccDeweyMap.filter(rule => rule.LCC == letter)
-        console.log('convertLccBasic', letter, ruleMatches)
+        console.info('convertLccBasic', letter, ruleMatches)
         if (ruleMatches.length == 1) {
             ruleMatches[0].mode = 'basic'
             return [ruleMatches[0].DDC, ruleMatches[0]]
@@ -2486,24 +2482,18 @@ export default function LcCallToDewey({ lcCall, parentPhone }) {
 
     }
 
-    const [dewey, deweyInfo] = useMemo(
-        () => {
-            const [match, letter, number] = lcCall.trim().match(/^([A-Z]*)(.*)/)
-            // console.log('letter', letter)
-            // console.log(lccDeweyMap)
-            const deweys = lccDeweyMap.filter(ddc => ddc.LCC == letter)
-            // console.log(deweys)
+    const [match, letter, number] = lcCall.trim().match(/^([A-Z]*)(.*)/)
+    const deweys = lccDeweyMap.filter(ddc => ddc.LCC == letter)
 
-            if (lccsWithLocalLogics.includes(letter)) {
-                return convertLccWithLocalLogics(letter, number)
-            }
+    console.info('letter', letter)
+    console.info(lccDeweyMap)
+    console.info(deweys)
 
-            return convertLccBasic(letter, number)
-        },
-        [lcCall, autoDeweyGenre]
-    )
+    const [dewey, deweyInfo] = lccsWithLocalLogics.includes(letter) ? convertLccWithLocalLogics(letter, number) : convertLccBasic(letter, number)
 
-    console.log(lcCall, dewey, deweyInfo)
+    console.info("lcCall: ", lcCall, dewey, deweyInfo)
+    console.info("dewey: ", dewey)
+    console.info("deweyInfo: ", deweyInfo)
 
     if (deweyInfo.mode == 'autoDewey') return (
         deweyInfo

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 9,
+    versionPatch: 10,
 
     regionUrls: {
 
@@ -306,7 +306,7 @@ export const useConfigStore = defineStore('config', {
 
 
 
-    
+
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -135,8 +135,6 @@ export const useProfileStore = defineStore('profile', {
     */
     returnStructureByGUID: (state) => {
       return (guid) => {
-        console.info("The thing")
-        console.info(state.activeProfile)
         for (let rt in state.activeProfile.rt){
           for (let pt in state.activeProfile.rt[rt].pt){
             if (state.activeProfile.rt[rt].pt[pt]['@guid'] === guid){
@@ -4547,7 +4545,7 @@ export const useProfileStore = defineStore('profile', {
     addDdc: async function(deweyInfo, guid, structure){
       console.info("Add DDC: ", deweyInfo)
       //Look to see if there is a DDC component
-      let activeProfile = this.profileStore.activeProfile
+      let activeProfile = this.activeProfile
       console.info(activeProfile)
       let hasEmptyDDC = false
       let ddcComponent = null
@@ -4575,7 +4573,7 @@ export const useProfileStore = defineStore('profile', {
       // if no empty ddc, create one
       if (!hasEmptyDDC){
         console.info("Creating component")
-        newDDC = await this.profileStore.duplicateComponentGetId(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'], this.structure, "lc:RT:bf2:Monograph:Work", lastClassifiction)
+        newDDC = await this.duplicateComponentGetId(this.returnStructureByComponentGuid(guid)['@guid'], structure, "lc:RT:bf2:Monograph:Work", lastClassifiction)
         ddcComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
       }
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4587,7 +4587,6 @@ export const useProfileStore = defineStore('profile', {
 
       //Add the defaults:
       const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
-      const newStructure = this.returnStructureByGUID(newComponent["@guid"])
 
       // look up one level & use the appropriate structure
       let parentStructure = this.returnStructureByComponentGuid(newComponent['@guid'])

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4536,7 +4536,12 @@ export const useProfileStore = defineStore('profile', {
 
 
     },
-
+    /** Add the DDC to marva
+     *
+     * @param {object} deweyInfo - The dewey information that will be inserted into Marva
+     * @param {string} guid - The GUID of the LCC component that will be used to create the new component
+     * @param {string} structure - the structure that will be used to create the new component
+     */
     addDdc: async function(deweyInfo, guid, structure){
       //Look to see if there is a DDC component
       let activeProfile = this.activeProfile

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3471,6 +3471,9 @@ export const useProfileStore = defineStore('profile', {
       */
 
   insertDefaultValuesComponent: async function(componentGuid, structure){
+    console.info("insertDefaultValuesComponent")
+    console.info("componentGuid: ", componentGuid)
+    console.info("structure: ", structure)
     // console.log(componentGuid)
     // console.log("structure",structure)
 
@@ -3624,6 +3627,9 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     duplicateComponent: async function(componentGuid, structure){
+      console.info("duplicateComponent")
+      console.info("    componentGuid: ", componentGuid)
+      console.info("    structure: ", structure)
       let createEmpty = true
 
       // locate the correct pt to work on in the activeProfile

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3477,10 +3477,6 @@ export const useProfileStore = defineStore('profile', {
       */
 
   insertDefaultValuesComponent: async function(componentGuid, structure){
-    console.info("insertDefaultValuesComponent")
-    console.info("componentGuid: ", componentGuid)
-    console.info("structure: ", structure)
-    console.info("whole thing: ", this.activeProfile)
     // console.log(componentGuid)
     // console.log("structure",structure)
 
@@ -3634,9 +3630,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     duplicateComponent: async function(componentGuid, structure){
-      console.info("duplicateComponent")
-      console.info("    componentGuid: ", componentGuid)
-      console.info("    structure: ", structure)
       let createEmpty = true
 
       // locate the correct pt to work on in the activeProfile
@@ -4545,22 +4538,17 @@ export const useProfileStore = defineStore('profile', {
     },
 
     addDdc: async function(deweyInfo, guid, structure){
-      console.info("Add DDC: ", deweyInfo)
       //Look to see if there is a DDC component
       let activeProfile = this.activeProfile
-      console.info(activeProfile)
       let hasEmptyDDC = false
       let ddcComponent = null
       let lastClassifiction = null
       for (let pt in activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt){
         if (pt.includes("id_loc_gov_ontologies_bibframe_classification__classification_numbers")){
           const target = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[pt]
-          console.info("target: ", target)
           const userValue = target.userValue
-          console.info("userValue: ", userValue)
           const classification = userValue["http://id.loc.gov/ontologies/bibframe/classification"][0]
           const type = classification["@type"]
-          console.info("component: ", classification)
           if (!pt.deleted){
             lastClassifiction = pt
             //type == "http://id.loc.gov/ontologies/bibframe/ClassificationDdc" &&
@@ -4574,15 +4562,11 @@ export const useProfileStore = defineStore('profile', {
       let newDDC
       // if no empty ddc, create one
       if (!hasEmptyDDC){
-        console.info("Creating component")
         newDDC = await this.duplicateComponentGetId(this.returnStructureByComponentGuid(guid)['@guid'], structure, "lc:RT:bf2:Monograph:Work", lastClassifiction)
         ddcComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
       }
 
       //add information to component
-      console.info("structure: ", structure)
-      console.info("structure string: ", JSON.stringify(structure))
-      console.info("ddcComponent", JSON.stringify(ddcComponent))
       let userValue = null
       try{
         userValue = ddcComponent.userValue["http://id.loc.gov/ontologies/bibframe/classification"][0]
@@ -4598,7 +4582,6 @@ export const useProfileStore = defineStore('profile', {
       }
 
       const newGuid = short.generate()
-      console.info("userValue: ", userValue)
       userValue["@type"] = "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
       userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(dewey) }]
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -131,6 +131,8 @@ export const useProfileStore = defineStore('profile', {
     */
     returnStructureByGUID: (state) => {
       return (guid) => {
+        console.info("The thing")
+        console.info(state.activeProfile)
         for (let rt in state.activeProfile.rt){
           for (let pt in state.activeProfile.rt[rt].pt){
             if (state.activeProfile.rt[rt].pt[pt]['@guid'] === guid){
@@ -3474,6 +3476,7 @@ export const useProfileStore = defineStore('profile', {
     console.info("insertDefaultValuesComponent")
     console.info("componentGuid: ", componentGuid)
     console.info("structure: ", structure)
+    console.info("whole thing: ", this.activeProfile)
     // console.log(componentGuid)
     // console.log("structure",structure)
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4586,18 +4586,22 @@ export const useProfileStore = defineStore('profile', {
       userValue["http://id.loc.gov/ontologies/bibframe/classificationPortion"] = [{ "@guid": newGuid, "http://id.loc.gov/ontologies/bibframe/classificationPortion": String(dewey) }]
 
       //Add the defaults:
-      // console.info("profile: ", this.profileStore.activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt)
-      // const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
-      // const newStructure = this.profileStore.returnStructureByGUID(newComponent["@guid"])
+      const newComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC]
+      const newStructure = this.returnStructureByGUID(newComponent["@guid"])
 
-      // console.info("newComponent['@guid']: ", newComponent['@guid'])
-      // console.info("newStructure: ", newStructure)
-      // console.info("ddcComponent: ", ddcComponent)
-
-      // console.info("*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*")
-
-      // this.profileStore.insertDefaultValuesComponent(newComponent['@guid'], ddcComponent)
-
+      // look up one level & use the appropriate structure
+      let parentStructure = this.returnStructureByComponentGuid(newComponent['@guid'])
+      if (parentStructure.valueConstraint && parentStructure.valueConstraint.valueTemplateRefs && parentStructure.valueConstraint.valueTemplateRefs.length>0){
+        for (let vRt of parentStructure.valueConstraint.valueTemplateRefs){
+          if (this.rtLookup[vRt]){
+            for (let pt of this.rtLookup[vRt].propertyTemplates){
+              if (pt.valueConstraint.defaults && pt.valueConstraint.defaults.length > 0){
+                this.insertDefaultValuesComponent(newComponent['@guid'], pt)
+              }
+            }
+          }
+        }
+      }
     },
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -102,6 +102,8 @@ export const useProfileStore = defineStore('profile', {
     showAutoDeweyModal: false,
     deweyData: {
       lcc: null,
+      guid: null,
+      structure: null,
     },
 
     mostCommonNonLatinScript: null,

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4578,7 +4578,9 @@ export const useProfileStore = defineStore('profile', {
       }
 
       //add information to component
-      console.info("ddcComponent", ddcComponent)
+      console.info("structure: ", structure)
+      console.info("structure string: ", JSON.stringify(structure))
+      console.info("ddcComponent", JSON.stringify(ddcComponent))
       let userValue = null
       try{
         userValue = ddcComponent.userValue["http://id.loc.gov/ontologies/bibframe/classification"][0]

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4546,6 +4546,8 @@ export const useProfileStore = defineStore('profile', {
       let hasEmptyDDC = false
       let ddcComponent = null
       let lastClassifiction = null
+      let newDDC
+
       for (let pt in activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt){
         if (pt.includes("id_loc_gov_ontologies_bibframe_classification__classification_numbers")){
           const target = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[pt]
@@ -4558,11 +4560,12 @@ export const useProfileStore = defineStore('profile', {
             if (!Object.keys(classification).includes("http://id.loc.gov/ontologies/bibframe/classificationPortion")){
               hasEmptyDDC = true
               ddcComponent = classification
+              newDDC = target.id
             }
           }
         }
       }
-      let newDDC
+
       // if no empty ddc, create one
       if (!hasEmptyDDC){
         newDDC = await this.duplicateComponentGetId(this.returnStructureByComponentGuid(guid)['@guid'], structure, "lc:RT:bf2:Monograph:Work", lastClassifiction)


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-286

Adds AutoDewey to Marva. AutoDewey can be accessed from the `Tools` menu or from the action button on an LCC component. When going through the action button, it will try to populate the LCC input field with the class and item portion of an LCCN if they are available. `Add to record` will create a new component in the Marva record and populate it with the created DDC and the defaults values for DDC.

It works best with `P` numbers, but will _try_ to work with any number.

Auto Dewey code is from: https://git.loc.gov/lcap/aws-lcap/ui-lcap-productivity-tools/-/blob/issue-001/lcap-productivity-tools/src/components/auto-dewey/instance-selected/lccall-to-dewey.js?ref_type=heads, only changed to better work with Vue.js and Marva.

![image](https://github.com/user-attachments/assets/695aece7-f59c-4ea7-96f7-fd77b6d1a412)
