### PR TITLE
too much transparency

### DIFF
--- a/src/components/panels/edit/fields/Main.vue
+++ b/src/components/panels/edit/fields/Main.vue
@@ -239,11 +239,17 @@ export default {
         if (colors[id]['default']){
             return colors[id]['default']
           }
-      }
+      } 
 
       
+
       if (this.preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-color')){
-        return this.preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-color')
+        if (this.preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-color') == 'transparent'){
+          return 'white'
+        }else{
+          return this.preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-color')
+        }
+        
       }
 
 


### PR DESCRIPTION
It was too transparent, the base level if no settings are applied should be white.