### PR TITLE
[BFP-304] Custom Layouts

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -37,9 +37,9 @@
                     <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
                       <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
-
                         <div class="component-label 1" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
+                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                         </div>
                         <Main
@@ -89,7 +89,7 @@
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
                           <div class="component-label 2" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
-
+                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                             <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
                           </div>
@@ -99,7 +99,8 @@
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false && (profileName.indexOf(':Instance') == -1 && profileName.indexOf(':Item') == -1 )">
                           <div class="component-label 3" >
                           <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
-                            {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
+                          <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
+                          {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                             <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
                           </div>
                         </template>
@@ -194,7 +195,7 @@
       ...mapStores(useProfileStore),
 
 
-      ...mapState(usePreferenceStore, ['styleDefault', 'layoutActive', 'layoutActiveFilter']),
+      ...mapState(usePreferenceStore, ['styleDefault', 'layoutActive', 'layoutActiveFilter', 'createLayoutMode']),
 
       // gives read access to this.count and this.double
       // ...mapState(usePreferenceStore, ['profilesLoaded']),

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -32,7 +32,7 @@
             <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
                 <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
                     :key="profileCompoent">
-                  <template v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
+                  <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || createLayoutMode) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
                     <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
@@ -84,12 +84,13 @@
                 <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
 
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-                    <div v-if="!preferenceStore.returnValue('--c-general-ad-hoc') || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent)))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
+                    <div v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || createLayoutMode) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent)))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
                       <template v-if="this.dualEdit == false">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
+
                           <div class="component-label 2" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
-                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
+                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['propertyURI']" />
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                             <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
                           </div>

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -90,7 +90,7 @@
 
                           <div class="component-label 2" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
-                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['propertyURI']" />
+                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" :value="profileName"/>
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                             <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
                           </div>

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -17,13 +17,13 @@
     :key="profileName"
     :class="{'edit-panel-work': (profileName.split(':').slice(-1)[0] == 'Work'), 'edit-panel-instance': (profileName.split(':').slice(-1)[0] == 'Instance'), 'edit-panel-item': (profileName.split(':').slice(-1)[0].includes('Item')), 'edit-panel-instance-secondary': (profileName.split(':').slice(-1)[0].indexOf('_') > -1 && !profileName.split(':').slice(-1)[0].includes('Item')), 'edit-panel-scroll-x-parent': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x')}">
           <template v-if="instanceMode == true && (profileName.indexOf(':Instance') > -1 || profileName.indexOf(':Item') > -1)">
-          <template v-if="profileName.includes(':Instance')">
+          <template v-if="profileName.includes(':Instance') && (!layoutActiveFilter || (layoutActiveFilter && Object.keys(layoutActiveFilter['properties']).includes(profileName)))">
                 <div>
                     <span class="instanceIdentifer">{{ instanceLabel(profileName) }}: {{ activeProfile.rt[profileName].URI.split("/").at(-1) }}</span>
-                    <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Instance</button>
+                    <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Instance?</button>
                 </div>
           </template>
-          <template v-if="profileName.includes(':Item')">
+          <template v-if="profileName.includes(':Item') && (!layoutActiveFilter || (layoutActiveFilter && Object.keys(layoutActiveFilter['properties']).includes(profileName)))">
                 <div>
                     <span class="instanceIdentifer">{{ instanceLabel(profileName) }}: {{ activeProfile.rt[profileName].URI.split("/").at(-1) }}</span>
                     <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Item</button>
@@ -34,7 +34,7 @@
                     :key="profileCompoent">
                   <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || createLayoutMode) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
+                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
 
                       <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
                         <div class="component-label 1" >
@@ -59,14 +59,14 @@
 
           </template>
       <template v-if="instanceMode == false">
-        <template v-if="profileName.includes(':Instance') && !this.dualEdit">
+        <template v-if="profileName.includes(':Instance') && !this.dualEdit && (!layoutActiveFilter || (layoutActiveFilter && Object.keys(layoutActiveFilter['properties']).includes(profileName)))">
             <div class="instanceInfoWrapper">
                 <span class="instanceIdentifer">{{ instanceLabel(profileName) }}: {{ activeProfile.rt[profileName].URI.split("/").at(-1) }}</span>
-                <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Instance</button>
+                <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Instance!</button>
             </div>
         </template>
 
-        <template v-if="profileName.includes(':Item') && !this.dualEdit">
+        <template v-if="profileName.includes(':Item') && !this.dualEdit && (!layoutActiveFilter || (layoutActiveFilter && Object.keys(layoutActiveFilter['properties']).includes(profileName)))">
             <div class="instanceInfoWrapper">
                 <span class="instanceIdentifer">{{ instanceLabel(profileName) }}: {{ activeProfile.rt[profileName].URI.split("/").at(-1) }}</span>
                 <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Item</button>

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -34,7 +34,7 @@
                     :key="profileCompoent">
                   <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || createLayoutMode) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
+                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
                       <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
                         <div class="component-label 1" >
@@ -75,7 +75,7 @@
 
         <template v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" :key="profileCompoent">
 
-          <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties.indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
+          <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
 
             <template v-if="!hideProps.includes(activeProfile.rt[profileName].pt[profileCompoent].propertyURI)">
 

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -34,7 +34,7 @@
                     :key="profileCompoent">
                   <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || createLayoutMode) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
+                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
 
                       <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
                         <div class="component-label 1" >
@@ -75,7 +75,7 @@
 
         <template v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" :key="profileCompoent">
 
-          <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].propertyURI) > -1) ">
+          <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
 
             <template v-if="!hideProps.includes(activeProfile.rt[profileName].pt[profileCompoent].propertyURI)">
 

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -32,9 +32,9 @@
             <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
                 <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
                     :key="profileCompoent">
-                  <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || createLayoutMode) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
+                  <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || (createLayoutMode && !layoutActive)) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-                    <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
+                    <template v-if="(createLayoutMode && layoutActive) || layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
 
                       <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
                         <div class="component-label 1" >
@@ -75,7 +75,7 @@
 
         <template v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" :key="profileCompoent">
 
-          <template v-if="layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
+          <template v-if="(createLayoutMode && layoutActive) || layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && layoutActiveFilter.properties[profileName].indexOf(activeProfile.rt[profileName].pt[profileCompoent].id) > -1) ">
 
             <template v-if="!hideProps.includes(activeProfile.rt[profileName].pt[profileCompoent].propertyURI)">
 
