### PR TITLE
[BFP-310] Expand Subject Results

### DIFF
--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -863,7 +863,7 @@
         let component = this.profileStore.returnStructureByComponentGuid(this.guid)
         let empty = this.profileStore.isEmptyComponent(component)
 
-        return empty
+        return empty && this.preferenceStore.returnValue('--c-general-ad-hoc') && component.mandatory != 'true'
       },
       // Hide empty element in ad hoc mode
       hideElement: function(){

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -111,7 +111,6 @@
 
                     <!-- LCSH -->
                     <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()>=3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
-                    <!-- <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="testClassFunction(this)" > -->
                       <span class="subject-results-heading">Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
@@ -837,33 +836,6 @@ computed: {
 
 },
 methods: {
-  testStyleFunction: function(){
-    let totalHeight = document.documentElement.clientHeight
-    let totalHeightUsed = 0
-    let numOverflows = 0
-
-    let subjectContainers = document.getElementsByClassName('subject-section')
-
-    for (let el of subjectContainers){
-      let overflow = this.hasOverFlow(el)
-      if (overflow){
-        numOverflows++
-      }
-      totalHeightUsed = totalHeightUsed + el.clientHeight
-    }
-
-    for (let el of subjectContainers){
-      let newHeight = (totalHeight - totalHeightUsed) / numOverflows
-      if (this.hasOverFlow(el)){
-        // el.style.maxHeight = newHeight + "px"
-        return newHeight + "px"
-      }
-    }
-  },
-
-  testClassFunction: function(){
-    return "test-class scrollable-subjects"
-  },
   hasOverFlow: function(element){
     let overflow = element.scrollHeight > element.clientHeight
     return overflow

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -110,7 +110,8 @@
                     </div>
 
                     <!-- LCSH -->
-                    <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                    <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()>=3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                    <!-- <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="testClassFunction(this)" > -->
                       <span class="subject-results-heading">Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
@@ -531,8 +532,6 @@
     font-weight: bold;
     color: green;
     font-size: larger;
-
-
   }
 
 
@@ -688,6 +687,7 @@ margin-top: 10px;
 }
 
 /* TODO: whats the best way to apply these so a section isn't smooshed down when there is only 1? */
+
 .small-container{
   height: 33%;
 }
@@ -695,7 +695,7 @@ margin-top: 10px;
   height: 50%;
 }
 .large-container{
-  height: 100px;
+  height: 90%;
 }
 
 /* document.documentElement.clientHeight */
@@ -707,6 +707,7 @@ margin-top: 10px;
   /* height: v-bind('returnBrowserHeight()'); */
   height: 100%;
 }
+
 
 /*
 .left-menu-list-item-has-data::before {
@@ -838,17 +839,46 @@ computed: {
 
 },
 methods: {
+  testStyleFunction: function(){
+    let totalHeight = document.documentElement.clientHeight
+    let totalHeightUsed = 0
+    let numOverflows = 0
 
+    let subjectContainers = document.getElementsByClassName('subject-section')
+
+    for (let el of subjectContainers){
+      let overflow = this.hasOverFlow(el)
+      if (overflow){
+        numOverflows++
+      }
+      totalHeightUsed = totalHeightUsed + el.clientHeight
+    }
+
+    for (let el of subjectContainers){
+      let newHeight = (totalHeight - totalHeightUsed) / numOverflows
+      if (this.hasOverFlow(el)){
+        // el.style.maxHeight = newHeight + "px"
+        return newHeight + "px"
+      }
+    }
+  },
+
+  testClassFunction: function(){
+    return "test-class scrollable-subjects"
+  },
+  hasOverFlow: function(element){
+    let overflow = element.scrollHeight > element.clientHeight
+    return overflow
+  },
   // Return the number of search results that are populated.
   // Used to determine how tall to make each set of search results
   numPopulatedResults: function(){
     let count = 0
     for (let key of Object.keys(this.searchResults)){
-      if (this.searchResults[key].length>1){
+      if (this.searchResults[key].length>=1){
         count++
       }
     }
-
     return count
   },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -686,8 +686,6 @@ margin-top: 10px;
   overflow-y: scroll;
 }
 
-/* TODO: whats the best way to apply these so a section isn't smooshed down when there is only 1? */
-
 .small-container{
   height: 33%;
 }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -16,7 +16,7 @@
     >
 
     <div ref="complexLookupModalContainer" class="complex-lookup-modal-container">
