### PR TITLE
[BFP 295] Cutter on Diacritics

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -121,6 +121,7 @@
           <div style="flex:1">
           <fieldset v-if="(lccFeatureData.contributors && lccFeatureData.contributors.length>0) || lccFeatureData.title" >
             <legend>Cutter Calculator</legend>
+            {{ lccFeatureData.title}}
 
             <template v-if="lccFeatureData.contributors">
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -121,8 +121,6 @@
           <div style="flex:1">
           <fieldset v-if="(lccFeatureData.contributors && lccFeatureData.contributors.length>0) || lccFeatureData.title" >
             <legend>Cutter Calculator</legend>
-            {{ lccFeatureData.title}}
-
             <template v-if="lccFeatureData.contributors">
 
               <template v-if="lccFeatureData.contributors[0]">

--- a/src/lib/utils_misc.js
+++ b/src/lib/utils_misc.js
@@ -17,7 +17,7 @@ const utilsMisc = {
     for (let el of allSelectable){
 
       // we're loop though so if we found it on the last iteration then the n
-      if (foundSource){        
+      if (foundSource){
         el.focus()
         break
       }
@@ -30,7 +30,7 @@ const utilsMisc = {
 
 
   },
-  
+
   prettifyXmlJS(xml, tab = '\t', nl = '\n'){
     let formatted = '', indent = '';
     const nodes = xml.slice(1, -1).split(/>\s*</);
@@ -46,14 +46,19 @@ const utilsMisc = {
 
 
   calculateCutter (toCut,howLong) {
+    console.info("toCut: ", toCut)
+
     var authorName = toCut
     authorName = authorName.toUpperCase();
     authorName = authorName.replace(/^[0-9]/,"a");
+    //replace diacritics with the letter
+    authorName = authorName.normalize('NFKD').replace(/[^\w]/g, '');
     authorName = authorName.replace(/[^A-Za-z]/g,"");
     //var authorNameLength = authorName.length;
     authorName = authorName.replace(/^QU/i,"@");
     authorName = authorName.replace(/(^.)CH/i,"$1#");
     var cutter = "";
+
     for (var i=0; i<authorName.length; i++) {
       if (i == 0) {
         cutter += authorName.slice(0,1); //alert (cutter);

--- a/src/lib/utils_misc.js
+++ b/src/lib/utils_misc.js
@@ -46,8 +46,6 @@ const utilsMisc = {
 
 
   calculateCutter (toCut,howLong) {
-    console.info("toCut: ", toCut)
-
     var authorName = toCut
     authorName = authorName.toUpperCase();
     authorName = authorName.replace(/^[0-9]/,"a");

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 12,
+    versionPatch: 13,
 
     regionUrls: {
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -29,14 +29,10 @@ export const useConfigStore = defineStore('config', {
         // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
-
-
         id: 'https://id.loc.gov/',
         env : 'staging',
         dev: true,
         displayLCOnlyFeatures: true,
-
-
       },
 
       staging:{


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-295

Characters with diacritics would be ignored, so if a name/title began with a diacritic the cutter would start on the second character. Diacritics should now be normalized, so `áàâäã` all become "a" with the same happening for other letters.