@@ -84,13 +84,14 @@
                 <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
 
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
-                    <div v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || createLayoutMode) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent)))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
+                    <!-- if createLatoutMode is active, and there is an active layout, show everything -->
+                    <div v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || (createLayoutMode && !layoutActive)) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && !profileStore.emptyComponents[profileName].includes(profileCompoent)))" :class="{ 'inline-mode' : (preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')), 'edit-panel-scroll-x-child': preferenceStore.returnValue('--b-edit-main-splitpane-edit-scroll-x'), 'read-only': isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])}">
+                      <!-- =={{ layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[profileCompoent].id) }} -->
                       <template v-if="this.dualEdit == false">
                         <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false && preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == false">
-
                           <div class="component-label 2" >
                             <input v-if="preferenceStore.copyMode && !activeProfile.rt[profileName].pt[profileCompoent].propertyLabel.includes('Admin')" type="checkbox" class="copy-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" />
-                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" :value="profileName"/>
+                            <input v-if="createLayoutMode" type="checkbox" class="layout-selection" :id="activeProfile.rt[profileName].pt[profileCompoent]['@guid']" :value="profileName" :checked="layoutActiveFilter && layoutActiveFilter['properties'][profileName] && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[profileCompoent].id)" />
                             {{activeProfile.rt[profileName].pt[profileCompoent].propertyLabel}}
                             <span v-if="isReadOnly(activeProfile.rt[profileName].pt[profileCompoent])"> (HISTORICAL - READ ONLY) <a style="color:black" href="#" @click="showDebug($event,activeProfile.rt[profileName].pt[profileCompoent])">debug</a></span>
                           </div>

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -49,6 +49,7 @@
       return {
         allSelected: false,
         instances: [],
+        layoutHash: null,
       }
     },
     props:{
@@ -312,16 +313,38 @@
               click: () => {
                 this.layoutActive=false
                 this.layoutActiveFilter=null
+                this.layoutHash=null
               }
             }
           )
 
+
            let layoutsMenu = []
-           layoutsMenu.push({
+           // If there is a custom layout loaded, options should be edit & delete
+           let layoutOptions
+
+           if (!this.layoutHash){
+            layoutOptions = [{
               text: "Create Layout",
               click: () => { this.createLayout() },
               icon: "add"
-            })
+            }]
+           } else {
+            layoutOptions = [{
+              text: "Edit Layout",
+              click: () => { this.editLayout() },
+              icon: "edit"
+            },
+            {
+              text: "Delete Layout",
+              click: () => { this.deleteLayout() },
+              icon: "delete"
+            }]
+           }
+
+           for (let opt in layoutOptions){
+            layoutsMenu.push(layoutOptions[opt])
+           }
             layoutsMenu.push({ is: "separator" })
 
            for (let l in this.layouts.all ){
@@ -341,6 +364,7 @@
               layoutsMenu.push({
                 text: l.label,
                 click: () => {
+                  this.layoutHash = hash
                   this.activateLayout(l)
                 }
               })
@@ -514,6 +538,18 @@
         console.info("Current Custom Layouts: ", this.customLayouts)
         this.createLayoutMode = true
         console.info("createLayoutMode: ", this.createLayoutMode)
+      },
+
+      editLayout: function(){
+        let target = this.layoutActiveFilter
+        console.info("Edit layout: ", target)
+      },
+
+      deleteLayout: function(){
+        this.preferenceStore.deleteLayout(this.layoutHash)
+        this.layoutActive = false
+        this.layoutActiveFilter = null
+        this.layoutHash = null
       },
 
       saveLayout: function(){

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -325,14 +325,26 @@
             layoutsMenu.push({ is: "separator" })
 
            for (let l in this.layouts.all ){
-
             layoutsMenu.push({
               text: this.layouts.all[l].label,
               click: () => {
                 this.activateLayout(this.layouts.all[l])
               }
-
             })
+           }
+
+           const customLayouts = this.preferenceStore.returnValue("--l-custom-layouts")
+           if (customLayouts != {}){
+            layoutsMenu.push({ is: "separator" })
+            for (let hash in customLayouts){
+              let l = customLayouts[hash]
+              layoutsMenu.push({
+                text: l.label,
+                click: () => {
+                  this.activateLayout(l)
+                }
+              })
+            }
            }
 
            console.info("???", this.createLayoutMode)
@@ -492,6 +504,7 @@
       },
 
       activateLayout(layout){
+        console.info("activate layout: ", layout)
         this.layoutActive = true
         this.layoutActiveFilter = layout
       },

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -309,6 +309,7 @@
               icon: "reorder",
               disabled: (this.layoutActive) ? false : true,
               class: (this.layoutActive) ? "layout-active" : "layout-not-active",
+              title: "Turn off layout",
 
               click: () => {
                 this.layoutActive=false

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -396,12 +396,18 @@
               { text: "Layouts",  menu: layoutsMenu }
             )
             if(this.layoutActive){
-              menu.push(
-                {
-                  text: this.layoutActiveFilter.label,
-                  class: 'active-layout-label'
-                }
-              )
+              console.info("turn on layout: ", this.layoutActive, "--", this.layoutActiveFilter)
+              if (this.layoutActiveFilter){
+                console.einfo("not this")
+                menu.push(
+                  {
+                    text: this.layoutActiveFilter.label,
+                    class: 'active-layout-label'
+                  }
+                )
+              } else {
+                this.layoutActiveFilter = null
+              }
             }
            } else {
             menu.push(
@@ -591,6 +597,9 @@
 
       cancelLayout: function(){
         this.createLayoutMode = false
+        this.layoutActive = false
+        this.layoutActiveFilter = null
+        this.layoutHash = null
       },
 
       selectAll: function(){

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -505,7 +505,11 @@
 
       saveLayout: function(){
         console.info("save")
-        // this.createLayoutMode = false
+        let saved = this.preferenceStore.saveLayout()
+
+        if (saved){
+          this.createLayoutMode = false
+        }
       },
 
       cancelLayout: function(){

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -340,7 +340,8 @@
                 e.stopPropagation()
                 this.editLayout()
               },
-              icon: "edit"
+              icon: "edit",
+              hotkey: "ctrl+shift+e"
             },
             {
               text: "Delete Layout",
@@ -349,7 +350,8 @@
                   this.deleteLayout()
                 }
               },
-              icon: "delete"
+              icon: "delete",
+              hotkey: "ctrl+shift+d"
             }]
            }
 
@@ -393,7 +395,7 @@
 
            if (!this.createLayoutMode){
             menu.push(
-              { text: "Layouts",  menu: layoutsMenu }
+              { text: "Layouts",  menu: layoutsMenu, menu_width: 250 }
             )
             if(this.layoutActive){
               if (this.layoutActiveFilter){

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -344,7 +344,11 @@
             },
             {
               text: "Delete Layout",
-              click: () => { this.deleteLayout() },
+              click: () => {
+                if (window.confirm("Do you really want to delete this layout?")){
+                  this.deleteLayout()
+                }
+              },
               icon: "delete"
             }]
            }
@@ -359,7 +363,8 @@
               text: this.layouts.all[l].label,
               click: () => {
                 this.activateLayout(this.layouts.all[l])
-              }
+              },
+
             })
            }
 
