### PR TITLE
[BFP-302] Ad hoc mode

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -27,7 +27,7 @@
             <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
                 <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
                     :key="profileCompoent">
-                  <template v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent))">
+                  <template v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
                     <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
@@ -72,7 +72,7 @@
 
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
 
-                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
+                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
                       <template v-if="this.dualEdit == false">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
                           <div class="component-label 1" >

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -71,8 +71,7 @@
                 <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
 
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-
-                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
+                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
                       <template v-if="this.dualEdit == false">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
                           <div class="component-label 1" >

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -187,6 +187,7 @@
       // ...mapState(usePreferenceStore, ['profilesLoaded']),
       ...mapState(useProfileStore, ['profilesLoaded','activeProfile','activeComponent', 'dataChanged']),
       ...mapWritableState(usePreferenceStore, ['debugModalData','showDebugModal']),
+      ...mapWritableState(useProfileStore, ['emptyComponents']),
 
       activeResourceName(){
 
@@ -276,6 +277,11 @@
                 // remove from rtOrder
                 const targetIndex = this.activeProfile.rtOrder.indexOf(profileName)
                 this.activeProfile.rtOrder.splice(targetIndex, 1)
+
+                // Remove from ad hoc
+                if (Object.keys(this.emptyComponents).includes(profileName)){
+                  delete this.emptyComponents[profileName]
+                }
 
                 // remove the profile
                 delete this.activeProfile.rt[profileName]

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -25,30 +25,30 @@
                 </div>
           </template>
             <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
+                <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
+                    :key="profileCompoent">
+                  <template v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent))">
+                  <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
+                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
-              <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
-                  :key="profileCompoent" v-if="!profileStore.emptyComponents[profileName].includes(profileCompoent)">
+                      <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
 
-                <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted && !profileStore.emptyComponents[profileName].includes(profileCompoent)">
-                  <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
-
-                    <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
-
-                      <div class="component-label 3" >
-                          <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
-                          {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
-                      </div>
-                      <Main
-                        :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']"
-                        :level="0"
-                        :id="activeProfile.rt[profileName].pt[profileCompoent].id"
-                        :parentId="activeProfile.rt[profileName].pt[profileCompoent].parentId"
-                        :readOnly="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])" />
+                        <div class="component-label 3" >
+                            <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
+                            {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
+                        </div>
+                        <Main
+                          :guid="activeProfile.rt[profileName].pt[profileCompoent]['@guid']"
+                          :level="0"
+                          :id="activeProfile.rt[profileName].pt[profileCompoent].id"
+                          :parentId="activeProfile.rt[profileName].pt[profileCompoent].parentId"
+                          :readOnly="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])" />
+                      </template>
                     </template>
                   </template>
-                </template>
 
-              </div>
+                  </template>
+                </div>
             </template>
 
 
@@ -72,7 +72,7 @@
 
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
 
-                    <div v-if="!profileStore.emptyComponents[profileName].includes(profileCompoent)" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
+                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
                       <template v-if="this.dualEdit == false">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
                           <div class="component-label 1" >

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -13,10 +13,10 @@
   </template>
 
   <div
+
     v-for="profileName in this.activeProfile.rtOrder"
     :key="profileName"
     :class="{'edit-panel-work': (profileName.split(':').slice(-1)[0] == 'Work'), 'edit-panel-instance': (profileName.split(':').slice(-1)[0] == 'Instance'), 'edit-panel-instance-secondary': (profileName.split(':').slice(-1)[0].indexOf('_') > -1), 'edit-panel-scroll-x-parent': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x')}">
-
           <template v-if="instanceMode == true && profileName.indexOf(':Instance') > -1">
           <template v-if="profileName.includes(':Instance')">
                 <div>
@@ -27,14 +27,14 @@
             <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
 
               <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
-                  :key="profileCompoent">
+                  :key="profileCompoent" v-if="!profileStore.emptyComponents[profileName].includes(profileCompoent)">
 
-                <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
+                <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted && !profileStore.emptyComponents[profileName].includes(profileCompoent)">
                   <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
                     <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
 
-                      <div class="component-label" >
+                      <div class="component-label 3" >
                           <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
                           {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                       </div>
@@ -72,13 +72,10 @@
 
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
 
-
-                    <div :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
-
-
+                    <div v-if="!profileStore.emptyComponents[profileName].includes(profileCompoent)" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
                       <template v-if="this.dualEdit == false">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
-                          <div class="component-label" >
+                          <div class="component-label 1" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
 
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
@@ -88,7 +85,7 @@
                     </template>
                     <template v-if="this.dualEdit == true">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false && profileName.indexOf(':Instance') == -1">
-                          <div class="component-label" >
+                          <div class="component-label 2" >
                           <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                             <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -27,13 +27,13 @@
             <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
                 <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
                     :key="profileCompoent">
-                  <template v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent))">
+                  <template v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
                     <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
                       <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
 
-                        <div class="component-label 3" >
+                        <div class="component-label" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                         </div>
@@ -71,10 +71,10 @@
                 <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
 
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
+                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent)))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
                       <template v-if="this.dualEdit == false">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
