### PR TITLE
Bfp 307 multiple non sort

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -33,7 +33,7 @@
 
   <template v-else>
     <div class="lookup-fake-input" v-if="showField" >
-      <div class="literal-holder" @click="focusClick(lValue)" v-for="lValue in literalValues">
+      <div class="literal-holder" @click="focusClick(lValue)" v-for="lValue in literalValues" @focusin="focused">
         <!-- <div>Literal ({{propertyPath.map((x)=>{return x.propertyURI}).join('>')}})</div> -->
         <div class="literal-field">
 
@@ -323,16 +323,16 @@ export default {
     },
 
     focused: function(){
-
-
-
+      console.info("focused")
       // set the state active field
       this.activeField = this.myGuid
 
       // if enabled show the action button
       if (this.preferenceStore.returnValue('--b-edit-general-action-button-display')){
+        console.info("set true")
         this.showActionButton=true
       }else{
+        console.info("set false")
         this.showActionButton=false
       }
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -323,16 +323,13 @@ export default {
     },
 
     focused: function(){
-      console.info("focused")
       // set the state active field
       this.activeField = this.myGuid
 
       // if enabled show the action button
       if (this.preferenceStore.returnValue('--b-edit-general-action-button-display')){
-        console.info("set true")
         this.showActionButton=true
       }else{
-        console.info("set false")
         this.showActionButton=false
       }
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -661,10 +661,6 @@ export default {
 
 
     actionButtonCommand: async function(cmd,options){
-
-
-
-
       if (cmd == 'addField'){
         this.profileStore.setValueLiteral(this.guid,short.generate(),this.propertyPath,"new value",null,true)
       }
@@ -706,22 +702,16 @@ export default {
           componentGuid: this.guid,
           values: this.profileStore.returnLiteralValueFromProfile(this.guid,this.propertyPath)
         }
-
-
         this.literalLangShow=true
-
-
       }
 
-
-      this.$refs['input_' + this.literalValues[0]['@guid']][0].focus()
-
-
-
+      try{
+        // this will fail when adding an additional literal and the current field is empty
+        this.$refs['input_' + this.literalValues[0]['@guid']][0].focus()
+      }catch(err){
+        console.error("Adding a field from an empty field: ", err)
+      }
     },
-
-
-
   },
   computed: {
     // other computed properties

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 30,
+    versionPatch: 31,
 
     regionUrls: {
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 31,
+    versionPatch: 32,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1824,6 +1824,7 @@ export const useProfileStore = defineStore('profile', {
         }
 
         // and now add in the literal value into the correct property
+        console.info("    setting value: ", value)
         blankNode[lastProperty] = value
         // for electronicLocators, update the ID, so the XML can get built correctly
         if (isLocator && Object.keys(blankNode).some((key) => key == "http://id.loc.gov/ontologies/bibframe/electronicLocator")){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1649,13 +1649,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
-      console.info("setValueLiteral")
-      console.info("componentGuid: ", componentGuid)
-      console.info("fieldGuid: ", fieldGuid)
-      console.info("propertyPath: ", propertyPath)
-      console.info("value: ", value)
-      console.info("lang: ", lang)
-      console.info("repeatedLiteral: ", repeatedLiteral)
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
 
@@ -1719,14 +1712,12 @@ export const useProfileStore = defineStore('profile', {
         // let blankNode = utilsProfile.returnGuidLocation(pt.userValue,fieldGuid)
 
         if (blankNode === false){
-          console.info("no blank node")
           // create the path to the blank node
           let buildBlankNodeResult
 
           let currentValueCount = utilsProfile.countValues(pt,propertyPath)
 
           if (currentValueCount === 0){
-            console.info("Populating the existing value")
             // this is the first value, we need to construct the hierarchy to the bnode
             buildBlankNodeResult = utilsProfile.buildBlanknode(pt,propertyPath, true)
 
@@ -1746,7 +1737,6 @@ export const useProfileStore = defineStore('profile', {
             // console.log(JSON.stringify(pt,null,2))
 
           }else{
-            console.info("Creating a new property")
             // there is already values here, so we need to insert a new value into the hiearchy
 
             let parent = utilsProfile.returnPropertyPathParent(pt,propertyPath)
@@ -1780,7 +1770,6 @@ export const useProfileStore = defineStore('profile', {
           // They used "Additional literal" on an empty field, add the new field
           // without this, the user needs to run the action twice to the the additional field
           if (currentValueCount === 0 && value=='new value'){
-            console.info("Creating a new property")
             // there is already values here, so we need to insert a new value into the hiearchy
 
             let parent = utilsProfile.returnPropertyPathParent(pt,propertyPath)
@@ -1824,7 +1813,6 @@ export const useProfileStore = defineStore('profile', {
         }
 
         // and now add in the literal value into the correct property
-        console.info("    setting value: ", value)
         blankNode[lastProperty] = value
         // for electronicLocators, update the ID, so the XML can get built correctly
         if (isLocator && Object.keys(blankNode).some((key) => key == "http://id.loc.gov/ontologies/bibframe/electronicLocator")){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1649,6 +1649,13 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
+      console.info("setValueLiteral")
+      console.info("componentGuid: ", componentGuid)
+      console.info("fieldGuid: ", fieldGuid)
+      console.info("propertyPath: ", propertyPath)
+      console.info("value: ", value)
+      console.info("lang: ", lang)
+      console.info("repeatedLiteral: ", repeatedLiteral)
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
 
@@ -1712,12 +1719,14 @@ export const useProfileStore = defineStore('profile', {
         // let blankNode = utilsProfile.returnGuidLocation(pt.userValue,fieldGuid)
 
         if (blankNode === false){
+          console.info("no blank node")
           // create the path to the blank node
           let buildBlankNodeResult
 
           let currentValueCount = utilsProfile.countValues(pt,propertyPath)
 
           if (currentValueCount === 0){
+            console.info("Populating the existing value")
             // this is the first value, we need to construct the hierarchy to the bnode
             buildBlankNodeResult = utilsProfile.buildBlanknode(pt,propertyPath, true)
 
@@ -1737,6 +1746,7 @@ export const useProfileStore = defineStore('profile', {
             // console.log(JSON.stringify(pt,null,2))
 
           }else{
+            console.info("Creating a new property")
             // there is already values here, so we need to insert a new value into the hiearchy
 
             let parent = utilsProfile.returnPropertyPathParent(pt,propertyPath)
@@ -1765,6 +1775,38 @@ export const useProfileStore = defineStore('profile', {
             blankNode[lastProperty] = true
             // console.log("--------pt 4------------")
             // console.log(JSON.stringify(pt,null,2))
+          }
+
+          // They used "Additional literal" on an empty field, add the new field
+          // without this, the user needs to run the action twice to the the additional field
+          if (currentValueCount === 0 && value=='new value'){
+            console.info("Creating a new property")
+            // there is already values here, so we need to insert a new value into the hiearchy
+
+            let parent = utilsProfile.returnPropertyPathParent(pt,propertyPath)
+
+            if (!parent){
+              console.error("Trying to add second literal, could not find the property path parent", pt)
+              return false
+            }
+
+            if (!parent[lastProperty]){
+              console.error('Trying to find the value of this literal, unable to:',componentGuid, fieldGuid, propertyPath, value, lang, pt)
+              return false
+            }
+            let newGuid = short.generate()
+
+            // make a place for it
+            parent[lastProperty].push(
+              {
+                '@guid': newGuid,
+              }
+            )
+
+            // get a link to it we'll edit it below
+            blankNode = utilsProfile.returnGuidLocation(pt.userValue,newGuid)
+            // set a temp value that will be over written below
+            blankNode[lastProperty] = true
           }
           // console.log("currentValueCount",currentValueCount)
         }


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-307

The change that made `non-sort character count` a drop down also made it so the action button wouldn't appear when the focus was on the field. This addresses that, so someone can add multiple's of this literal field.

This also fixes an issue when someone tries to add "Additional Literal" and the current field doesn't have a value. The user would need to select the action twice. The first time would populate the field with a placeholder, "new value," and the second would create the new field.