@@ -556,8 +561,14 @@
         this.createLayoutMode = true
       },
 
-      deleteLayout: function(){
-        this.preferenceStore.deleteLayout(this.layoutHash)
+      deleteLayout: function(hash=null){
+        let targetHash
+        if (hash){
+          targetHash = hash
+        } else {
+          targetHash = this.layoutHash
+        }
+        this.preferenceStore.deleteLayout(targetHash)
         this.layoutActive = false
         this.layoutActiveFilter = null
         this.layoutHash = null
@@ -565,14 +576,12 @@
 
       saveLayout: function(){
         let saved = this.preferenceStore.saveLayout()
-
-        // if there is a loaded layout, refresh it
-        if (this.layoutActive){
-          this.layoutHash = saved
-          const customLayouts = this.preferenceStore.returnValue("--l-custom-layouts")
-          let l = customLayouts[this.layoutHash]
-          this.activateLayout(l)
-        }
+        let l
+        const customLayouts = this.preferenceStore.returnValue("--l-custom-layouts")
+        this.layoutHash = saved
+        l = customLayouts[this.layoutHash]
+        // switch to the new layout
+        this.activateLayout(l)
         if (saved){
           this.createLayoutMode = false
         }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -541,21 +541,16 @@
       },
 
       activateLayout(layout){
-        console.info("activate layout: ", layout)
         this.layoutActive = true
         this.layoutActiveFilter = layout
       },
 
       createLayout: function(){
-        console.info("Create Layout")
-        console.info("Current Custom Layouts: ", this.customLayouts)
         this.createLayoutMode = true
-        console.info("createLayoutMode: ", this.createLayoutMode)
       },
 
       editLayout: function(){
         let target = this.layoutActiveFilter
-        console.info("Edit layout: ", target)
         this.createLayoutMode = true
       },
 
@@ -567,9 +562,7 @@
       },
 
       saveLayout: function(){
-        console.info("save")
         let saved = this.preferenceStore.saveLayout()
-        console.info("saved: ", saved)
 
         // if there is a loaded layout, refresh it
         if (this.layoutActive){
@@ -584,7 +577,6 @@
       },
 
       cancelLayout: function(){
-        console.info("cancel")
         this.createLayoutMode = false
       },
 

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -381,6 +381,8 @@
                   this.layoutHash = layoutList[idx]
                   this.activateLayout(layout)
                 },
+                emoji: layout.profileId == this.activeProfile.id ? "heavy_check_mark" : "x",
+                title: layout.profileId == this.activeProfile.id ? "Layout Matches Profile." : "Can't use ''" + layout.profileId  + "'' layout with ''" + this.activeProfile.id + "'' profile."
               })
             }
            }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -326,7 +326,10 @@
            if (!this.layoutHash){
             layoutOptions = [{
               text: "Create Layout",
-              click: () => { this.createLayout() },
+              click: (e) => {
+                e.stopPropagation()
+                this.createLayout()
+              },
               icon: "add"
             }]
            } else {

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -366,14 +366,16 @@
            const customLayouts = this.preferenceStore.returnValue("--l-custom-layouts")
            if (customLayouts != {}){
             layoutsMenu.push({ is: "separator" })
-            for (let hash in customLayouts){
-              let l = customLayouts[hash]
+            const layoutList = Object.keys(customLayouts)
+            for (let idx in layoutList){
+              let layout = customLayouts[layoutList[idx]]
               layoutsMenu.push({
-                text: l.label,
+                text: layout.label,
+                hotkey: "ctrl+" + idx,
                 click: () => {
-                  this.layoutHash = hash
-                  this.activateLayout(l)
-                }
+                  this.layoutHash = layoutList[idx]
+                  this.activateLayout(layout)
+                },
               })
             }
            }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -63,9 +63,9 @@
       ...mapStores(useProfileStore,usePreferenceStore),
 
       ...mapState(useProfileStore, ['profilesLoaded','activeProfile','rtLookup', 'activeProfileSaved', 'isEmptyComponent']),
-      ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay']),
+      ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay', 'customLayouts', 'createLayoutMode']),
       ...mapState(useConfigStore, ['layouts']),
-      ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal','layoutActiveFilter','layoutActive','showFieldColorsModal']),
+      ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal','layoutActiveFilter','layoutActive','showFieldColorsModal', 'customLayouts', 'createLayoutMode']),
       ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData','showValidateModal', 'showRecoveryModal', 'showAutoDeweyModal', 'showItemInstanceSelection', 'showAdHocModal', 'emptyComponents']),
       ...mapWritableState(useConfigStore, ['showNonLatinBulkModal','showNonLatinAgentModal']),
 
@@ -317,6 +317,12 @@
           )
 
            let layoutsMenu = []
+           layoutsMenu.push({
+              text: "Create Layout",
+              click: () => { this.createLayout() },
+              icon: "add"
+            })
+            layoutsMenu.push({ is: "separator" })
 
            for (let l in this.layouts.all ){
 
@@ -329,9 +335,28 @@
             })
            }
 
+           console.info("???", this.createLayoutMode)
+          //  menu.push(
+          //     !this.createLayoutMode ? { text: "Layouts",  menu: layoutsMenu } : { text: "Save Layout", click: () => { this.saveLayout() }}
+          //   )
+
+           if (!this.createLayoutMode){
             menu.push(
               { text: "Layouts",  menu: layoutsMenu }
             )
+           } else {
+            menu.push(
+              { text: "Save Layout", click: (e) => {
+                e.stopPropagation()
+                console.info("click save: ", e)
+                this.saveLayout()
+               }},
+              { text: "Cancel Layout", click: (e) => {
+                e.stopPropagation()
+                this.cancelLayout()
+              }},
+            )
+           }
 
         }
 
@@ -469,6 +494,23 @@
       activateLayout(layout){
         this.layoutActive = true
         this.layoutActiveFilter = layout
+      },
+
+      createLayout: function(){
+        console.info("Create Layout")
+        console.info("Current Custom Layouts: ", this.customLayouts)
+        this.createLayoutMode = true
+        console.info("createLayoutMode: ", this.createLayoutMode)
+      },
+
+      saveLayout: function(){
+        console.info("save")
+        // this.createLayoutMode = false
+      },
+
+      cancelLayout: function(){
+        console.info("cancel")
+        this.createLayoutMode = false
       },
 
       selectAll: function(){

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -396,7 +396,6 @@
               { text: "Layouts",  menu: layoutsMenu }
             )
             if(this.layoutActive){
-              console.info("turn on layout: ", this.layoutActive, "--", this.layoutActiveFilter)
               if (this.layoutActiveFilter){
                 console.einfo("not this")
                 menu.push(

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -314,6 +314,7 @@
                 this.layoutActive=false
                 this.layoutActiveFilter=null
                 this.layoutHash=null
+                this.createLayoutMode=false
               }
             }
           )