-                          <div class="component-label 1" >
+                          <div class="component-label" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
 
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
@@ -84,7 +84,7 @@
                     </template>
                     <template v-if="this.dualEdit == true">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false && profileName.indexOf(':Instance') == -1">
-                          <div class="component-label 2" >
+                          <div class="component-label" >
                           <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                             <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>

--- a/src/components/panels/nav/AdHocModal.vue
+++ b/src/components/panels/nav/AdHocModal.vue
@@ -61,6 +61,11 @@
           } else {
             this.emptyComponents[rt].push(pt)
           }
+        },
+
+        setLabel: function(rt){
+          let pieces = rt.split(":")
+          return pieces.at(-1)
         }
     },
 
@@ -95,13 +100,14 @@
           <div id="error-holder" ref="errorHolder">
             <div>
                 <h1>Ad Hoc Mode Elements</h1>
-                <div class="dewey-menu-button">
+                <div style="z-index: 100;">
                     <button @click="done()" class="close-button">Close</button>
                 </div>
             </div>
             <h3>Below you can select elements to display or hide in Marva.</h3>
+            <p>Fields that are mandatory or populated can't be hidden.</p>
             <div v-for="(v, rt) in activeProfile.rt">
-              <h2 style="margin-top: 5px;">{{ rt }}</h2>
+              <h2 style="margin-top: 5px;">{{ setLabel(rt) }}</h2>
               <div v-for="(obj, pt) in activeProfile.rt[rt].pt">
                 <li style="margin-bottom: 2px;">
                   <div id="container" v-if="obj.mandatory!='true' && isEmptyComponent(obj)">
@@ -114,7 +120,7 @@
                   </div>
                   <div v-else>
                     <div class="mandatory-container" v-if="obj.mandatory == 'true'">
-                      <div class="mandatory">MANDATORY</div>
+                      <div class="mandatory">Mandatory</div>
                       <div>{{ obj.propertyLabel }}</div>
                     </div>
                     <div class="mandatory-container" v-else>
@@ -198,6 +204,7 @@
 /* toggle */
 #container{
   display: table;
+  margin-left: 20px;
 }
 
 #container div {
