### PR TITLE
check for owl:DatatypeProperty in type check

### DIFF
--- a/src/lib/utils_rdf.js
+++ b/src/lib/utils_rdf.js
@@ -263,6 +263,11 @@ const utilsRDF = {
     let range = prop.getElementsByTagName("rdfs:range")
 
     let objProp = prop.getElementsByTagName("owl:ObjectProperty")
+    let dataProp = prop.getElementsByTagName("owl:DatatypeProperty")
+
+    
+
+
 
 
     // console.log("propXml",propXml)
@@ -345,7 +350,14 @@ const utilsRDF = {
       result = 'http://www.w3.org/2000/01/rdf-schema#Resource'
 
     }
+    if (dataProp.length > 0){
+      // at least we know it is a literal
 
+      result = 'http://www.w3.org/2000/01/rdf-schema#Literal'
+
+    }
+
+    
 
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 36,
+    versionPatch: 37,
 
     regionUrls: {
 


### PR DESCRIPTION
Same issue as yesterday with the changes to the ontology definitions causing issue with marva's ability to decide what type to use, also check for owl:DatatypeProperty