### PR TITLE
Fix marc subject bug

### DIFF
--- a/src/lib/utils_rdf.js
+++ b/src/lib/utils_rdf.js
@@ -64,7 +64,7 @@ const utilsRDF = {
   * @return {bolean}
   */
   isUriALiteral: function(URI){
-      if (this.LITERAL_TYPES.map((v) => {return v.toLowerCase()}).indexOf(URI.toLowerCase()) > -1){
+      if (URI && this.LITERAL_TYPES.map((v) => {return v.toLowerCase()}).indexOf(URI.toLowerCase()) > -1){
           return true
       }
       return false
@@ -82,7 +82,7 @@ const utilsRDF = {
       // grab the rtLookup from the profile store
       if (!rtLookup){
         rtLookup= useProfileStore().rtLookup
-      } 
+      }
 
       // if the component itself has it set then just return it we dont need to dig around
       if (propertyURI == pt.propertyURI){
@@ -129,7 +129,7 @@ const utilsRDF = {
           if (!pt.userValue[pt.propertyURI]){
               lookForResourceURI = true
           }else{
-              if (pt.userValue[pt.propertyURI] && pt.userValue[pt.propertyURI][0]){                  
+              if (pt.userValue[pt.propertyURI] && pt.userValue[pt.propertyURI][0]){
                   if (!pt.userValue[pt.propertyURI][0]['@type']){
                       lookForResourceURI = true
                   }
@@ -152,14 +152,14 @@ const utilsRDF = {
           }
       }
 
-      
+
       return false
 
   },
 
   /**
-  * 
-  * 
+  *
+  *
   * @param {string} propertyURI - the string URI to test
   * @param {obj} pt - the pt template from the profile
   * @return {string} URI - the uri of the type
@@ -169,7 +169,7 @@ const utilsRDF = {
       // grab the rtLookup from the profile store
       if (!rtLookup){
         rtLookup= useProfileStore().rtLookup
-      } 
+      }
       // only do this on templates that have one reference templates for now (may need to expand)
       if (pt.valueConstraint && pt.valueConstraint.valueTemplateRefs && pt.valueConstraint.valueTemplateRefs.length==1){
         let valueTemplateRef = pt.valueConstraint.valueTemplateRefs[0]
@@ -195,7 +195,7 @@ const utilsRDF = {
       // grab the rtLookup from the profile store
       if (!rtLookup){
         rtLookup= useProfileStore().rtLookup
-      } 
+      }
 
       let template = rtLookup[valueTemplateRef]
       let foundProperty = null
@@ -255,7 +255,7 @@ const utilsRDF = {
       return 'http://www.w3.org/2000/01/rdf-schema#Resource'
     }
 
-    
+
 
 
     // at this point we have a well cached lookup of the whole onotlogy in localstorage
@@ -275,7 +275,7 @@ const utilsRDF = {
       // check if it has a rdfs:subPropertyOf, if it does then we can ask for that
       let subPropertyOf = prop.getElementsByTagName("rdfs:subPropertyOf")
       if (subPropertyOf.length>0){
-        if (subPropertyOf[0].attributes['rdf:resource']){          
+        if (subPropertyOf[0].attributes['rdf:resource']){
           let subPropertyResult = await this.suggestTypeNetwork(subPropertyOf[0].attributes['rdf:resource'].value)
           if (subPropertyResult){
             return subPropertyResult

--- a/src/lib/utils_rdf.js
+++ b/src/lib/utils_rdf.js
@@ -64,7 +64,7 @@ const utilsRDF = {
   * @return {bolean}
   */
   isUriALiteral: function(URI){
-      if (URI && this.LITERAL_TYPES.map((v) => {return v.toLowerCase()}).indexOf(URI.toLowerCase()) > -1){
+      if (this.LITERAL_TYPES.map((v) => {return v.toLowerCase()}).indexOf(URI.toLowerCase()) > -1){
           return true
       }
       return false
@@ -78,7 +78,6 @@ const utilsRDF = {
   * @return {string} URI - the uri of the type
   */
   suggestTypeProfile: function(propertyURI,pt){
-
       // grab the rtLookup from the profile store
       if (!rtLookup){
         rtLookup= useProfileStore().rtLookup
@@ -149,6 +148,8 @@ const utilsRDF = {
                       console.warn("Did not find the requested template name", rtKey)
                   }
               }
+          }else if (!lookForResourceURI && pt.userValue[pt.propertyURI][0]['@type']){
+            return pt.userValue[pt.propertyURI][0]['@type']
           }
       }
 
@@ -234,7 +235,6 @@ const utilsRDF = {
   * @return {string|boolean} URI - the uri of the type or false
   */
   suggestTypeNetwork: async function(propertyURI){
-
     let result = false
 
     // some very common hardcoded options

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 27,
+    versionPatch: 28,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -249,7 +249,7 @@ export const useProfileStore = defineStore('profile', {
 
       }
 
-      // now go through and see if there are the the same group being used in multiple profiles if so 
+      // now go through and see if there are the the same group being used in multiple profiles if so
       // that means they have cross profile components (2 fields in Work 1 in instance for exmaple)
 
 
@@ -268,7 +268,7 @@ export const useProfileStore = defineStore('profile', {
               }
             }
 
-          }          
+          }
         }
       }
 
@@ -285,7 +285,7 @@ export const useProfileStore = defineStore('profile', {
           groupsOrder: [],
           label: 'Multi',
           profileId: 'Multi'
-        } 
+        }
 
         for (let groupName of groupsToMerge){
 
@@ -320,7 +320,7 @@ export const useProfileStore = defineStore('profile', {
 
 
         results.push(multiProfile)
-        
+
 
 
       }


### PR DESCRIPTION
The issue would happen if you typed `|a` and paused before typing the string. The `|a` would populate the type, but there is no condition to return that previous set type in `suggestTypeProfile()`. The fix adds a check that if the type was previously set, it will be returned. Otherwise it would be `false` and cause an error when creating the XML.

![image](https://github.com/user-attachments/assets/22dbf20d-ac7c-48ac-b486-2e34f2dd1aae)