@@ -223,6 +230,7 @@
 
 .mandatory-container {
   display: table;
+  margin-left: 20px;
 }
 .mandatory {
   position: relative;

--- a/src/components/panels/nav/AdHocModal.vue
+++ b/src/components/panels/nav/AdHocModal.vue
@@ -1,0 +1,276 @@
+<script>
+  import { useProfileStore } from '@/stores/profile'
+  import { useConfigStore } from '@/stores/config'
+
+
+  import {  mapStores, mapState, mapWritableState } from 'pinia'
+  import { VueFinalModal } from 'vue-final-modal'
+  import VueDragResize from 'vue3-drag-resize'
+
+
+  export default {
+    components: {
+      VueFinalModal,
+      VueDragResize,
+    },
+
+    data() {
+      return {
+        width: 0,
+        height: 0,
+        top: 100,
+        left: 0,
+        validationResults: {},
+        validating: false,
+        initalHeight: 400,
+        initalLeft: (window.innerWidth /2 ) - 450,
+
+
+      }
+    },
+    computed: {
+      // other computed properties
+      // ...
+      // gives access to this.counterStore and this.userStore
+      ...mapStores(useProfileStore,useConfigStore),
+      ...mapState(useProfileStore, ['emptyComponents', 'activeProfile']),
+
+      // ...mapState(usePreferenceStore, ['debugModalData']),
+      ...mapWritableState(useProfileStore, ['showAdHocModal', 'emptyComponents']),
+    },
+
+
+    methods: {
+        done : function(){
+          this.showAdHocModal = false
+        },
+
+        dragResize: function(newRect){
+          this.width = newRect.width
+          this.height = newRect.height
+          this.top = newRect.top
+          this.left = newRect.left
+          this.$refs.errorHolder.style.height = newRect.height + 'px'
+
+        },
+    },
+
+    mounted() {}
+  }
+
+
+
+</script>
+
+<template>
+    <VueFinalModal
+      display-directive="show"
+      :hide-overlay="false"
+      :overlay-transition="'vfm-fade'"
+      :click-to-close="true"
+      :esc-to-close="true"
+
+    >
+        <VueDragResize
+          :is-active="true"
+          :w="900"
+          :h="initalHeight"
+          :x="initalLeft"
+          class="login-modal"
+          @resizing="dragResize"
+          @dragging="dragResize"
+
+          :sticks="['br']"
+          :stickSize="22"
+        >
+          <div id="error-holder" ref="errorHolder">
+            <div>
+                <h1>Ad Hoc Mode Elements</h1>
+                <div class="dewey-menu-button">
+                    <button @click="done()" class="close-button">Close</button>
+                </div>
+            </div>
+            <h3>Below you can select elements to display or hide in Marva.</h3>
+
+            <div v-for="(value, key) in emptyComponents">
+              <h2>{{ key }}</h2>
+                <li v-for="item in value">
+                  <div id="container">
+                    <input type="checkbox" id="search-type" class="toggle" name="search-type" value="keyword" @click="changeSearchType($event)" ref="toggle">
+                    <label for="search-type" class="toggle-container">
+                      <div>Display</div>
+                      <div>Hide</div>
+                    </label>
+                    {{ this.activeProfile.rt[key].pt[item].propertyLabel }}
+                  </div>
+                </li>
+              </div>
+          </div>
+        </VueDragResize>
+    </VueFinalModal>
+</template>
+
+<style scoped>
+  #error-holder{
+    overflow-y: scroll;
+  }
+
+  .checkbox-option{
+    width: 20px;
+    height: 20px;
+  }
+
+  .option{
+    display: flex;
+  }
+  .option-title{
+    flex:2;
+  }
+  .option-title-header{
+    font-weight: bold;
+  }
+  .option-title-desc{
+    font-size: 0.8em;
+    color:gray;
+  }
+  #debug-content{
+    overflow: hidden;
+    overflow-y: auto;
+  }
+  .menu-buttons{
+    margin-bottom: 2em;
+    position: relative;
+  }
+  .close-button{
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    background-color: white;
+    border-radius: 5px;
+    border: solid 1px black;
+    cursor: pointer;
+  }
+  .login-modal{
+    background-color: white;
+    -webkit-box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
+    box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
+    border-radius: 1em;
+    padding:1em;
+    border: solid 1px black;
+  }
+  div{
+    /* margin-top: 2em; */
+  }
+
+  input{
+    font-size: 1.5em;
+    margin-top: 0.5em;
+
+  }
+  strong{
+    font-weight: bold
+  }
+  button{
+    font-size: 1.5em;
+  }
+
+  .level-INFO,
+  .level-SUCCESS,
+  .level-WARNING,
+  .level-ERROR{
+    list-style: none;
+    width: fit-content;
+    margin-bottom: 5px;
+    padding: .75rem 1.25rem;
+  }
+  .level-WARNING {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+  }
+  .level-ERROR {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+  }
+
+  .level-SUCCESS {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+  }
+
+  .level-INFO {
+    color: #0c5460;
+    background-color: #d1ecf1;
+    border-color: #bee5eb;
+  }
+
+  /* toggle */
+  #container{
+	margin-left: 5px;
+}
+
+.toggle {
+	display: none;
+}
+
+.toggle-container {
+   position: relative;
+   display: grid;
+   grid-template-columns: repeat(2, 1fr);
+   width: fit-content;
+   border: 3px solid lightskyblue;
+   border-radius: 20px;
+   background: lightskyblue;
+   font-weight: bold;
+   color: lightskyblue;
+   cursor: pointer;
+}
+
+.toggle-container::before {
+   content: '';
+   position: absolute;
+   width: 50%;
+   height: 100%;
+   left: 0%;
+   border-radius:20px;
+   background: black;
+   transition: all 0.3s;
+}
+
+.toggle-container div {
+   padding: 6px;
+   text-align: center;
+   z-index: 1;
+}
+
+.toggle:checked + .toggle-container::before {
+   left: 50%;
+}
+
+.toggle:checked + .toggle-container div:first-child{
+   color: black;
+   transition: color 0.3s;
+}
+.toggle:checked + .toggle-container div:last-child{
+   color: lightskyblue;
+   transition: color 0.3s;
+}
+.toggle + .toggle-container div:first-child{
+   color: lightskyblue;
+   transition: color 0.3s;
+}
+.toggle + .toggle-container div:last-child{
+   color: black;
+   transition: color 0.3s;
+}
+
+.menu-buttons{
+  right: 20px;
+  top: 5px;
+  position: absolute;
+  z-index: 100000;
+
+}
+</style>

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -53,11 +53,11 @@
 
       ...mapStores(useProfileStore,usePreferenceStore),
 
-      ...mapState(useProfileStore, ['profilesLoaded','activeProfile','rtLookup', 'activeProfileSaved']),
+      ...mapState(useProfileStore, ['profilesLoaded','activeProfile','rtLookup', 'activeProfileSaved', 'isEmptyComponent']),
       ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay']),
       ...mapState(useConfigStore, ['layouts']),
       ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal','layoutActiveFilter','layoutActive','showFieldColorsModal']),
-      ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal', 'showAutoDeweyModal']),
+      ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal', 'showAutoDeweyModal', 'showHideModal', 'emptyComponents']),
       ...mapWritableState(useConfigStore, ['showNonLatinBulkModal','showNonLatinAgentModal']),
 
 
@@ -179,7 +179,22 @@
               // active: this.happy,
               click: () => { this.showNonLatinAgentModal = true }
             },