-      <div style="position: relative;">
+      <div style="position: relative" class="subject-container-outer">
           <div style="position:absolute; right:2em; top:  0.25em; z-index: 100;">
 			      <div class="menu-buttons">
 				    <button @click="closeEditor()">Close</button>
@@ -95,11 +95,11 @@
                 </div>
 
 
-                <div style="flex:1; align-self: flex-end;" :class="{'scroll-all':  preferenceStore.returnValue('--b-edit-complex-scroll-all') && !preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                <div style="flex:1; align-self: flex-end; height: 95%" :class="{'scroll-all':  preferenceStore.returnValue('--b-edit-complex-scroll-all') && !preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
 
                   <div v-if="activeSearch!==false">{{activeSearch}}</div>
-                  <div v-if="searchResults !== null">
-                    <div v-if="searchResults && searchResults.names.length>0 && !this.searching" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                  <div v-if="searchResults !== null" style="height: 95%">
+                    <div v-if="searchResults && searchResults.names.length>0 && !this.searching" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
                       <span class="subject-results-heading">LCNAF</span>
                       <div v-for="(name,idx) in searchResults.names" @click="selectContext((searchResults.names.length - idx)*-1)" @mouseover="loadContext((searchResults.names.length - idx)*-1)" :data-id="(searchResults.names.length - idx)*-1" :key="name.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1 ),'picked': (pickLookup[(searchResults.names.length - idx)*-1] && pickLookup[(searchResults.names.length - idx)*-1].picked)}]">
                         <span v-if="name.suggestLabel && name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
@@ -110,7 +110,7 @@
                     </div>
 
                     <!-- LCSH -->
-                    <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                    <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1 }">
                       <span class="subject-results-heading">Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
@@ -118,7 +118,7 @@
                       </div>
                     </div>
 
-                    <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                    <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
                       <span class="subject-results-heading">Simple</span>
                       <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
@@ -128,15 +128,16 @@
 
 
                     <!-- ChildrenSubjects -->
-                    <div v-if="searchResults && searchResults.subjectsChildrenComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
-                      <span class="subject-results-heading">CYAK</span>
+                    <div v-if="searchResults && searchResults.subjectsChildrenComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
+                      <span class="subject-results-heading">CYAK Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsChildrenComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
                         <span v-if="subjectC.collections"> {{ this.buildAddtionalInfo(subjectC.collections) }}</span>
                       </div>
                     </div>
 
-                  <div v-if="searchResults && searchResults.subjectsChildren.length>0">
+                  <div v-if="searchResults && searchResults.subjectsChildren.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
+                    <span class="subject-results-heading">CYAK Simple</span>
                       <div v-for="(subject,idx) in searchResults.subjectsChildren" @click="selectContext(searchResults.subjectsChildrenComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsChildrenComplex.length + idx)" :data-id="searchResults.subjectsChildrenComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsChildrenComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsChildrenComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsChildrenComplex.length + idx] && pickLookup[searchResults.subjectsChildrenComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
                         <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
@@ -392,7 +393,8 @@
     width: 99%;
     margin-left: auto;
     margin-right: auto;
-    height: 470px;
+    /* height: 470px; */
+    height: 90%;
   }
 
   .subject-editor-container-lowres{
@@ -406,7 +408,7 @@
 
   .subject-editor-container-left{
     display: flex;
-    height: 468px;
+    height: 95%;
     position: relative;
     overflow-y: hidden;
   }
@@ -426,7 +428,8 @@
     flex:1;
     align-self: flex-start;
     padding: 2em;
-    height: 503px;
+    /* height: 503px; */
+    height: 100%;
     overflow-y: scroll;
     background: whitesmoke;
   }
