### PR TITLE
[BFP 252] Replace property name with values, sometimes

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -347,7 +347,6 @@ export default {
     },
 
     expandHeightToContent: function(){
-
       for (let key of Object.keys(this.$refs)){
         if (key.startsWith('input_')){
           if (this.$refs[key] && this.$refs[key][0]){

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -48,6 +48,7 @@
           "http://id.loc.gov/ontologies/bibframe/subject",
           "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
           "http://id.loc.gov/ontologies/bibframe/language",
+          "http://id.loc.gov/ontologies/bibframe/identifiedBy",
         ].includes(propertyURI)
       },
       returnHeadingLabel(component){
@@ -65,10 +66,18 @@
             case 'http://id.loc.gov/ontologies/bibframe/language':
               prefix = '[Lang 008]: '
               break
+            case 'http://id.loc.gov/ontologies/bibframe/identifiedBy':
+              if (component.userValue && component.userValue[propertyURI]){
+                let type = component.userValue[propertyURI][0]["@type"]
+                prefix = type.split("/").at(-1).toUpperCase() + ': '
+                break
+              }
             default:
               prefix = ''
           }
         }
+
+        console.info("component: ", component)
 
         let returnString = prefix + 'No Heading'
         if (component && component.userValue && component.userValue[propertyURI]
@@ -98,6 +107,18 @@
         && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@id'].indexOf('/fast/') > -1){
 
           returnString = prefix + '(FAST) ' + returnString
+        }
+
+        //identifiers have slightly different pat
+        if (component && component.userValue && component.userValue[propertyURI]
+            && component.userValue[propertyURI].length>0
+            && component.userValue[propertyURI][0]
+            && component.userValue[propertyURI][0]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value']
+            && component.userValue[propertyURI][0]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value'].length>0
+            && component.userValue[propertyURI][0]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value'][0]
+            && component.userValue[propertyURI][0]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value'][0]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value']
+        ){
+          returnString = prefix + component.userValue[propertyURI][0]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value'][0]['http://www.w3.org/1999/02/22-rdf-syntax-ns#value']
         }
 
         //For GEO, add the GACs code at the end

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -69,15 +69,13 @@
             case 'http://id.loc.gov/ontologies/bibframe/identifiedBy':
               if (component.userValue && component.userValue[propertyURI]){
                 let type = component.userValue[propertyURI][0]["@type"]
-                prefix = type.split("/").at(-1).toUpperCase() + ': '
+                prefix = '[' + type.split("/").at(-1).toUpperCase() + ']: '
                 break
               }
             default:
               prefix = ''
           }
         }
-
-        console.info("component: ", component)
 
         let returnString = prefix + 'No Heading'
         if (component && component.userValue && component.userValue[propertyURI]

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -43,28 +43,52 @@
 
 
     methods: {
-
-      returnSubjectHeadingLabel(component){
-
-        let returnString = 'No Heading'
-        if (component && component.userValue && component.userValue['http://id.loc.gov/ontologies/bibframe/subject']
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'].length>0
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label']
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'].length>0
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']){
-          returnString = component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
+      replacePropertyWithValue(propertyURI){
+        return [
+          "http://id.loc.gov/ontologies/bibframe/subject",
+          "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
+          "http://id.loc.gov/ontologies/bibframe/language",
+        ].includes(propertyURI)
+      },
+      returnHeadingLabel(component){
+        let propertyURI = null
+        let prefix = null
+        if (component){
+          propertyURI = component.propertyURI
+          switch (propertyURI){
+            case 'http://id.loc.gov/ontologies/bibframe/subject':
+              prefix = '[SH]'
+              break
+            case 'http://id.loc.gov/ontologies/bibframe/geographicCoverage':
+              prefix = '[GEO]'
+              break
+            case 'http://id.loc.gov/ontologies/bibframe/language':
+              prefix = '[Lang 008]'
+              break
+            default:
+              prefix = ''
+          }
         }
 
-        if (component && component.userValue && component.userValue['http://id.loc.gov/ontologies/bibframe/subject']
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'].length>0
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].length>0
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]
-        && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']){
-          returnString = component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']
+        let returnString = prefix + ' No Heading'
+        if (component && component.userValue && component.userValue[propertyURI]
+        && component.userValue[propertyURI].length>0
+        && component.userValue[propertyURI][0]
+        && component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label']
+        && component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'].length>0
+        && component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]
+        && component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']){
+          returnString = prefix + ": " + component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
+        }
+
+        if (component && component.userValue && component.userValue[propertyURI]
+        && component.userValue[propertyURI].length>0
+        && component.userValue[propertyURI][0]
+        && component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']
+        && component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].length>0
+        && component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]
+        && component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']){
+          returnString = prefix + ": " + component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']
         }
 
         if (component && component.userValue && component.userValue['http://id.loc.gov/ontologies/bibframe/subject']
@@ -73,7 +97,7 @@
         && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@id']
         && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@id'].indexOf('/fast/') > -1){
 
-          returnString = '(FAST) ' + returnString
+          returnString = prefix + ': (FAST) ' + returnString
         }
 
 
@@ -183,8 +207,8 @@
                                 <li @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}]">
                                   <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