-
+            { is: 'separator'},
+            {
+              text: 'Show/Hide Elements',
+              click: () => { this.showHideModal = true },
+              icon: 'menu'
+            },
+            {
+              text: 'Show All Elements',
+              click: () => this.showAllElements(),
+              icon: 'visibility'
+            },
+            {
+              text: 'Hide All Elements',
+              click: () => this.hideAllElements(),
+              icon: 'visibility_off'
+            },
             { is: 'separator'},
             {
               text: 'Copy Mode [' + (this.preferenceStore.copyMode ? "on" : "off") + ']',
@@ -521,6 +536,25 @@
         document.body.appendChild(temp)
         temp.click()
         document.body.removeChild(temp)
+      },
+
+      // Show all hidden elements
+      showAllElements: function(){
+        for (let key in this.emptyComponents){
+          this.emptyComponents[key] = []
+        }
+      },
+
+      // Hide all empty elements
+      hideAllElements: function(){
+        for (let rt in this.activeProfile.rt){
+          for (let element in this.activeProfile.rt[rt].pt){
+            let empty = this.isEmptyComponent(this.activeProfile.rt[rt].pt[element])
+            if(empty){
+              this.emptyComponents[rt].push(element)
+            }
+          }
+        }
       },
 
     },

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -551,7 +551,11 @@
           for (let element in this.activeProfile.rt[rt].pt){
             let empty = this.isEmptyComponent(this.activeProfile.rt[rt].pt[element])
             if(empty){
-              this.emptyComponents[rt].push(element)
+              if (Object.keys(this.emptyComponents).includes(rt)){
+                this.emptyComponents[rt].push(element)
+              } else {
+                this.emptyComponents[rt] = [element]
+              }
             }
           }
         }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -548,14 +548,12 @@
       // Hide all empty elements
       hideAllElements: function(){
         for (let rt in this.activeProfile.rt){
+          this.emptyComponents[rt] = []
           for (let element in this.activeProfile.rt[rt].pt){
             let empty = this.isEmptyComponent(this.activeProfile.rt[rt].pt[element])
-            if(empty){
-              if (Object.keys(this.emptyComponents).includes(rt)){
-                this.emptyComponents[rt].push(element)
-              } else {
-                this.emptyComponents[rt] = [element]
-              }
+            const mandatory = this.activeProfile.rt[rt].pt[element].mandatory
+            if(empty && mandatory != 'true'){
+              this.emptyComponents[rt].push(element)
             }
           }
         }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -57,7 +57,7 @@
       ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay']),
       ...mapState(useConfigStore, ['layouts']),
       ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal','layoutActiveFilter','layoutActive','showFieldColorsModal']),
-      ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal', 'showAutoDeweyModal', 'showHideModal', 'emptyComponents']),
+      ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal', 'showAutoDeweyModal', 'showAdHocModal', 'emptyComponents']),
       ...mapWritableState(useConfigStore, ['showNonLatinBulkModal','showNonLatinAgentModal']),
 
 
@@ -179,22 +179,7 @@
               // active: this.happy,
               click: () => { this.showNonLatinAgentModal = true }
             },
-            { is: 'separator'},
-            {
-              text: 'Show/Hide Elements',
-              click: () => { this.showHideModal = true },
-              icon: 'menu'
-            },
-            {
-              text: 'Show All Elements',
-              click: () => this.showAllElements(),
-              icon: 'visibility'
-            },
-            {
-              text: 'Hide All Elements',
-              click: () => this.hideAllElements(),
-              icon: 'visibility_off'
-            },
+
             { is: 'separator'},
             {
               text: 'Copy Mode [' + (this.preferenceStore.copyMode ? "on" : "off") + ']',
@@ -212,9 +197,34 @@
             }
           ] }
           )
+        }
 
-
-
+        if(this.$route.path.startsWith('/edit/')){
+          console.info("menu: ", menu)
+          for (let sub in menu){
+            console.info("sub: ", menu[sub])
+            if (menu[sub].text == 'Tools'){
+              menu[sub].menu.push(
+                { is: 'separator'},
+                {
+                  text: 'Show/Hide Elements',
+                  icon: 'menu',
+                  custom_chevron: ">",
+                  click: () => this.showAdHocModal(),
+                },
+                {
+                  text: 'Show Empty Elements',
+                  click: () => this.showAllElements(),
+                  icon: 'visibility'
+                },
+                {
+                  text: 'Hide Empty Elements',
+                  click: () => this.hideAllElements(),
+                  icon: 'visibility_off'
+                },
+              )
+            }
+          }
         }
 
 
@@ -557,6 +567,11 @@
             }
           }
         }
+      },
+
+      showAdHocModal: function(){
+        console.info("???")
+        this.showAdHocModal = true
       },
 
     },

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -17,6 +17,10 @@
         <RecoveryModal ref="recoverymodal" v-model="showRecoveryModal" />
       </template>
 
+      <template v-if="showAdHocModal==true">
+        <AdHocModal ref="adHocModal" v-model="showAdHocModal" />
+      </template>
+
     </Teleport>
 
   </div>
@@ -33,10 +37,11 @@
   import PostModal from "@/components/panels/nav/PostModal.vue";
   import ValidateModal from "@/components/panels/nav/ValidateModal.vue";
   import RecoveryModal from "@/components/panels/nav/RecoveryModal.vue";