@@ -682,12 +685,27 @@ margin-top: 10px;
 
 .scrollable-subjects {
   overflow-y: scroll;
-  max-height: 150px;
 }
 
+/* TODO: whats the best way to apply these so a section isn't smooshed down when there is only 1? */
+.small-container{
+  height: 33%;
+}
+.medium-container{
+  height: 50%;
+}
+.large-container{
+  height: 100px;
+}
+
+/* document.documentElement.clientHeight */
 .scroll-all {
   overflow-y: scroll;
-  max-height: 450px;
+}
+
+.subject-container-outer{
+  /* height: v-bind('returnBrowserHeight()'); */
+  height: 100%;
 }
 
 /*
@@ -800,7 +818,6 @@ data: function() {
 
     nextInputIsVoyagerModeDiacritics: false,
 
-
     activeTypes: {
       'madsrdf:Topic': {label:'Topic / Heading ($a $x)', value:'madsrdf:Topic',selected:false},
       'madsrdf:GenreForm': {label:'Genre ($v)', value:'madsrdf:GenreForm',selected:false},
@@ -821,6 +838,19 @@ computed: {
 
 },
 methods: {
+
+  // Return the number of search results that are populated.
+  // Used to determine how tall to make each set of search results
+  numPopulatedResults: function(){
+    let count = 0
+    for (let key of Object.keys(this.searchResults)){
+      if (this.searchResults[key].length>1){
+        count++
+      }
+    }
+
+    return count
+  },
 
   //parse complex headings so we can have complete and broken up headings
   parseComplexSubject: async function(uri){
@@ -2643,8 +2673,8 @@ methods: {
   },
 
   cleanState: function(){
-	this.searchMode = "LCSHNAF"
-	this.components= []
+    this.searchMode = "LCSHNAF"
+    this.components= []
     this.lookup= {}
     this.searchResults= null
     this.activeSearch= false

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -99,7 +99,7 @@
 
                   <div v-if="activeSearch!==false">{{activeSearch}}</div>
                   <div v-if="searchResults !== null" style="height: 95%">
-                    <div v-if="searchResults && searchResults.names.length>0 && !this.searching" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
+                    <div v-if="searchResults && searchResults.names.length>0 && !this.searching" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">LCNAF</span>
                       <div v-for="(name,idx) in searchResults.names" @click="selectContext((searchResults.names.length - idx)*-1)" @mouseover="loadContext((searchResults.names.length - idx)*-1)" :data-id="(searchResults.names.length - idx)*-1" :key="name.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1 ),'picked': (pickLookup[(searchResults.names.length - idx)*-1] && pickLookup[(searchResults.names.length - idx)*-1].picked)}]">
                         <span v-if="name.suggestLabel && name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
@@ -110,7 +110,7 @@
                     </div>
 
                     <!-- LCSH -->
-                    <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1 }">
+                    <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
@@ -118,7 +118,7 @@
                       </div>
                     </div>
 
-                    <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
+                    <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">Simple</span>
                       <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
@@ -128,7 +128,7 @@
 
 
                     <!-- ChildrenSubjects -->
-                    <div v-if="searchResults && searchResults.subjectsChildrenComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
+                    <div v-if="searchResults && searchResults.subjectsChildrenComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">CYAK Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsChildrenComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
@@ -136,7 +136,7 @@
                       </div>
                     </div>
 
-                  <div v-if="searchResults && searchResults.subjectsChildren.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3, 'medium-container': this.numPopulatedResults()==2, 'large-container': this.numPopulatedResults()==1}">
+                  <div v-if="searchResults && searchResults.subjectsChildren.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                     <span class="subject-results-heading">CYAK Simple</span>
                       <div v-for="(subject,idx) in searchResults.subjectsChildren" @click="selectContext(searchResults.subjectsChildrenComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsChildrenComplex.length + idx)" :data-id="searchResults.subjectsChildrenComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsChildrenComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsChildrenComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsChildrenComplex.length + idx] && pickLookup[searchResults.subjectsChildrenComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1651,10 +1651,10 @@ methods: {
         out.push("(GnFrm)")
       } else if (collections.includes("GeographicSubdivisions")){
         out.push("(GeoSubDiv)")
-      } else if (collections.includes("Subdivisions")){
-        out.push("(SubDiv)")
       } else if (collections.includes("LCSH_Childrens")){
           out.push("(ChldSubj)")
+      } else if (collections.includes("Subdivisions")){
+        out.push("(SubDiv)")
       }
 
       // if (collections.includes("LCNAF")){

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -95,31 +95,31 @@
                 </div>
 
 
-                <div style="flex:1; align-self: flex-end;">
+                <div style="flex:1; align-self: flex-end;" :class="{'scroll-all':  preferenceStore.returnValue('--b-edit-complex-scroll-all') && !preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
 
                   <div v-if="activeSearch!==false">{{activeSearch}}</div>
                   <div v-if="searchResults !== null">
-                    <div v-if="searchResults && searchResults.names.length>0 && !this.searching">
-
+                    <div v-if="searchResults && searchResults.names.length>0 && !this.searching" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                      <span class="subject-results-heading">LCNAF</span>
                       <div v-for="(name,idx) in searchResults.names" @click="selectContext((searchResults.names.length - idx)*-1)" @mouseover="loadContext((searchResults.names.length - idx)*-1)" :data-id="(searchResults.names.length - idx)*-1" :key="name.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1 ),'picked': (pickLookup[(searchResults.names.length - idx)*-1] && pickLookup[(searchResults.names.length - idx)*-1].picked)}]">
-                          <span v-if="name.suggestLabel && name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
+                        <span v-if="name.suggestLabel && name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
                           <span v-else>{{name.suggestLabel}}</span>
                           <span> [LCNAF]</span>
                           <span v-if="name.collections"> {{ this.buildAddtionalInfo(name.collections) }}</span>
                         </div>
-                      <hr>
                     </div>
 
                     <!-- LCSH -->
-                    <div v-if="searchResults && searchResults.subjectsComplex.length>0">
+                    <div v-if="searchResults && searchResults.subjectsComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                      <span class="subject-results-heading">Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
                         <span v-if="subjectC.collections"> {{ this.buildAddtionalInfo(subjectC.collections) }}</span>
                       </div>
-                      <hr>
                     </div>
 
-                    <div v-if="searchResults && searchResults.subjectsSimple.length>0">
+                    <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                      <span class="subject-results-heading">Simple</span>
                       <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
                         <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
@@ -128,12 +128,12 @@
 
 
                     <!-- ChildrenSubjects -->
-                    <div v-if="searchResults && searchResults.subjectsChildrenComplex.length>0">
+                    <div v-if="searchResults && searchResults.subjectsChildrenComplex.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                      <span class="subject-results-heading">CYAK</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsChildrenComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
                         <span v-if="subjectC.collections"> {{ this.buildAddtionalInfo(subjectC.collections) }}</span>
                       </div>
-                      <hr>
                     </div>
 
                   <div v-if="searchResults && searchResults.subjectsChildren.length>0">
@@ -673,6 +673,21 @@ margin-top: 10px;
 	padding-top: 5px;
 	padding-left: 15px;
 	float: right;
+}
+
+.subject-section{
+  border-top: solid black;
+  border-bottom: solid-black;
+}
+
+.scrollable-subjects {
+  overflow-y: scroll;
+  max-height: 150px;
+}
+
+.scroll-all {
+  overflow-y: scroll;
+  max-height: 450px;
 }
 
 /*

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -226,7 +226,12 @@
 
       jumpToElement: function(profileName, elementName){
         //if it's hidden show it
-        let removed = this.profileStore.removeFromAdHocMode(profileName, elementName)
+        let removed
+        if (this.preferenceStore.returnValue('--c-general-ad-hoc')){
+          removed = this.profileStore.removeFromAdHocMode(profileName, elementName)
+        } else {
+          removed = true
+        }
         //jump to it
         if (removed){
           this.activeComponent = this.activeProfile.rt[profileName].pt[elementName]

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2198,10 +2198,10 @@ const utilsNetwork = {
 
 
       this.subjectSearchActive = true
-      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings'
+      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=30').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings'
       let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
-      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=20').replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
       let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2199,6 +2199,7 @@ const utilsNetwork = {
       const numResultsNames = usePreferenceStore().returnValue('--b-edit-complex-number-names')
       const numResultsComplex = usePreferenceStore().returnValue('--b-edit-complex-number-complex')
       const numResultsSimple = usePreferenceStore().returnValue('--b-edit-complex-number-simple')
+      const numResultsCyac = usePreferenceStore().returnValue('--b-edit-complex-number-cyac')
 
 
       this.subjectSearchActive = true
@@ -2218,8 +2219,8 @@ const utilsNetwork = {
       let hubsUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
       let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
 
-      let childrenSubject = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&-memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-      let childrenSubjectComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=ComplexType'
+      let childrenSubject = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&-memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+      let childrenSubjectComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&rdftype=ComplexType'
       let childrenSubjectSubdivision = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
       let searchValHierarchicalGeographic = searchVal.replaceAll('‑','-') //.split(' ').join('--')

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2225,7 +2225,7 @@ const utilsNetwork = {
 
       let searchValHierarchicalGeographic = searchVal.replaceAll('‑','-') //.split(' ').join('--')
 
-      let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>',searchValHierarchicalGeographic).replace('&count=25','&count=4').replace("<OFFSET>", "1")
+      let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>',searchValHierarchicalGeographic).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")
 
       if (mode == 'GEO'){
         subjectUrlHierarchicalGeographic = subjectUrlHierarchicalGeographic.replace('&count=4','&count=12').replace("<OFFSET>", "1")

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2196,13 +2196,17 @@ const utilsNetwork = {
         }
       }
 
+      const numResultsNames = usePreferenceStore().returnValue('--b-edit-complex-number-names')
+      const numResultsComplex = usePreferenceStore().returnValue('--b-edit-complex-number-complex')
+      const numResultsSimple = usePreferenceStore().returnValue('--b-edit-complex-number-simple')
+
 
       this.subjectSearchActive = true
-      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=30').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings'
+      let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsNames).replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings'
       let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
-      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count=20').replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
-      let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+      let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
+      let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
       let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
       let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 21,
+    versionPatch: 22,
 
     regionUrls: {
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -693,8 +693,8 @@ export const usePreferenceStore = defineStore('preference', {
         range: [true,false]
       },
       '--b-edit-complex-scroll-independently' : {
-        desc: 'Scroll the results of each section independently.',
-        descShort: 'Scroll by section',
+        desc: 'Scroll the results of each section independently (LCNAF, CYAC, Complex headings...).',
+        descShort: 'Scroll by Section',
         value: false,
         type: 'boolean',
         unit: null,
@@ -702,7 +702,7 @@ export const usePreferenceStore = defineStore('preference', {
         range: [true,false]
       },
       '--b-edit-complex-number-names' : {
-        desc: 'Set the number of names that will appear in the subject builder.',
+        desc: 'Set the number of names that will appear in the subject builder. More results might be slower.',
         descShort: 'Number of Names',
         value: 5,
         type: 'number',
@@ -711,7 +711,7 @@ export const usePreferenceStore = defineStore('preference', {
         step: 5,
       },
       '--b-edit-complex-number-complex' : {
-        desc: 'Set the number of complex headings that will appear in the subject builder.',
+        desc: 'Set the number of complex headings that will appear in the subject builder. More results might be slower.',
         descShort: 'Number of Complex Headings',
         value: 5,
         type: 'number',
@@ -720,7 +720,7 @@ export const usePreferenceStore = defineStore('preference', {
         step: 5,
       },
       '--b-edit-complex-number-simple' : {
-        desc: 'Set the number of simple headings that will appear in the subject builder.',
+        desc: 'Set the number of simple headings that will appear in the subject builder. More results might be slower.',
         descShort: 'Number of Simple Headings',
         value: 5,
         type: 'number',
@@ -729,8 +729,8 @@ export const usePreferenceStore = defineStore('preference', {
         step: 5,
       },
       '--b-edit-complex-number-cyac' : {
-        desc: "Set the number of Children's headings that will appear in the subject builder.",
-        descShort: 'Number of Cyac Headings',
+        desc: "Set the number of Children's headings that will appear in the subject builder. More results might be slower.",
+        descShort: 'Number of CYAC Headings',
         value: 5,
         type: 'number',
         group: 'Complex Lookup',

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -682,8 +682,52 @@ export const usePreferenceStore = defineStore('preference', {
         unit: null,
         group: 'Complex Lookup',
         range: [true,false]
-    },
-
+      },
+      '--b-edit-complex-scroll-all' : {
+        desc: 'Scroll all the results at the same time.',
+        descShort: 'Scroll All Results',
+        value: true,
+        type: 'boolean',
+        unit: null,
+        group: 'Complex Lookup',
+        range: [true,false]
+      },
+      '--b-edit-complex-scroll-independently' : {
+        desc: 'Scroll the results of each section independently.',
+        descShort: 'Scroll by section',
+        value: false,
+        type: 'boolean',
+        unit: null,
+        group: 'Complex Lookup',
+        range: [true,false]
+      },
+      '--b-edit-complex-number-names' : {
+        desc: 'Set the number of names that will appear in the subject builder.',
+        descShort: 'Number of Names',
+        value: 5,
+        type: 'number',
+        group: 'Complex Lookup',
+        range: [5, 100],
+        step: 5,
+      },
+      '--b-edit-complex-number-complex' : {
+        desc: 'Set the number of complex headings that will appear in the subject builder.',
+        descShort: 'Number of Complex Headings',
+        value: 5,
+        type: 'number',
+        group: 'Complex Lookup',
+        range: [5, 100],
+        step: 5,
+      },
+      '--b-edit-complex-number-simple' : {
+        desc: 'Set the number of simple headings that will appear in the subject builder.',
+        descShort: 'Number of Simple Headings',
+        value: 5,
+        type: 'number',
+        group: 'Complex Lookup',
+        range: [5, 100],
+        step: 5,
+      },
 
       //general
       '--c-general-icon-instance-color' : {

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -728,6 +728,15 @@ export const usePreferenceStore = defineStore('preference', {
         range: [5, 100],
         step: 5,
       },
+      '--b-edit-complex-number-cyac' : {
+        desc: "Set the number of Children's headings that will appear in the subject builder.",
+        descShort: 'Number of Cyac Headings',
+        value: 5,
+        type: 'number',
+        group: 'Complex Lookup',
+        range: [5, 100],
+        step: 5,
+      },
 
       //general
       '--c-general-icon-instance-color' : {


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-310

This adds a few preferences to allow a cataloger to set how many results they want for a few different searches. Minimum is 5 with a max of 100, step 5.

![image](https://github.com/user-attachments/assets/b8a5da7c-4fdd-43d5-bddc-3ec4fbc309c2)
 
There are two options for scrolling. Either all the results at once:
![image](https://github.com/user-attachments/assets/64fa8577-69d6-4365-9483-ac45d8d23b12)

Or the sections independently:
![image](https://github.com/user-attachments/assets/8308c3cd-76c3-4d4a-af06-4723c6eab7cb)


There's also an update to the CSS to get subject build modal to better fit the entire window instead of being limited. There are headings above each section (LCNAF, Complex, Simple...) and stronger borders between the sections.

![image](https://github.com/user-attachments/assets/b04db1d9-3c04-4b80-ad16-45285ffa9abe)