-                                      <span v-if="activeProfile.rt[profileName].pt[element].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'">
-                                        [SH]: {{ returnSubjectHeadingLabel(activeProfile.rt[profileName].pt[element]) }}
+                                      <span v-if="replacePropertyWithValue(activeProfile.rt[profileName].pt[element].propertyURI)">
+                                        {{ returnHeadingLabel(activeProfile.rt[profileName].pt[element]) }}
                                       </span>
                                       <span v-else>
                                         {{activeProfile.rt[profileName].pt[element].propertyLabel}}

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -100,7 +100,19 @@
           returnString = prefix + '(FAST) ' + returnString
         }
 
-
+        //For GEO, add the GACs code at the end
+        if (propertyURI == "http://id.loc.gov/ontologies/bibframe/geographicCoverage"){
+          if (component && component.userValue && component.userValue[propertyURI]
+              && component.userValue[propertyURI].length>0
+              && component.userValue[propertyURI][0]
+              && component.userValue[propertyURI][0]['http://id.loc.gov/ontologies/bibframe/code']
+              && component.userValue[propertyURI][0]['http://id.loc.gov/ontologies/bibframe/code'].length>0
+              && component.userValue[propertyURI][0]['http://id.loc.gov/ontologies/bibframe/code'][0]
+              && component.userValue[propertyURI][0]['http://id.loc.gov/ontologies/bibframe/code'][0]['http://id.loc.gov/ontologies/bibframe/code']
+          ){
+            returnString = returnString + " [" + component.userValue[propertyURI][0]['http://id.loc.gov/ontologies/bibframe/code'][0]['http://id.loc.gov/ontologies/bibframe/code'] + "]"
+          }
+        }
 
 
         return returnString

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -57,20 +57,20 @@
           propertyURI = component.propertyURI
           switch (propertyURI){
             case 'http://id.loc.gov/ontologies/bibframe/subject':
-              prefix = '[SH]'
+              prefix = '[SH]: '
               break
             case 'http://id.loc.gov/ontologies/bibframe/geographicCoverage':
-              prefix = '[GEO]'
+              prefix = '[GEO]: '
               break
             case 'http://id.loc.gov/ontologies/bibframe/language':
-              prefix = '[Lang 008]'
+              prefix = '[Lang 008]: '
               break
             default:
               prefix = ''
           }
         }
 
-        let returnString = prefix + ' No Heading'
+        let returnString = prefix + 'No Heading'
         if (component && component.userValue && component.userValue[propertyURI]
         && component.userValue[propertyURI].length>0
         && component.userValue[propertyURI][0]
@@ -78,7 +78,7 @@
         && component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'].length>0
         && component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]
         && component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']){
-          returnString = prefix + ": " + component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
+          returnString = prefix + component.userValue[propertyURI][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
         }
 
         if (component && component.userValue && component.userValue[propertyURI]
@@ -88,7 +88,7 @@
         && component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'].length>0
         && component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]
         && component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']){
-          returnString = prefix + ": " + component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']
+          returnString = prefix + component.userValue[propertyURI][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel'][0]['http://www.loc.gov/mads/rdf/v1#authoritativeLabel']
         }
 
         if (component && component.userValue && component.userValue['http://id.loc.gov/ontologies/bibframe/subject']
@@ -97,7 +97,7 @@
         && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@id']
         && component.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@id'].indexOf('/fast/') > -1){
 
-          returnString = prefix + ': (FAST) ' + returnString
+          returnString = prefix + '(FAST) ' + returnString
         }
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 14,
+    versionPatch: 15,
 
     regionUrls: {
 


### PR DESCRIPTION
Add: https://staff.loc.gov/tasks/browse/BFP-252

In the `propertyPanel`, additional property labels are replaced with their value. This is in addition to subjects. The properties names are replaced with the value for the following:
* Geographic coverage: The name and the GACs code
* Language: only the field for the value in the 008
* Identifiers: these are in the instance

![image](https://github.com/user-attachments/assets/eb6e5132-0ccb-413c-8acb-ae0b96489e8d)

![image](https://github.com/user-attachments/assets/a41138b5-32e8-4a85-acce-b6d622f0be78)