+  import AdHocModal from "@/components/panels/nav/AdHocModal.vue";
 
 
   export default {
-    components: { VueFileToolbarMenu, PostModal, ValidateModal,RecoveryModal },
+    components: { VueFileToolbarMenu, PostModal, ValidateModal,RecoveryModal, AdHocModal },
     data() {
       return {
         allSelected: false,
@@ -200,17 +205,14 @@
         }
 
         if(this.$route.path.startsWith('/edit/')){
-          console.info("menu: ", menu)
           for (let sub in menu){
-            console.info("sub: ", menu[sub])
             if (menu[sub].text == 'Tools'){
               menu[sub].menu.push(
                 { is: 'separator'},
                 {
                   text: 'Show/Hide Elements',
                   icon: 'menu',
-                  custom_chevron: ">",
-                  click: () => this.showAdHocModal(),
+                  click: () => { this.showAdHocModal = true },
                 },
                 {
                   text: 'Show Empty Elements',
@@ -568,12 +570,6 @@
           }
         }
       },
-
-      showAdHocModal: function(){
-        console.info("???")
-        this.showAdHocModal = true
-      },
-
     },
 
     created() {}

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -123,12 +123,15 @@
       jumpToElement: function(profileName, elementName){
         //if it's hidden show it
         if (this.emptyComponents[profileName].includes(elementName)){
-          console.info("this is a hidden element")
+          console.info("this is a hidden element, removing it from the list: ", elementName)
           let idx = this.emptyComponents[profileName].indexOf(elementName)
+          console.info("idx: ", idx)
           this.emptyComponents[profileName].splice(idx, 1)
+          console.info("new emptyComponentList: ", this.emptyComponents[profileName])
         }
         //jump to it
         this.activeComponent = this.activeProfile.rt[profileName].pt[elementName]
+        console.info("activeComponent: ", this.activeComponent)
       },
     },
   }

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -179,9 +179,6 @@
 
 
                   <ul class="sidebar-property-ul" role="list">
-
-
-
                           <draggable
                             v-model="activeProfile.rt[profileName].ptOrder"
                             group="people"
@@ -191,7 +188,7 @@
                             item-key="id">
                             <template #item="{element}">
                               <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI)">
-                                <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName].includes(element) )}]">
+                                <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName] && emptyComponents[profileName].includes(element) )}]">
                                   <a href="#" @click.stop="jumpToElement(profileName, element)" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
                                       <span v-if="activeProfile.rt[profileName].pt[element].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'">
@@ -200,8 +197,6 @@
                                       <span v-else>
                                         {{activeProfile.rt[profileName].pt[element].propertyLabel}}
                                       </span>
-
-
 
                                   </a>
                                   <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-show-types')">

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -33,10 +33,10 @@
       // gives access to this.counterStore and this.userStore
       ...mapStores(useProfileStore,usePreferenceStore),
       // // gives read access to this.count and this.double
-      ...mapState(useProfileStore, ['profilesLoaded','activeProfile', 'dataChanged','rtLookup', 'activeComponent']),
+      ...mapState(useProfileStore, ['profilesLoaded','activeProfile', 'dataChanged','rtLookup', 'activeComponent', 'emptyComponents']),
       ...mapState(usePreferenceStore, ['styleDefault', 'isEmptyComponent']),
 
-      ...mapWritableState(useProfileStore, ['activeComponent']),
+      ...mapWritableState(useProfileStore, ['activeComponent', 'emptyComponents']),
 
 
     },
@@ -119,6 +119,17 @@
               return false
           }
       },
+
+      jumpToElement: function(profileName, elementName){
+        //if it's hidden show it
+        if (this.emptyComponents[profileName].includes(elementName)){
+          console.info("this is a hidden element")
+          let idx = this.emptyComponents[profileName].indexOf(elementName)
+          this.emptyComponents[profileName].splice(idx, 1)
+        }
+        //jump to it
+        this.activeComponent = this.activeProfile.rt[profileName].pt[elementName]
+      },
     },
   }
 
@@ -180,8 +191,8 @@
                             item-key="id">
                             <template #item="{element}">
                               <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI)">
-                                <li @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}]">
-                                  <a href="#" @click.stop="activeComponent = activeProfile.rt[profileName].pt[element]" class="sidebar-property-ul-alink">
+                                <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName].includes(element) )}]">
+                                  <a href="#" @click.stop="jumpToElement(profileName, element)" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
                                       <span v-if="activeProfile.rt[profileName].pt[element].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'">
                                         [SH]: {{ returnSubjectHeadingLabel(activeProfile.rt[profileName].pt[element]) }}