@@ -335,7 +336,10 @@
            } else {
             layoutOptions = [{
               text: "Edit Layout",
-              click: () => { this.editLayout() },
+              click: (e) => {
+                e.stopPropagation()
+                this.editLayout()
+              },
               icon: "edit"
             },
             {
@@ -382,6 +386,14 @@
             menu.push(
               { text: "Layouts",  menu: layoutsMenu }
             )
+            if(this.layoutActive){
+              menu.push(
+                {
+                  text: this.layoutActiveFilter.label,
+                  class: 'active-layout-label'
+                }
+              )
+            }
            } else {
             menu.push(
               { text: "Save Layout", click: (e) => {
@@ -544,6 +556,7 @@
       editLayout: function(){
         let target = this.layoutActiveFilter
         console.info("Edit layout: ", target)
+        this.createLayoutMode = true
       },
 
       deleteLayout: function(){
@@ -556,7 +569,15 @@
       saveLayout: function(){
         console.info("save")
         let saved = this.preferenceStore.saveLayout()
+        console.info("saved: ", saved)
 
+        // if there is a loaded layout, refresh it
+        if (this.layoutActive){
+          this.layoutHash = saved
+          const customLayouts = this.preferenceStore.returnValue("--l-custom-layouts")
+          let l = customLayouts[this.layoutHash]
+          this.activateLayout(l)
+        }
         if (saved){
           this.createLayoutMode = false
         }
@@ -782,6 +803,11 @@
     }
     .layout-not-active{
       display: none !important;
+    }
+
+    .active-layout-label:hover,
+    .active-layout-label {
+      background: rgb(30, 231, 57) !important;
     }
 
 

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -374,7 +374,6 @@
             }
            }
 
-           console.info("???", this.createLayoutMode)
           //  menu.push(
           //     !this.createLayoutMode ? { text: "Layouts",  menu: layoutsMenu } : { text: "Save Layout", click: () => { this.saveLayout() }}
           //   )
@@ -387,7 +386,6 @@
             menu.push(
               { text: "Save Layout", click: (e) => {
                 e.stopPropagation()
-                console.info("click save: ", e)
                 this.saveLayout()
                }},
               { text: "Cancel Layout", click: (e) => {

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -397,15 +397,12 @@
             )
             if(this.layoutActive){
               if (this.layoutActiveFilter){
-                console.einfo("not this")
                 menu.push(
                   {
                     text: this.layoutActiveFilter.label,
                     class: 'active-layout-label'
                   }
                 )
-              } else {
-                this.layoutActiveFilter = null
               }
             }
            } else {

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -190,7 +190,7 @@
                                         [SH]: {{ returnSubjectHeadingLabel(activeProfile.rt[profileName].pt[element]) }}
                                       </span>
                                       <span v-else>
-                                        {{activeProfile.rt[profileName].pt[element].propertyLabel}}?!?!
+                                        {{activeProfile.rt[profileName].pt[element].propertyLabel}}
                                       </span>
 
                                   </a>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -184,7 +184,7 @@
                             @change="change"
                             item-key="id">
                             <template #item="{element}">
-                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[element].id)">
+                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && ( (layoutActive && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[element].id)) || !layoutActive)">
                                 <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName] && emptyComponents[profileName].includes(element) && !layoutActive )}]">
                                   <a href="#" @click.stop="jumpToElement(profileName, element)" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -34,7 +34,7 @@
       ...mapStores(useProfileStore,usePreferenceStore),
       // // gives read access to this.count and this.double
       ...mapState(useProfileStore, ['profilesLoaded','activeProfile', 'dataChanged','rtLookup', 'activeComponent', 'emptyComponents']),
-      ...mapState(usePreferenceStore, ['styleDefault', 'isEmptyComponent', 'layoutActive', 'layoutActiveFilter',]),
+      ...mapState(usePreferenceStore, ['styleDefault', 'isEmptyComponent', 'layoutActive', 'layoutActiveFilter', 'createLayoutMode']),
 
       ...mapWritableState(useProfileStore, ['activeComponent', 'emptyComponents']),
     },
@@ -182,7 +182,7 @@
                             @change="change"
                             item-key="id">
                             <template #item="{element}">
-                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && ( (layoutActive && layoutActiveFilter['properties'][profileName] && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[element].id)) || !layoutActive)">
+                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && ( (layoutActive && layoutActiveFilter['properties'][profileName] && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[element].id)) || !layoutActive || (createLayoutMode && layoutActive))">
                                 <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName] && emptyComponents[profileName].includes(element) && !layoutActive )}]">
                                   <a href="#" @click.stop="jumpToElement(profileName, element)" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -34,11 +34,9 @@
       ...mapStores(useProfileStore,usePreferenceStore),
       // // gives read access to this.count and this.double
       ...mapState(useProfileStore, ['profilesLoaded','activeProfile', 'dataChanged','rtLookup', 'activeComponent', 'emptyComponents']),
-      ...mapState(usePreferenceStore, ['styleDefault', 'isEmptyComponent']),
+      ...mapState(usePreferenceStore, ['styleDefault', 'isEmptyComponent', 'layoutActive', 'layoutActiveFilter',]),
 
       ...mapWritableState(useProfileStore, ['activeComponent', 'emptyComponents']),
-
-
     },
 
 
@@ -186,8 +184,8 @@
                             @change="change"
                             item-key="id">
                             <template #item="{element}">
-                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI)">
-                                <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName] && emptyComponents[profileName].includes(element) )}]">
+                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[element].id)">
+                                <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName] && emptyComponents[profileName].includes(element) && !layoutActive )}]">
                                   <a href="#" @click.stop="jumpToElement(profileName, element)" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
                                       <span v-if="activeProfile.rt[profileName].pt[element].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'">

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -142,7 +142,6 @@
     <AccordionList  :open-multiple-items="false">
 
       <template v-for="profileName in activeProfile.rtOrder" :key="profileName">
-
       <!-- <div v-for="profileName in activeProfile.rtOrder" class="sidebar" :key="profileName"> -->
 
         <template v-if="activeProfile.rt[profileName].noData != true">
@@ -174,7 +173,6 @@
                   </template>
 
 
-
                   <ul class="sidebar-property-ul" role="list">
                           <draggable
                             v-model="activeProfile.rt[profileName].ptOrder"
@@ -184,7 +182,7 @@
                             @change="change"
                             item-key="id">
                             <template #item="{element}">
-                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && ( (layoutActive && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[element].id)) || !layoutActive)">
+                              <template v-if="!activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && ( (layoutActive && layoutActiveFilter['properties'][profileName] && layoutActiveFilter['properties'][profileName].includes(activeProfile.rt[profileName].pt[element].id)) || !layoutActive)">
                                 <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName] && emptyComponents[profileName].includes(element) && !layoutActive )}]">
                                   <a href="#" @click.stop="jumpToElement(profileName, element)" class="sidebar-property-ul-alink">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
