### PR TITLE
Hide from action button

### DIFF
--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -116,7 +116,7 @@
           </button>
         </template>
 
-        <template v-if="preferenceStore.returnValue('--c-general-ad-hoc') && this.profileStore.isEmptyComponent(this.structure)">
+        <template v-if="showHideElementButton()">
           <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="hideElement()">
             <span class="">🙈</span>Hide Element
           </button>
@@ -848,6 +848,12 @@
         this.profileStore.deleteComponent(this.guid)
       },
 
+      showHideElementButton: function(){
+        let component = this.profileStore.returnStructureByComponentGuid(this.guid)
+        let empty = this.profileStore.isEmptyComponent(component)
+
+        return empty
+      },
       // Hide empty element in ad hoc mode
       hideElement: function(){
         let structure = this.profileStore.returnStructureByComponentGuid(this.guid)

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -116,6 +116,12 @@
           </button>
         </template>
 
+        <template v-if="preferenceStore.returnValue('--c-general-ad-hoc') && this.profileStore.isEmptyComponent(this.structure)">
+          <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="hideElement()">
+            <span class="">🙈</span>Hide Element
+          </button>
+        </template>
+
         <button style="width:100%" :id="`action-button-command-${fieldGuid}-0`" class="" @click="showDebug()">
           <span class="button-shortcut-label">0</span>
           Debug
@@ -229,7 +235,7 @@
 
 
       ...mapWritableState(usePreferenceStore, ['debugModalData','showDebugModal']),
-      ...mapWritableState(useProfileStore, ['showAutoDeweyModal', 'deweyData']),
+      ...mapWritableState(useProfileStore, ['showAutoDeweyModal', 'deweyData', 'emptyComponents']),
 
       scriptShifterOptionsForMenu(){
 
@@ -840,6 +846,12 @@
         activeStructure = this.updateContrib(activeStructure, currentType)
         this.profileStore.parseActiveInsert(activeStructure)
         this.profileStore.deleteComponent(this.guid)
+      },
+
+      // Hide empty element in ad hoc mode
+      hideElement: function(){
+        let structure = this.profileStore.returnStructureByComponentGuid(this.guid)
+        this.emptyComponents[structure.parentId].push(structure.id)
       },
 
     },

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -212,7 +212,7 @@
           )
         }
 
-        if(this.$route.path.startsWith('/edit/')){
+        if(this.$route.path.startsWith('/edit/') && this.preferenceStore.returnValue('--c-general-ad-hoc')){
           for (let sub in menu){
             if (menu[sub].text == 'Tools'){
               menu[sub].menu.push(

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 17,
+    versionPatch: 18,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4538,6 +4538,7 @@ export const useProfileStore = defineStore('profile', {
 
     //Check if the component's userValue is empty
     isEmptyComponent: function(c){
+      console.info("isEmpty? ", c)
       const component = c
       const emptyArray = new Array("@root")
       const userValue = JSON.parse(JSON.stringify(component["userValue"]))
@@ -4545,6 +4546,7 @@ export const useProfileStore = defineStore('profile', {
 
       // if there is only a @root
       if (JSON.stringify(Object.keys(component.userValue)) == JSON.stringify(emptyArray)){
+          console.info("only has root")
           return true
       } else {
           // if the children only have "@..." properties


### PR DESCRIPTION
Adds the ability to hide an empty element from the action button when Ad Hoc mode is on.

Also hides the Ad Hoc related options from under `Tools` when the mode is off.