@@ -510,8 +521,13 @@ li.system-populated:before {
 li.user-populated:before {
     font-family: 'Material Icons';
     content: 'task_alt';
-    //content: '✓';
     color: white !important;
+}
+
+li.not-populated-hide:before{
+  font-family: 'Material Icons';
+  content: 'visibility_off';
+  color: white !important;
 }
 
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -123,15 +123,11 @@
       jumpToElement: function(profileName, elementName){
         //if it's hidden show it
         if (this.emptyComponents[profileName].includes(elementName)){
-          console.info("this is a hidden element, removing it from the list: ", elementName)
           let idx = this.emptyComponents[profileName].indexOf(elementName)
-          console.info("idx: ", idx)
           this.emptyComponents[profileName].splice(idx, 1)
-          console.info("new emptyComponentList: ", this.emptyComponents[profileName])
         }
         //jump to it
         this.activeComponent = this.activeProfile.rt[profileName].pt[elementName]
-        console.info("activeComponent: ", this.activeComponent)
       },
     },
   }

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1843,10 +1843,13 @@ const utilsParse = {
         }else{
           profile.rt[pkey].pt[key].dataLoaded=false
           // if there is no data loaded, add it to the list for ad hoc
-          if (Object.keys(useProfileStore().emptyComponents).includes(pkey)){
-            useProfileStore().emptyComponents[pkey].push(key)
-          } else {
-            useProfileStore().emptyComponents[pkey] = [key]
+          const e = profile.rt[pkey].pt[key]
+          if (e.mandatory != 'true'){
+            if (Object.keys(useProfileStore().emptyComponents).includes(pkey)){
+              useProfileStore().emptyComponents[pkey].push(key)
+            } else {
+              useProfileStore().emptyComponents[pkey] = [key]
+            }
           }
 
 

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -380,7 +380,6 @@ const utilsParse = {
   },
 
   transformRts: async function(profile){
-    console.info("transformRts")
     let toDeleteNoData = []
 
     // before we start processing make sure we have enough instance rts for the number needed

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -380,6 +380,7 @@ const utilsParse = {
   },
 
   transformRts: async function(profile){
+    console.info("transformRts")
     let toDeleteNoData = []
 
     // before we start processing make sure we have enough instance rts for the number needed
@@ -1839,10 +1840,8 @@ const utilsParse = {
         if (Object.keys(profile.rt[pkey].pt[key].userValue).length>1){
           // there could be one property for all components, the @root id
           profile.rt[pkey].pt[key].dataLoaded=true
-          console.info("\ndataloaded: ", pkey, "--", key)
         }else{
           profile.rt[pkey].pt[key].dataLoaded=false
-          console.info("\nNO dataloaded: ", pkey, "--", key)
           // if there is no data loaded, add it to the list for ad hoc
           if (Object.keys(useProfileStore().emptyComponents).includes(pkey)){
             useProfileStore().emptyComponents[pkey].push(key)

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -54,7 +54,7 @@ const utilsParse = {
     if (uri.match(/lcc:[A-Z]/)){
       return true
     }
-    
+
     // for (let nsKey of Object.keys(this.namespace)){
 
     //  let pattern = `${nsKey}:[A-Z]/`
@@ -206,7 +206,7 @@ const utilsParse = {
       //     '</xsl:stylesheet>',
       // ].join('\n'), 'application/xml');
 
-      // var xsltProcessor = new XSLTProcessor();    
+      // var xsltProcessor = new XSLTProcessor();
       // xsltProcessor.importStylesheet(xsltDoc);
       // var resultDoc = xsltProcessor.transformToDocument(this.activeDom);
       // var resultXml = new XMLSerializer().serializeToString(resultDoc);
@@ -214,7 +214,7 @@ const utilsParse = {
 
 
       // xml = xml.replace(/(<\/?.*?>)/g, '$1\n');
-      
+
       this.activeDom = parser.parseFromString(xml, 'application/xml');
       this.testDom = parser.parseFromString(xml, 'application/xml');
 
@@ -253,11 +253,11 @@ const utilsParse = {
   sniffWorkRelationType(xml){
     for (let child of xml.children){
       if (child.tagName == 'bf:relation'){
-      
+
         // let hasUncontrolled = false
         // if (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1){ hasUncontrolled = true }
         // if (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bibframe/Uncontrolled")>-1){ hasUncontrolled = true }
-        
+
         // let hasSeriesProperty = false
         // if (child.innerHTML.indexOf("bf:hasSeries")>-1){ hasSeriesProperty = true }
 
@@ -289,9 +289,9 @@ const utilsParse = {
         // console.log('hasSeries',hasSeries)
         // console.log('hasAssociatedResource',hasAssociatedResource)
 
-        
 
-        
+
+
 
       // old Logic
        if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) && child.innerHTML.indexOf("hasSeries")>-1){
@@ -339,7 +339,7 @@ const utilsParse = {
   },
 
   /**
-  * For our hub profile we broke out the different title types, sniff for which profile to use 
+  * For our hub profile we broke out the different title types, sniff for which profile to use
   *
   * @param {Node} xml - the XML payload
   * @return {Node}
@@ -350,7 +350,7 @@ const utilsParse = {
         if ( child.innerHTML.indexOf("bf:VariantTitle")>-1){
           child.setAttribute('local:pthint', 'lc:RT:bf2:Title:VarTitle')
         }if ( child.innerHTML.indexOf("bf:TransliteratedTitle")>-1){
-          child.setAttribute('local:pthint', 'lc:RT:bflc:TranscribedTitle')          
+          child.setAttribute('local:pthint', 'lc:RT:bflc:TranscribedTitle')
         }else{
           // leave blank?
         }
@@ -365,7 +365,7 @@ const utilsParse = {
   },
 
   updateAdditionalInstanceParentValues: function(profile, instanceName, newRdId){
-  // when a record comes in with multiple (secondary) instances, each instance will have the 
+  // when a record comes in with multiple (secondary) instances, each instance will have the
   // same parent and parentId, so all of there components will match. This causes issues with
   // navigation, but not anywhere else?
   // adapted from `profile.createSecondaryInstance()` to have parent properties be unique and correct
@@ -375,10 +375,10 @@ const utilsParse = {
             profile.pt[pt].parentId = profile.pt[pt].parentId.replace(instanceName, newRdId)
             profile.pt[pt].parent = profile.pt[pt].parent.replace(instanceName, newRdId)
         }
-        
+
         return profile
   },
-  
+
   transformRts: async function(profile){
     let toDeleteNoData = []
 
@@ -418,7 +418,7 @@ const utilsParse = {
       }else if (pkey.endsWith(':Hub')){
         tle = "bf:Hub"
         isHub=true
-      }else{        
+      }else{
         rtsToRemove.push(pkey)
         // don't mess with anything other than top level entities in the profile, remove them from the profile
         continue
@@ -557,7 +557,7 @@ const utilsParse = {
 
       }
 
-      
+
 
       let sucessfulProperties  = []
       let sucessfulElements  = []
@@ -592,9 +592,9 @@ const utilsParse = {
 
           if (this.UriNamespace(e.tagName) == propertyURI){
 
-            
+
             // elHashOrder.push(hashCode((new XMLSerializer()).serializeToString(e)))
-            
+
 
             // if it has a hint then we need to check if we can find the right pt for it
             if (e.attributes['local:pthint'] && e.attributes['local:pthint'].value){
@@ -629,7 +629,7 @@ const utilsParse = {
               el.push(e)
             }
 
-            
+
           }
         }
 
@@ -750,7 +750,7 @@ const utilsParse = {
             }
 
             // do a deepHierarchy check here to see if it is a very nested bf:relation property if so we will mark it here
-            if (ptk.propertyURI == 'http://id.loc.gov/ontologies/bibframe/relation'){              
+            if (ptk.propertyURI == 'http://id.loc.gov/ontologies/bibframe/relation'){
               if (e.innerHTML.indexOf("bf:hasInstance")>-1){
                 ptk.deepHierarchy=true
               }
@@ -1640,7 +1640,7 @@ const utilsParse = {
             }else{
               let newKey = `${k}_${counter}`
               let currentpos = profile.rt[pkey].ptOrder.indexOf(k)
-              let newpos = currentpos + 1               
+              let newpos = currentpos + 1
               profile.rt[pkey].ptOrder.splice(newpos, 0, newKey);
               populateData.id = newKey
               ptsCreatedThisLoop.push(newKey)
@@ -1653,7 +1653,7 @@ const utilsParse = {
 
             // do a little sanity check here, loop through and
             userValue = this.removeEmptyBnodes(userValue)
-                       
+
 
             counter++
 
@@ -1663,8 +1663,8 @@ const utilsParse = {
           if (ptsCreatedThisLoop.length>1){
             let posOfFirst = 9999
             // we need to find the first occurance of the property to know where to start cutting and replacing
-            for (let ptCreated of ptsCreatedThisLoop){             
-              if (profile.rt[pkey].ptOrder.indexOf(ptCreated)<posOfFirst){ posOfFirst = profile.rt[pkey].ptOrder.indexOf(ptCreated)}              
+            for (let ptCreated of ptsCreatedThisLoop){
+              if (profile.rt[pkey].ptOrder.indexOf(ptCreated)<posOfFirst){ posOfFirst = profile.rt[pkey].ptOrder.indexOf(ptCreated)}
             }
             if (posOfFirst != -1 && posOfFirst != 9999){
               // cut out the old ones and inset the new order
@@ -1839,8 +1839,16 @@ const utilsParse = {
         if (Object.keys(profile.rt[pkey].pt[key].userValue).length>1){
           // there could be one property for all components, the @root id
           profile.rt[pkey].pt[key].dataLoaded=true
+          console.info("\ndataloaded: ", pkey, "--", key)
         }else{
           profile.rt[pkey].pt[key].dataLoaded=false
+          console.info("\nNO dataloaded: ", pkey, "--", key)
+          // if there is no data loaded, add it to the list for ad hoc
+          if (Object.keys(useProfileStore().emptyComponents).includes(pkey)){
+            useProfileStore().emptyComponents[pkey].push(key)
+          } else {
+            useProfileStore().emptyComponents[pkey] = [key]
+          }
 
 
           for (let k in profile.rt[pkey].pt[key].userValue){
@@ -1979,7 +1987,7 @@ const utilsParse = {
       if (index !== -1) {
         profile.rtOrder.splice(index, 1);
       }
-      
+
 
     }
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 15,
+    versionPatch: 16,
 
     regionUrls: {
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -698,7 +698,7 @@ export const usePreferenceStore = defineStore('preference', {
           range: [true,false]
       },
       '--c-general-ad-hoc' : {
-          desc: 'Turn on Ad Hoc Mode. Ad Hoc mode will only display populated fields in Marva, other fields can be added as needed.',
+          desc: 'Turn on Ad Hoc Mode. Ad Hoc mode will only display populated and mandatory fields in Marva, other fields can be added as needed.',
           descShort: 'Ad Hoc Mode',
           value: false,
           type: 'boolean',

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -697,6 +697,15 @@ export const usePreferenceStore = defineStore('preference', {
           group: 'General',
           range: [true,false]
       },
+      '--c-general-ad-hoc' : {
+          desc: 'Turn on Ad Hoc Mode. Ad Hoc mode will only display populated fields in Marva, other fields can be added as needed.',
+          descShort: 'Ad Hoc Mode',
+          value: false,
+          type: 'boolean',
+          unit: null,
+          group: 'General',
+          range: [true,false]
+      },
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4438,7 +4438,6 @@ export const useProfileStore = defineStore('profile', {
 
     //Check if the component's userValue is empty
     isEmptyComponent: function(c){
-      console.info("checking if empty: ", c)
       const component = c
       const emptyArray = new Array("@root")
       const userValue = JSON.parse(JSON.stringify(component["userValue"]))

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4026,6 +4026,16 @@ export const useProfileStore = defineStore('profile', {
         // update the parentId
         this.activeProfile.rt[newRtId].pt[pt].parentId = this.activeProfile.rt[newRtId].pt[pt].parentId.replace(instanceName, newRtId)
         this.activeProfile.rt[newRtId].pt[pt].parent = this.activeProfile.rt[newRtId].pt[pt].parent.replace(instanceName, newRtId)
+
+        // TODO: make sure this is included in the branch for adding items
+        // If it's not mandatory, add it to ad hoc mode's emptyComponents list
+        if (this.activeProfile.rt[newRtId].pt[pt].mandatory != 'true'){
+          if (Object.keys(this.emptyComponents).includes(newRtId)){
+            this.emptyComponents[newRtId].push(pt)
+          } else {
+            this.emptyComponents[newRtId] = [pt]
+          }
+        }
       }
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -100,7 +100,7 @@ export const useProfileStore = defineStore('profile', {
       componentPropertyPath:null
     },
     showAutoDeweyModal: false,
-    showHideModal: false,
+    showAdHocModal: false,
     deweyData: {
       lcc: null,
       guid: null,

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -100,6 +100,7 @@ export const useProfileStore = defineStore('profile', {
       componentPropertyPath:null
     },
     showAutoDeweyModal: false,
+    showHideModal: false,
     deweyData: {
       lcc: null,
       guid: null,
@@ -4437,6 +4438,7 @@ export const useProfileStore = defineStore('profile', {
 
     //Check if the component's userValue is empty
     isEmptyComponent: function(c){
+      console.info("checking if empty: ", c)
       const component = c
       const emptyArray = new Array("@root")
       const userValue = JSON.parse(JSON.stringify(component["userValue"]))

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -124,6 +124,8 @@ export const useProfileStore = defineStore('profile', {
     literalLangInfo: null,
     literalLangShow: false,
 
+    // List of empty components for ad hoc mode
+    emptyComponents: {},
 
 
   }),
@@ -4434,7 +4436,6 @@ export const useProfileStore = defineStore('profile', {
 
 
     //Check if the component's userValue is empty
-
     isEmptyComponent: function(c){
       const component = c
       const emptyArray = new Array("@root")

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -448,14 +448,11 @@
         let useProfile = null
         console.log("this.profiles",this.profiles)
         console.log("useInstanceProfile",useInstanceProfile)
-        console.info("loading profile: ",this.profile)
         for (let key in this.profiles){
           if (this.profiles[key].rtOrder.indexOf(useInstanceProfile)>-1){
             useProfile = JSON.parse(JSON.stringify(this.profiles[key]))
           }
         }
-
-        console.info("loading profile 2: ",this.profile)
 
         // check if the input field is empty
         if (this.urlToLoad == "" && useProfile===null){
@@ -515,8 +512,6 @@
           useProfile.log = []
         }
 
-        console.info("loading 1")
-
         // setup the log and set the procinfo so the post process knows what to do with this record
         useProfile.log.push({action:'loadInstance',from:this.urlToLoad})
         useProfile.procInfo= "update instance"
@@ -555,13 +550,11 @@
             this.emptyComponents[rt] = []
             for (let element in this.activeProfile.rt[rt].pt){
               const e = this.activeProfile.rt[rt].pt[element]
-              console.info("element: ", e, "--", e.mandatory)
               if (e.mandatory != 'true'){
                 this.emptyComponents[rt].push(element)
               }
             }
           }
-          console.info("empty: ", this.emptyComponents)
         }
 
         if (multiTestFlag){


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-302

This adds Ad hoc mode as a preference to Marva. Ad hoc mode hides all empty fields, unless they are `mandatory` according to the profile. 

It is enabled under `Preferences` > `General.` Hidden properties will appear in the property panel with an icon indicating it is hidden. 
![image](https://github.com/user-attachments/assets/5b92d70c-1082-416f-aa24-677eeef99fab)

Clicking on a hidden item will add it to the form and jump to it.

There are some options under `Tools` related to hiding/showing empty records and one to open a modal that has a list of all of the properties which can be toggled between hide/show. The user is not able to hide a mandatory field or a field that is populated.

![image](https://github.com/user-attachments/assets/4fca8b47-99aa-4e98-936f-e4004bbf0f89)

![image](https://github.com/user-attachments/assets/cf188115-63d4-4580-9758-1317d10f8b49)