@@ -192,7 +190,7 @@
                                         [SH]: {{ returnSubjectHeadingLabel(activeProfile.rt[profileName].pt[element]) }}
                                       </span>
                                       <span v-else>
-                                        {{activeProfile.rt[profileName].pt[element].propertyLabel}}
+                                        {{activeProfile.rt[profileName].pt[element].propertyLabel}}?!?!
                                       </span>
 
                                   </a>

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -234,10 +234,10 @@ export const useConfigStore = defineStore('config', {
         label: "Titles",
         properties: {
             "lc:RT:bf2:Monograph:Work": [
-                "http://id.loc.gov/ontologies/bibframe/title"
+              "id_loc_gov_ontologies_bibframe_title__title_information"
             ],
             "lc:RT:bf2:Monograph:Instance": [
-                "http://id.loc.gov/ontologies/bibframe/title"
+              "id_loc_gov_ontologies_bibframe_title__title_information"
             ]
         }
       },
@@ -245,7 +245,10 @@ export const useConfigStore = defineStore('config', {
         profileId: "Monograph",
         label: "Contributors",
         properties: {
-          "lc:RT:bf2:Monograph:Work": ["http://id.loc.gov/ontologies/bibframe/contribution"]
+          "lc:RT:bf2:Monograph:Work": [
+            "id_loc_gov_ontologies_bibframe_contribution__creator_of_work",
+            "id_loc_gov_ontologies_bibframe_contribution__contributors"
+          ]
         }
       },
       subjects: {
@@ -253,8 +256,8 @@ export const useConfigStore = defineStore('config', {
         label: "Subjects & Class",
         properties: {
           "lc:RT:bf2:Monograph:Work": [
-            "http://id.loc.gov/ontologies/bibframe/subject",
-            "http://id.loc.gov/ontologies/bibframe/classification",
+            "id_loc_gov_ontologies_bibframe_subject__subjects",
+            "id_loc_gov_ontologies_bibframe_classification__classification_numbers",
           ]
         }
       }

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -246,8 +246,6 @@ export const useConfigStore = defineStore('config', {
         properties: [
           "http://id.loc.gov/ontologies/bibframe/subject",
           "http://id.loc.gov/ontologies/bibframe/classification",
-
-
         ]
       }
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 20,
+    versionPatch: 21,
 
     regionUrls: {
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -230,23 +230,33 @@ export const useConfigStore = defineStore('config', {
   layouts: {
     all: {
       titles: {
+        profileId: "Monograph",
         label: "Titles",
-        properties: [
-          "http://id.loc.gov/ontologies/bibframe/title"
-        ]
+        properties: {
+            "lc:RT:bf2:Monograph:Work": [
+                "http://id.loc.gov/ontologies/bibframe/title"
+            ],
+            "lc:RT:bf2:Monograph:Instance": [
+                "http://id.loc.gov/ontologies/bibframe/title"
+            ]
+        }
       },
       contributors: {
+        profileId: "Monograph",
         label: "Contributors",
-        properties: [
-          "http://id.loc.gov/ontologies/bibframe/contribution"
-        ]
+        properties: {
+          "lc:RT:bf2:Monograph:Work": ["http://id.loc.gov/ontologies/bibframe/contribution"]
+        }
       },
       subjects: {
+        profileId: "Monograph",
         label: "Subjects & Class",
-        properties: [
-          "http://id.loc.gov/ontologies/bibframe/subject",
-          "http://id.loc.gov/ontologies/bibframe/classification",
-        ]
+        properties: {
+          "lc:RT:bf2:Monograph:Work": [
+            "http://id.loc.gov/ontologies/bibframe/subject",
+            "http://id.loc.gov/ontologies/bibframe/classification",
+          ]
+        }
       }
 
     }

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -862,10 +862,10 @@ export const usePreferenceStore = defineStore('preference', {
       },
 
       // Custom Layouts, isn't really a preference, but need to store it somewhere
-      '--b-scriptshifter-capitalize-first-letter' : {
+      '--l-custom-layouts' : {
         desc: '',
         descShort: '',
-        value: false,
+        value: {},
         type: 'object',
         group: 'layouts',
       },
@@ -1030,6 +1030,7 @@ export const usePreferenceStore = defineStore('preference', {
     * @return {string|number} - The value of the property
     */
     returnValue: function(propertyName,excludeUnitType){
+      console.info("Returning value for ", propertyName, "--", this.styleDefault[propertyName])
       if (!this.styleDefault[propertyName]){
         console.warn("Trying to return", propertyName, ' but does not exist.')
         return ""
@@ -1052,6 +1053,7 @@ export const usePreferenceStore = defineStore('preference', {
     * @return {boolean} - Did it work
     */
     setValue: function(propertyName,value){
+      console.info("setting value for ", propertyName, " to ", value)
       if (!this.styleDefault[propertyName]){
         return false
       }
@@ -1160,6 +1162,8 @@ export const usePreferenceStore = defineStore('preference', {
     },
 
     saveLayout: function(){
+      let currentLayouts = this.returnValue('--l-custom-layouts')
+      console.info(">>>>>>>>>>>>>>>>>", currentLayouts)
       let components = []
       let compontGuids = []
       let properties = []
@@ -1195,7 +1199,7 @@ export const usePreferenceStore = defineStore('preference', {
 
       console.info("components: ", components)
 
-      layout[layoutHash] = {
+      layout = {
         label: layoutName,
         properties: {}
       }
@@ -1204,22 +1208,21 @@ export const usePreferenceStore = defineStore('preference', {
         console.info("component: ", component)
         const parentId = component.parentId
         const propertyUri = component.propertyURI
-        if (Object.keys(layout[layoutHash].properties).includes(parentId)){
-          layout[layoutHash].properties[parentId].push(propertyUri)
+        if (Object.keys(layout.properties).includes(parentId)){
+          layout.properties[parentId].push(propertyUri)
         } else {
-          layout[layoutHash].properties[parentId] = [propertyUri]
+          layout.properties[parentId] = [propertyUri]
         }
       }
 
       console.info("layout: ", layout)
 
+      currentLayouts[layoutHash] = layout
 
-      return false
-      let name = prompt("Save layout as")
-      console.info("saving layout as ", name)
+      console.info("current layouts:", currentLayouts)
+      this.setValue('--l-custom-layouts', currentLayouts)
 
-
-
+      return false //true
     }
 
     /**

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -883,7 +883,7 @@ export const usePreferenceStore = defineStore('preference', {
       // Custom Layouts, isn't really a preference, but need to store it somewhere
       /**
        * The structure of a layout is
-       * hash: {  // hash is made from the `user's label + profileId`
+       * hash: {  // hash is made from the `user's label`
               "profileId": "Monograph",         // the id for the profile associated with the layout
               "label": "Monograph-Work-Title",  // user assigned lable
               "properties": {

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -3,7 +3,7 @@ import { useProfileStore } from './profile'
 import { getCurrentInstance } from 'vue'
 import diacrticsVoyagerMacroExpress from "@/lib/diacritics/diacritic_pack_voyager_macro_express.json"
 import diacrticsVoyagerNative from "@/lib/diacritics/diacritic_pack_voyager_native.json"
-
+import utilsProfile from '../lib/utils_profile'
 
 export const usePreferenceStore = defineStore('preference', {
   state: () => ({
@@ -1158,6 +1158,29 @@ export const usePreferenceStore = defineStore('preference', {
     toggleCopyMode: function(){
         this.copyMode = !this.copyMode
     },
+
+    saveLayout: function(){
+      let properties = []
+      console.info("profile: ", useProfileStore().activeProfile)
+      const profileId =  useProfileStore().activeProfile.id
+      console.info("profileId: ", profileId)
+
+      let copyTargets = document.querySelectorAll('input[class=layout-selection]:checked')
+      console.info("targets: ", copyTargets)
+      if (copyTargets.length == 0){
+        alert("No elements are selected for the profile. Select some and try again.")
+        return false
+      }
+      copyTargets.forEach((item) => properties.push(item.id))
+
+
+      return false
+      let name = prompt("Save layout as")
+      console.info("saving layout as ", name)
+
+
+
+    }
 
     /**
     * Take a url and rewrites it to match the url pattern of the current enviornment

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1210,10 +1210,13 @@ export const usePreferenceStore = defineStore('preference', {
         console.info("component: ", component)
         const parentId = component.parentId
         const propertyUri = component.propertyURI
+        const propertyId = component.id
         if (Object.keys(layout.properties).includes(parentId)){
-          layout.properties[parentId].push(propertyUri)
+          layout.properties[parentId].push(propertyId)
         } else {
-          layout.properties[parentId] = [propertyUri]
+          layout.properties[parentId] = [propertyId]
+          // this needed to be more granular(?) Adding "Note about the work" will also pick up "Language note"
+          // use the id
         }
       }
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1183,7 +1183,11 @@ export const usePreferenceStore = defineStore('preference', {
         return false
       }
 
-      let layoutName = prompt("Save layout as")
+      let currentName = ""
+      if (this.layoutActive){
+        currentName = this.layoutActiveFilter.label
+      }
+      let layoutName = prompt("Save layout as", currentName)
       console.info("Name: ", layoutName)
       if (layoutName == ""){
         alert("Layout name can't be empty.")
@@ -1227,7 +1231,7 @@ export const usePreferenceStore = defineStore('preference', {
       console.info("current layouts:", JSON.stringify(currentLayouts))
       this.setValue('--l-custom-layouts', currentLayouts)
 
-      return false //true
+      return layoutHash
     }
 
     /**

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1030,7 +1030,6 @@ export const usePreferenceStore = defineStore('preference', {
     * @return {string|number} - The value of the property
     */
     returnValue: function(propertyName,excludeUnitType){
-      console.info("Returning value for ", propertyName, "--", this.styleDefault[propertyName])
       if (!this.styleDefault[propertyName]){
         console.warn("Trying to return", propertyName, ' but does not exist.')
         return ""
@@ -1187,11 +1186,8 @@ export const usePreferenceStore = defineStore('preference', {
       }
 
       const hashCode = s => s.split('').reduce((a,b) => (((a << 5) - a) + b.charCodeAt(0))|0, 0)
-      let itemId
       let layoutHash = hashCode(layoutName)
-
       copyTargets.forEach((item) => compontGuids.push(item.id))
-
       for (const guid of compontGuids){
         let component = utilsProfile.returnPt(useProfileStore().activeProfile, guid)
         components.push(component)
@@ -1200,6 +1196,7 @@ export const usePreferenceStore = defineStore('preference', {
       console.info("components: ", components)
 
       layout = {
+        profileId: profileId,
         label: layoutName,
         properties: {}
       }
@@ -1219,7 +1216,7 @@ export const usePreferenceStore = defineStore('preference', {
 
       currentLayouts[layoutHash] = layout
 
-      console.info("current layouts:", currentLayouts)
+      console.info("current layouts:", JSON.stringify(currentLayouts))
       this.setValue('--l-custom-layouts', currentLayouts)
 
       return false //true

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1052,7 +1052,6 @@ export const usePreferenceStore = defineStore('preference', {
     * @return {boolean} - Did it work
     */
     setValue: function(propertyName,value){
-      console.info("setting value for ", propertyName, " to ", value)
       if (!this.styleDefault[propertyName]){
         return false
       }
@@ -1167,17 +1166,12 @@ export const usePreferenceStore = defineStore('preference', {
 
     saveLayout: function(){
       let currentLayouts = this.returnValue('--l-custom-layouts')
-      console.info(">>>>>>>>>>>>>>>>>", currentLayouts)
       let components = []
       let compontGuids = []
-      let properties = []
       let layout = {}
-      console.info("profile: ", useProfileStore().activeProfile)
       const profileId =  useProfileStore().activeProfile.id
-      console.info("profileId: ", profileId)
 
       let copyTargets = document.querySelectorAll('input[class=layout-selection]:checked')
-      console.info("targets: ", copyTargets)
       if (copyTargets.length == 0){
         alert("No elements are selected for the layout. Select some and try again.")
         return false
@@ -1189,7 +1183,6 @@ export const usePreferenceStore = defineStore('preference', {
         currentName = this.layoutActiveFilter.label
       }
       let layoutName = prompt("Save layout as", currentName)
-      console.info("Name: ", layoutName)
       if (layoutName == ""){
         alert("Layout name can't be empty.")
         return false
@@ -1203,8 +1196,6 @@ export const usePreferenceStore = defineStore('preference', {
         components.push(component)
       }
 
-      console.info("components: ", components)
-
       layout = {
         profileId: profileId,
         label: layoutName,
@@ -1212,7 +1203,6 @@ export const usePreferenceStore = defineStore('preference', {
       }
 
       for (let component of components){
-        console.info("component: ", component)
         const parentId = component.parentId
         const propertyUri = component.propertyURI
         const propertyId = component.id

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1162,6 +1162,7 @@ export const usePreferenceStore = defineStore('preference', {
     deleteLayout: function(target){
       let currentLayouts = this.returnValue('--l-custom-layouts')
       delete currentLayouts[target]
+      this.setValue('--l-custom-layouts', currentLayouts)
     },
 
     saveLayout: function(){

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -862,6 +862,21 @@ export const usePreferenceStore = defineStore('preference', {
       },
 
       // Custom Layouts, isn't really a preference, but need to store it somewhere
+      /**
+       * The structure of a layout is
+       * hash: {  // hash is made from the `user's label + profileId`
+              "profileId": "Monograph",         // the id for the profile associated with the layout
+              "label": "Monograph-Work-Title",  // user assigned lable
+              "properties": {
+                  "lc:RT:bf2:Monograph:Work": [ // ProfileName
+                      "id_loc_gov_ontologies_bibframe_contribution__creator_of_work" // property id
+                  ]
+              }
+          }
+       * This allows greater granularity in the layouts, but also means layouts will only work for the profile they are created with.
+       * Without this level of granuality, it's not possible to allows the user to differentiate between "Notes about the Work" & "Notes about the Instance."
+       * Additionally, using the `propertyId` instead of the `propertyURI` allows "Notes about the Work" to be different from "Language Note"
+       */
       '--l-custom-layouts' : {
         desc: '',
         descShort: '',

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -47,8 +47,9 @@ export const usePreferenceStore = defineStore('preference', {
     showTextMacroModal: false,
 
     layoutActive: false,
-
     layoutActiveFilter: null,
+    customLayouts: {},
+    createLayoutMode: false,
 
 
 
@@ -75,7 +76,6 @@ export const usePreferenceStore = defineStore('preference', {
 
 
       // the left properties panel
-
       '--c-edit-main-splitpane-properties-background-color' : {
           value:'#2a2a2a',
           desc: 'The background color of the properties side bar on the edit screen.',
@@ -102,7 +102,6 @@ export const usePreferenceStore = defineStore('preference', {
           group: 'Sidebars - Property',
           range: [5,100]
       },
-
       '--n-edit-main-splitpane-properties-font-size' : {
           desc: 'The fontsize of the text in the property list side bar.',
           descShort: 'Font Size',
@@ -121,7 +120,6 @@ export const usePreferenceStore = defineStore('preference', {
           group: 'Sidebars - Property',
           range: null
       },
-
       '--c-edit-main-splitpane-properties-font-color' : {
           value:'#fff',
           desc: 'The font color of the text in the property list.',
@@ -853,7 +851,6 @@ export const usePreferenceStore = defineStore('preference', {
     },
 
       // scriptshifter
-
       '--b-scriptshifter-capitalize-first-letter' : {
         desc: 'Capitalize the first letter of the transliterated string.',
         descShort: 'Capitalize the first letter',
@@ -862,6 +859,15 @@ export const usePreferenceStore = defineStore('preference', {
         unit: null,
         group: 'Scriptshifter',
         range: [true,false]
+      },
+
+      // Custom Layouts, isn't really a preference, but need to store it somewhere
+      '--b-scriptshifter-capitalize-first-letter' : {
+        desc: '',
+        descShort: '',
+        value: false,
+        type: 'object',
+        group: 'layouts',
       },
 
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1184,6 +1184,7 @@ export const usePreferenceStore = defineStore('preference', {
       }
 
       let currentName = ""
+      //prepopulate the prompt with the current layout name when editing
       if (this.layoutActive){
         currentName = this.layoutActiveFilter.label
       }
@@ -1220,17 +1221,13 @@ export const usePreferenceStore = defineStore('preference', {
         } else {
           layout.properties[parentId] = [propertyId]
           // this needed to be more granular(?) Adding "Note about the work" will also pick up "Language note"
-          // use the id
+          // if it uses the propertyURI
         }
       }
-
-      console.info("layout: ", layout)
-
       currentLayouts[layoutHash] = layout
-
-      console.info("current layouts:", JSON.stringify(currentLayouts))
       this.setValue('--l-custom-layouts', currentLayouts)
 
+      // return the layout hash value so we can correctly refresh the current layout when editing
       return layoutHash
     }
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1160,6 +1160,11 @@ export const usePreferenceStore = defineStore('preference', {
         this.copyMode = !this.copyMode
     },
 
+    deleteLayout: function(target){
+      let currentLayouts = this.returnValue('--l-custom-layouts')
+      delete currentLayouts[target]
+    },
+
     saveLayout: function(){
       let currentLayouts = this.returnValue('--l-custom-layouts')
       console.info(">>>>>>>>>>>>>>>>>", currentLayouts)

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1160,7 +1160,10 @@ export const usePreferenceStore = defineStore('preference', {
     },
 
     saveLayout: function(){
+      let components = []
+      let compontGuids = []
       let properties = []
+      let layout = {}
       console.info("profile: ", useProfileStore().activeProfile)
       const profileId =  useProfileStore().activeProfile.id
       console.info("profileId: ", profileId)
@@ -1168,10 +1171,47 @@ export const usePreferenceStore = defineStore('preference', {
       let copyTargets = document.querySelectorAll('input[class=layout-selection]:checked')
       console.info("targets: ", copyTargets)
       if (copyTargets.length == 0){
-        alert("No elements are selected for the profile. Select some and try again.")
+        alert("No elements are selected for the layout. Select some and try again.")
         return false
       }
-      copyTargets.forEach((item) => properties.push(item.id))
+
+      let layoutName = prompt("Save layout as")
+      console.info("Name: ", layoutName)
+      if (layoutName == ""){
+        alert("Layout name can't be empty.")
+        return false
+      }
+
+      const hashCode = s => s.split('').reduce((a,b) => (((a << 5) - a) + b.charCodeAt(0))|0, 0)
+      let itemId
+      let layoutHash = hashCode(layoutName)
+
+      copyTargets.forEach((item) => compontGuids.push(item.id))
+
+      for (const guid of compontGuids){
+        let component = utilsProfile.returnPt(useProfileStore().activeProfile, guid)
+        components.push(component)
+      }
+
+      console.info("components: ", components)
+
+      layout[layoutHash] = {
+        label: layoutName,
+        properties: {}
+      }
+
+      for (let component of components){
+        console.info("component: ", component)
+        const parentId = component.parentId
+        const propertyUri = component.propertyURI
+        if (Object.keys(layout[layoutHash].properties).includes(parentId)){
+          layout[layoutHash].properties[parentId].push(propertyUri)
+        } else {
+          layout[layoutHash].properties[parentId] = [propertyUri]
+        }
+      }
+
+      console.info("layout: ", layout)
 
 
       return false

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -357,8 +357,7 @@
 .edit-layout-opac,
 .edit-layout-xml,
 .edit-layout-marc {
-  opacity: 25%;
-  pointer-events: none;
+  opacity: 50%;
 }
 
 .edit-layout-main {

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -10,24 +10,22 @@
 
       <splitpanes>
         <pane  v-if="panelDisplay.properties"
-          :class="{'edit-main-splitpane-properties': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-properties-no-scrollbar')}"
+          :class="{'edit-main-splitpane-properties': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-properties-no-scrollbar'), 'edit-layout-properties':  createLayoutMode}"
           :size="preferenceStore.returnValue('--n-edit-main-splitpane-properties-width')"
           min-size="5">
           <Properties/>
 
         </pane>
 
-
         <template v-if="panelDisplay.dualEdit">
-
           <pane
-            :class="{'edit-main-splitpane-edit': true, 'edit-main-splitpane-edit-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-edit-no-scrollbar')}"
+            :class="{'edit-main-splitpane-edit': true, 'edit-main-splitpane-edit-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-edit-no-scrollbar'), 'edit-layout-main':  createLayoutMode}"
             :size="preferenceStore.returnValue('--n-edit-main-splitpane-edit-width')">
             <EditPanel :instanceMode="false" :dualEdit="true" />
           </pane>
 
           <pane
-            :class="{'edit-main-splitpane-edit': true, 'edit-main-splitpane-edit-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-edit-no-scrollbar')}"
+            :class="{'edit-main-splitpane-edit': true, 'edit-main-splitpane-edit-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-edit-no-scrollbar'), 'edit-layout-main':  createLayoutMode}"
             :size="preferenceStore.returnValue('--n-edit-main-splitpane-edit-width')">
             <EditPanel :instanceMode="true" :dualEdit="true"/>
           </pane>
@@ -39,7 +37,7 @@
         <template v-else>
 
             <pane
-              :class="{'edit-main-splitpane-edit': true, 'edit-main-splitpane-edit-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-edit-no-scrollbar')}"
+              :class="{'edit-main-splitpane-edit': true, 'edit-main-splitpane-edit-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-edit-no-scrollbar'), 'edit-layout-main':  createLayoutMode}"
               :size="preferenceStore.returnValue('--n-edit-main-splitpane-edit-width')">
 
               <EditPanel :key="test" :instanceMode="false" :dualEdit="false"/>
@@ -50,21 +48,21 @@
 
 
         <pane v-if="panelDisplay.opac"
-          :class="{'edit-main-splitpane-opac': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-opac-no-scrollbar')}"
+          :class="{'edit-main-splitpane-opac': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-opac-no-scrollbar'), 'edit-layout-opac':  createLayoutMode}"
           :size="preferenceStore.returnValue('--n-edit-main-splitpane-opac-width')"
         >
           <Opac/>
         </pane>
 
         <pane v-if="panelDisplay.xml"
-          :class="{'edit-main-splitpane-xml': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-opac-no-scrollbar')}"
+          :class="{'edit-main-splitpane-xml': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-opac-no-scrollbar'), 'edit-layout-xml':  createLayoutMode}"
           :size="preferenceStore.returnValue('--n-edit-main-splitpane-opac-width')"
         >
           <Xml/>
 
         </pane>
         <pane v-if="panelDisplay.marc"
-          :class="{'edit-main-splitpane-marc': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-opac-no-scrollbar')}"
+          :class="{'edit-main-splitpane-marc': true, 'edit-main-splitpane-no-scrollbar': preferenceStore.returnValue('--b-edit-main-splitpane-opac-no-scrollbar'), 'edit-layout-marc':  createLayoutMode}"
           :size="preferenceStore.returnValue('--n-edit-main-splitpane-opac-width')"
         >
           <Marc/>
@@ -135,11 +133,11 @@
       // ...
       // gives access to this.counterStore and this.userStore
       ...mapStores(usePreferenceStore,useProfileStore),
-      ...mapState(usePreferenceStore, ['styleDefault','panelDisplay']),
+      ...mapState(usePreferenceStore, ['styleDefault','panelDisplay', 'createLayoutMode']),
       ...mapState(useProfileStore, ['profilesLoaded','activeProfileSaved']),
 
 
-      ...mapWritableState(usePreferenceStore, ['showDebugModal']),
+      ...mapWritableState(usePreferenceStore, ['showDebugModal', 'createLayoutMode']),
 
       ...mapWritableState(useProfileStore, ['literalLangGuid','literalLangShow','activeProfile']),
 
@@ -180,7 +178,7 @@
 
       console.log("Mounted called", this.$route.params.action, this.$route.params.recordId )
       console.log(this.$route.params)
-      this.profileStore.resetLocalComponentCache()      
+      this.profileStore.resetLocalComponentCache()
       if (this.profilesLoaded && this.activeProfile){
 
         if (this.activeProfile.neweId){
@@ -198,7 +196,7 @@
       }
 
 
-      
+
 
 
 
@@ -354,8 +352,20 @@
     height: 0;
 }
 
+/* Layout Edit */
+.edit-layout-properties,
+.edit-layout-opac,
+.edit-layout-xml,
+.edit-layout-marc {
+  opacity: 25%;
+  pointer-events: none;
+}
 
-
+.edit-layout-main {
+  border: solid rgb(30, 231, 57) 5px;
+  border-radius: 10px;
+  padding: 2px;
+}
 
 
 


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-304

Adds the ability to create a custom Layout. Layouts are profile dependent. This overrides ad hoc mode. An empty component that is part of the layout will be displayed in the form.

The option to create a layout is at the top of the menu:
![image](https://github.com/user-attachments/assets/bfacf65c-ebf3-40b5-9928-dbbeeb540c2e)

Selecting the option will put a green border around the form and place a check box next to each component. Also, the `Layouts` button turns in `Save Layout` & `Cancel Layout`. The other panels become slightly opaque, but can still be interacted with.
![image](https://github.com/user-attachments/assets/5ee3fd97-f292-424b-9e58-16905aa0e508)

After select which fields and selection `Save Layout`, the user will be asked to give it a name. The new layout will appear at the bottom of the menu. The custom layouts have shortcuts.
![image](https://github.com/user-attachments/assets/7ea3529f-3b26-480c-afa5-3f717e576536)
A ✔️  means that the layout was created with the current profile. The ❌ means it was not and loading it will be empty. 

When a layout is loaded, `Create a layout` turns in to 2 options `Edit Layout` and `Delete Layout`, and the name of the current layout appears highlighted in green next to the menu option. Only the components that are part of the layout will appear in the 
will in the form and in the property panel. `Edit Layout` will open the same screen as `Create Layout` except the current components in that layout will be preselected. Saving something with the same name as another layout will cause the new layout to overwrite the existing one. `Delete Layout` will ask the user to confirm the deletion.
![image](https://github.com/user-attachments/assets/b4d0e714-8036-462b-8c2d-8f46ac7bb996)


### Notes about the structure of layout
The structure of a layout is
```json
       hash: {  // hash is made from the `user's label`
              "profileId": "Monograph",         // the id for the profile associated with the layout
              "label": "Monograph-Work-Title",  // user assigned label
              "properties": {
                  "lc:RT:bf2:Monograph:Work": [ // ProfileName
                      "id_loc_gov_ontologies_bibframe_contribution__creator_of_work" // property id
                  ]
              }
          }
```
This allows greater granularity in the layouts, but also means layouts will only work for the profile they are created with. Without this level of granuality, it's not possible to allows the user to differentiate between "Notes about the Work" & "Notes about the Instance. Additionally, using the `propertyId` instead of the `propertyURI` allows "Notes about the Work" to be different from "Language Note" and selected independently.

