### PR TITLE
Some fixes

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -29,11 +29,11 @@
                     <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Item</button>
                 </div>
           </template>
-            <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ))">
-                <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
+            <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ) )">
+              <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
                     :key="profileCompoent">
                   <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || (createLayoutMode && !layoutActive)) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
-                  <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted">
+                  <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted && !hideAdminField(activeProfile.rt[profileName].pt[profileCompoent], profileName)">
                     <template v-if="(createLayoutMode && layoutActive) || layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && includeInLayout(activeProfile.rt[profileName].pt[profileCompoent].id, layoutActiveFilter['properties'][profileName])) ">
 
                       <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
@@ -248,6 +248,11 @@
         isReadOnly: function(component){
 
           if (component.adminMetadataType && component.adminMetadataType == 'secondary'){
+            return true
+          }
+
+          if (component.propetyLabel == 'Local identifier'){
+            console.info("make readOnly")
             return true
           }
 

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -252,7 +252,6 @@
           }
 
           if (component.propetyLabel == 'Local identifier'){
-            console.info("make readOnly")
             return true
           }
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -905,9 +905,9 @@ fieldset{
   color: v-bind("preferenceStore.returnValue('--c-edit-main-literal-lang-label-font-color')");
 
 
-  
 
-  
+
+
 }
 
 .inline-mode-editable-span-input{
@@ -993,8 +993,8 @@ fieldset{
   z-index: 1;
   top: -4px;
   left: 2px;
- 
-  
+
+
 }
 
 
@@ -1012,7 +1012,7 @@ textarea{
   font-size: v-bind("preferenceStore.returnValue('--n-edit-main-literal-font-size')");
   color: v-bind("preferenceStore.returnValue('--c-edit-main-literal-font-color')");
 
-  
+
 
 
   height: 1.25em;
@@ -1023,7 +1023,7 @@ textarea{
 .lookup-fake-input{
   min-height: 2em;
   /* background-color: transparent; */
- 
+
 
 
 }
@@ -1078,7 +1078,7 @@ textarea:hover{
 }
 .component .lookup-fake-input{
   border-top:solid 1px v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-border-color')") !important;
-} 
+}
 
 
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -1,5 +1,4 @@
 <template>
-
   <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == true">
     <template v-if="inlineModeShouldDisplay">
 
@@ -756,6 +755,11 @@ export default {
         this.hasNoData=false
       }
 
+
+      // if (this.structure.propertyLabel == "Local identifier"){
+      //   console.info("make readOnly?")
+      //   this.readOnly = true
+      // }
 
       return values
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -34,8 +34,7 @@
     <div class="lookup-fake-input" v-if="showField" >
       <div class="literal-holder" @click="focusClick(lValue)" v-for="lValue in literalValues" @focusin="focused">
         <!-- <div>Literal ({{propertyPath.map((x)=>{return x.propertyURI}).join('>')}})</div> -->
-        <div class="literal-field">
-
+        <div :class="['literal-field', {'read-only': structure.propertyLabel=='Local identifier'}]">
 
           <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false">
             <div v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-show-field-labels')"  class="lookup-fake-input-label">{{structure.propertyLabel}}</div>
@@ -85,6 +84,7 @@
                   :ref="'input_' + lValue['@guid']"
                   :data-guid="lValue['@guid']"
                   :disabled="readOnly"
+                  :readonly="structure.propertyLabel=='Local identifier'"
                   ></textarea>
               </template>
 
@@ -220,6 +220,7 @@ import utilsNetwork from '@/lib/utils_network'
 
 
 import ActionButton from "@/components/panels/edit/fields/helpers/ActionButton.vue";
+import { readonly } from 'vue'
 
 export default {
   name: "Literal",
@@ -755,12 +756,6 @@ export default {
         this.hasNoData=false
       }
 
-
-      // if (this.structure.propertyLabel == "Local identifier"){
-      //   console.info("make readOnly?")
-      //   this.readOnly = true
-      // }
-
       return values
 
     },
@@ -1084,6 +1079,11 @@ textarea:hover{
   border-top:solid 1px v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-border-color')") !important;
 }
 
+.read-only,
+.read-only form textarea{
+  background: lightgray;
+  cursor: no-drop;
+}
 
 
 

--- a/src/components/panels/edit/fields/Main.vue
+++ b/src/components/panels/edit/fields/Main.vue
@@ -239,9 +239,9 @@ export default {
         if (colors[id]['default']){
             return colors[id]['default']
           }
-      } 
+      }
 
-      
+
 
       if (this.preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-color')){
         if (this.preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-color') == 'transparent'){
@@ -249,7 +249,7 @@ export default {
         }else{
           return this.preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-color')
         }
-        
+
       }
 
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -2,7 +2,6 @@
 
   <template  v-if="structure.valueConstraint.valueTemplateRefs.length > 1">
 
-
     <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == true">
       <select style="display: inline; width: 20px; border-color:whitesmoke; background-color: transparent;" @change="templateChange($event)">
           <option v-for="rt in allRtTemplate" :value="rt.id" :selected="(rt.id === thisRtTemplate.id)">{{rt.resourceLabel}}</option>

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -419,7 +419,6 @@
         if (this.structure.parentId.includes("lc:RT:bf2:SeriesHub")){
           return false
         }
-        console.info(">>>>", this.guid, "--", this.structure)
 
         //does this have defaults, or are the defaults higher up?
         let defaults = this.structure.valueConstraint.defaults
@@ -427,14 +426,12 @@
         if (defaults.length > 0){
           this.profileStore.insertDefaultValuesComponent(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'],this.structure)
         } else {
-          console.info
           // // look up one level & use the appropriate structure
           let parentStructure = this.profileStore.returnStructureByComponentGuid(this.guid)
           if (parentStructure.valueConstraint && parentStructure.valueConstraint.valueTemplateRefs && parentStructure.valueConstraint.valueTemplateRefs.length>0){
             for (let vRt of parentStructure.valueConstraint.valueTemplateRefs){
               if (vRt==this.structure.parentId && this.profileStore.rtLookup[vRt]){
                 for (let pt of this.profileStore.rtLookup[vRt].propertyTemplates){
-                  console.info(">>>> ", pt.propertyLabel, "--", pt)
                   if (pt.valueConstraint.defaults && pt.valueConstraint.defaults.length > 0){
                     let struct = this.profileStore.returnStructureByComponentGuid(this.guid)
                     // if (struct.parentId == this.structure.parentId){ // will this have unintended sideffects?

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -12,8 +12,8 @@
  -->
 
  <VMenu ref="action-button-menu" :triggers="useOpenModes" @show="shortCutPressed" v-model:shown="isMenuShown"  @hide="menuClosed">
-  
-  
+
+
     <button tabindex="-1" :id="`action-button-${fieldGuid}`" :class="{'action-button':true,'small-mode': small }"><span class="material-icons action-button-icon">{{preferenceStore.returnValue('--s-edit-general-action-button-icon')}}</span></button>
 
     <InstanceSelectionModal ref="instanceSelectionModal" :currentRt="currentRt" :instances="instances" v-model="displayInstanceSelectionModal" @hideInstanceSelectionModal="hideInstanceSelectionModal()" @emitSetInstance="setInstance"/>
@@ -289,7 +289,7 @@
         let btext = this.preferenceStore.returnValue('--c-edit-general-action-button-menu-button-text-color');
         let btsize = this.preferenceStore.returnValue('--n-edit-general-action-button-menu-button-text-size');
 
-        
+
         let style = `background-color: ${bback}; border: solid 1px ${bborder}; color: ${btext}; width:100%; font-size: ${btsize}`
 
 
@@ -419,31 +419,35 @@
         if (this.structure.parentId.includes("lc:RT:bf2:SeriesHub")){
           return false
         }
+
         //does this have defaults, or are the defaults higher up?
         let defaults = this.structure.valueConstraint.defaults
 
         if (defaults.length > 0){
           this.profileStore.insertDefaultValuesComponent(this.profileStore.returnStructureByComponentGuid(this.guid)['@guid'],this.structure)
         } else {
+          console.info
           // // look up one level & use the appropriate structure
           let parentStructure = this.profileStore.returnStructureByComponentGuid(this.guid)
           if (parentStructure.valueConstraint && parentStructure.valueConstraint.valueTemplateRefs && parentStructure.valueConstraint.valueTemplateRefs.length>0){
             for (let vRt of parentStructure.valueConstraint.valueTemplateRefs){
               if (vRt==this.structure.parentId && this.profileStore.rtLookup[vRt]){
                 for (let pt of this.profileStore.rtLookup[vRt].propertyTemplates){
+                  console.info(">>>> ", pt.propertyLabel, "--", pt)
                   if (pt.valueConstraint.defaults && pt.valueConstraint.defaults.length > 0){
                     let struct = this.profileStore.returnStructureByComponentGuid(this.guid)
                     // if (struct.parentId == this.structure.parentId){ // will this have unintended sideffects?
                     //   this.profileStore.insertDefaultValuesComponent(struct['@guid'], pt)
                     // }
-                    this.profileStore.insertDefaultValuesComponent(struct['@guid'], pt)
 
+                    this.profileStore.insertDefaultValuesComponent(struct['@guid'], pt)
                   }
                 }
               }
             }
           }
         }
+
         this.sendFocusHome()
       },
 
@@ -905,17 +909,17 @@
 
 <style scoped>
   .action-button-menu-background{
-    width: 250px;   
+    width: 250px;
 
-    
+
   }
 
   button{
     margin-bottom: 5px;
     position: relative;
-    
 
-    
+
+
   }
 
   hr{
@@ -951,7 +955,7 @@
       display: inline-flex;
       align-items: center;
   }
-/* 
+/*
   .action-button-list-container{
     position: absolute;
     z-index: 1000;

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -419,6 +419,7 @@
         if (this.structure.parentId.includes("lc:RT:bf2:SeriesHub")){
           return false
         }
+        console.info(">>>>", this.guid, "--", this.structure)
 
         //does this have defaults, or are the defaults higher up?
         let defaults = this.structure.valueConstraint.defaults

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -94,8 +94,8 @@
 
                 </div>
 
-                
-                
+
+
                 <div :style="`flex:1; align-self: flex-end; height: 95%; ${this.preferenceStore.styleModalBackgroundColor()}`" :class="{'scroll-all':  preferenceStore.returnValue('--b-edit-complex-scroll-all') && !preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
 
                   <div v-if="activeSearch!==false">{{activeSearch}}</div>
@@ -951,7 +951,7 @@ methods: {
             this.typeLookup[0] = 'madsrdf:GenreForm'
         }
         if (type.includes("http://www.loc.gov/mads/rdf/v1#Geographic" || type.includes("http://www.loc.gov/mads/rdf/v1#HierarchicalGeographic"))){
-            this.typeLookup[0] = 'madsrdf:Geographic'
+          this.typeLookup[0] = 'madsrdf:Geographic'
         }
         if (type.includes("http://www.loc.gov/mads/rdf/v1#Temporal")){
             this.typeLookup[0] = 'madsrdf:Temporal'
@@ -2325,24 +2325,26 @@ methods: {
         for (let x of this.components){
           if (this.localContextCache[x.uri]){
 
-
-            if (this.localContextCache[x.uri].nodeMap && this.localContextCache[x.uri].nodeMap['MADS Collection'] && this.localContextCache[x.uri].nodeMap['MADS Collection'].includes('GeographicSubdivisions')){
-              x.type = 'madsrdf:Geographic'
-            }
-
-
-            if (this.localContextCache[x.uri].type === 'GenreForm'){
-              x.type = 'madsrdf:GenreForm'
-            } else if (this.localContextCache[x.uri].type === 'Temporal'){
-              x.type = 'madsrdf:Temporal'
-            } else if (this.localContextCache[x.uri].type === 'Geographic'){
-              x.type = 'madsrdf:Geographic'
-            } else if (this.localContextCache[x.uri].type === 'Topic'){
-              x.type = 'madsrdf:Topic'
+            if (this.activeComponent.type){
+              // don't do anything
             } else {
-                x.type = 'madsrdf:Topic'
-            }
+              if (this.localContextCache[x.uri].nodeMap && this.localContextCache[x.uri].nodeMap['MADS Collection'] && this.localContextCache[x.uri].nodeMap['MADS Collection'].includes('GeographicSubdivisions')){
+                x.type = 'madsrdf:Geographic'
+              }
 
+
+              if (this.localContextCache[x.uri].type === 'GenreForm'){
+                x.type = 'madsrdf:GenreForm'
+              } else if (this.localContextCache[x.uri].type === 'Temporal'){
+                x.type = 'madsrdf:Temporal'
+              } else if (this.localContextCache[x.uri].type === 'Geographic'){
+                x.type = 'madsrdf:Geographic'
+              } else if (this.localContextCache[x.uri].type === 'Topic'){
+                x.type = 'madsrdf:Topic'
+              } else {
+                  x.type = 'madsrdf:Topic'
+              }
+            }
           }
 
         }
@@ -2474,7 +2476,10 @@ methods: {
       // if so over write the user defined type with the full type from the authority file so that
       // something like a name becomes a madsrdf:PersonalName instead of madsrdf:Topic
       if (c.uri && c.uri.includes('id.loc.gov/authorities/names/') && this.localContextCache && this.localContextCache[c.uri]){
-        c.type = this.localContextCache[c.uri].typeFull.replace('http://www.loc.gov/mads/rdf/v1#','madsrdf:')
+        let tempType = this.localContextCache[c.uri].typeFull.replace('http://www.loc.gov/mads/rdf/v1#','madsrdf:')
+        if (!Object.keys(this.activeTypes).includes(tempType)){
+          c.type = tempType
+        }
       }
     }
 
@@ -2559,7 +2564,7 @@ methods: {
 					  subfield = subfield[idx]
 				  }
 
-				  switch(subfield){
+				switch(subfield){
 					case("$a"):
 					  subfield = "madsrdf:Topic"
 					  break

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -800,7 +800,6 @@
         for (let rt in this.activeProfile.rt){
           for (let pt in this.activeProfile.rt[rt].pt){
             let component = this.activeProfile.rt[rt].pt[pt]
-            console.info("\n\n", component.propertyLabel,": ", component)
             if ( component.valueConstraint.defaults.length > 0){
               // top level component
               this.profileStore.insertDefaultValuesComponent(component['@guid'], component)
@@ -808,19 +807,10 @@
             }
             //go deeper
             let parentStructure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
-            console.info("parentStructure: ", parentStructure)
             for (let vRt of component.valueConstraint.valueTemplateRefs){
-              console.info("vRt: ", vRt)
-              console.info("component: ", component)
-              console.info("this.profileStore.rtLookup[vRt]: ", this.profileStore.rtLookup[vRt])
-
               for (let template of this.profileStore.rtLookup[vRt].propertyTemplates){
-                console.info("    template: ", template)
-                // if (vRt==template.parentId && this.profileStore.rtLookup[vRt]){
-                //TODO: how is preferenceId set, and why do all classification options have the same value after the pipe?
                 if (component.preferenceId.includes(vRt)){
                   if (template.valueConstraint.defaults && template.valueConstraint.defaults.length > 0){
-                    console.info("        Setting default: ", parentStructure, "--", template)
                     this.profileStore.insertDefaultValuesComponent(parentStructure['@guid'], template)
                   }
                 }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -208,6 +208,12 @@
                   this.profileStore.pasteSelected()
                 })
               }
+            },
+            { is: 'separator'},
+            {
+              text: 'Add All Defaults',
+              click: () => { this.addAllDefaults() },
+              icon: "clear_all"
             }
           ] }
           )
@@ -789,6 +795,29 @@
           }
         }
       },
+
+      addAllDefaults: function(){
+        for (let rt in this.activeProfile.rt){
+          for (let pt in this.activeProfile.rt[rt].pt){
+            let component = this.activeProfile.rt[rt].pt[pt]
+            let structure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
+            console.info("component: ", component)
+            if ( component.valueConstraint.defaults.length > 0){
+              // top level component
+              this.profileStore.insertDefaultValuesComponent(component['@guid'], structure)
+              continue
+            }
+            //go deeper
+            for (let vRt of component.valueConstraint.valueTemplateRefs){
+              for (let template of this.profileStore.rtLookup[vRt].propertyTemplates){
+                if (template.valueConstraint.defaults && template.valueConstraint.defaults.length > 0){
+                  this.profileStore.insertDefaultValuesComponent(structure['@guid'], template)
+                }
+              }
+            }
+          }
+        }
+      }
 
     },
 

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -799,19 +799,28 @@
       addAllDefaults: function(){
         for (let rt in this.activeProfile.rt){
           for (let pt in this.activeProfile.rt[rt].pt){
+            console.info("\n\n\n*************************************")
+            console.info(pt)
             let component = this.activeProfile.rt[rt].pt[pt]
+            let structure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
             if ( component.valueConstraint.defaults.length > 0){
               // top level component
-              this.profileStore.insertDefaultValuesComponent(component['@guid'], component)
-              continue
+              console.info("    pt: ", pt)
+              console.info("    component: ", JSON.parse(JSON.stringify(component)))
+              if (Object.keys(component.userValue).every(k => k.startsWith("@"))){ // it's empty
+                this.profileStore.insertDefaultValuesComponent(component['@guid'], structure)
+                continue
+              }
             }
             //go deeper
-            let parentStructure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
+            console.info("structure: ", structure)
+            console.info("component: ", component)
             for (let vRt of component.valueConstraint.valueTemplateRefs){
+              console.info("    vRt: ", vRt)
               for (let template of this.profileStore.rtLookup[vRt].propertyTemplates){
                 if (component.preferenceId.includes(vRt)){
                   if (template.valueConstraint.defaults && template.valueConstraint.defaults.length > 0){
-                    this.profileStore.insertDefaultValuesComponent(parentStructure['@guid'], template)
+                    this.profileStore.insertDefaultValuesComponent(structure['@guid'], template)
                   }
                 }
               }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -800,18 +800,29 @@
         for (let rt in this.activeProfile.rt){
           for (let pt in this.activeProfile.rt[rt].pt){
             let component = this.activeProfile.rt[rt].pt[pt]
-            let structure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
-            console.info("component: ", component)
+            console.info("\n\n", component.propertyLabel,": ", component)
             if ( component.valueConstraint.defaults.length > 0){
               // top level component
-              this.profileStore.insertDefaultValuesComponent(component['@guid'], structure)
+              this.profileStore.insertDefaultValuesComponent(component['@guid'], component)
               continue
             }
             //go deeper
+            let parentStructure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
+            console.info("parentStructure: ", parentStructure)
             for (let vRt of component.valueConstraint.valueTemplateRefs){
+              console.info("vRt: ", vRt)
+              console.info("component: ", component)
+              console.info("this.profileStore.rtLookup[vRt]: ", this.profileStore.rtLookup[vRt])
+
               for (let template of this.profileStore.rtLookup[vRt].propertyTemplates){
-                if (template.valueConstraint.defaults && template.valueConstraint.defaults.length > 0){
-                  this.profileStore.insertDefaultValuesComponent(structure['@guid'], template)
+                console.info("    template: ", template)
+                // if (vRt==template.parentId && this.profileStore.rtLookup[vRt]){
+                //TODO: how is preferenceId set, and why do all classification options have the same value after the pipe?
+                if (component.preferenceId.includes(vRt)){
+                  if (template.valueConstraint.defaults && template.valueConstraint.defaults.length > 0){
+                    console.info("        Setting default: ", parentStructure, "--", template)
+                    this.profileStore.insertDefaultValuesComponent(parentStructure['@guid'], template)
+                  }
                 }
               }
             }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -63,7 +63,7 @@
 
       ...mapStores(useProfileStore,usePreferenceStore),
 
-      ...mapState(useProfileStore, ['profilesLoaded','activeProfile','rtLookup', 'activeProfileSaved', 'isEmptyComponent']),
+      ...mapState(useProfileStore, ['profilesLoaded','activeProfile','rtLookup', 'activeProfileSaved', 'isEmptyComponent', 'activeProfilePosted']),
       ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay', 'customLayouts', 'createLayoutMode']),
       ...mapState(useConfigStore, ['layouts']),
       ...mapWritableState(usePreferenceStore, ['showLoginModal','showScriptshifterConfigModal','showDiacriticConfigModal','showTextMacroModal','layoutActiveFilter','layoutActive','showFieldColorsModal', 'customLayouts', 'createLayoutMode']),
@@ -293,7 +293,7 @@
               { text: 'Lookup Field', click: () => this.preferenceStore.togglePrefModal('Lookup Field')},
 
 
-              
+
               { text: 'Modals', click: () => this.preferenceStore.togglePrefModal('Modals')},
 
               { text: 'Complex Lookup', click: () => this.preferenceStore.togglePrefModal('Complex Lookup')},
@@ -478,8 +478,10 @@
                 this.$nextTick(()=>{
                   this.$refs.postmodal.post();
                   this.profileStore.saveRecord()
+                  this.activeProfilePosted = true
                 })
-              }
+              },
+              class: (this.activeProfilePosted) ? "record-posted" : "record-unposted",
             }
           )
 
@@ -816,8 +818,8 @@
       --bar-button-radius: 4px;
       --bar-button-hover-bkg: rgb(244, 241, 242);
 
-      
-      
+
+
       --bar-button-hover-bkg: rgb(244, 241, 242);
       --bar-button-active-color: rgb(26, 115, 232);
       --bar-button-active-bkg: rgb(232, 240, 254);
@@ -864,7 +866,7 @@
 
 
 
-    
+
 
     .nav-icon-color{
       fill: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-nav-font-color')") !important;
@@ -881,6 +883,9 @@
 
       position: absolute !important;
       right: 0;
+    }
+    .record-posted{
+      color: green !important;
     }
     .save-not-saved span{
       color: orangered !important;

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 40,
+    versionPatch: 41,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -369,7 +369,7 @@ export const useProfileStore = defineStore('profile', {
 
       let startingPointData;
 
-      
+
       try{
         let response = await fetch(config.returnUrls.starting);
         startingPointData =  await response.json()
@@ -379,7 +379,7 @@ export const useProfileStore = defineStore('profile', {
       }
 
 
-      
+
       // FLAG: NEEDS_PROFILE_ALIGNMENT
       // TEMP HACK ADD IN HUBS
 
@@ -3192,8 +3192,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {boolean}
     */
     returnLccInfo: function(componentGuid){
-
-
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
       let classNumber = null
@@ -3210,6 +3208,7 @@ export const useProfileStore = defineStore('profile', {
 
       // find the work and pull out stuff
       for (let rtId in this.activeProfile.rt){
+        let target = false
 
         if (rtId.indexOf(":Work") > -1){
           for (let ptId in this.activeProfile.rt[rtId].pt){
@@ -3223,9 +3222,7 @@ export const useProfileStore = defineStore('profile', {
       }
       // console.log("work",work)
       if (work){
-
-        for (let ptId in work.pt){
-
+        for (let ptId of work.ptOrder){
           let pt = work.pt[ptId]
 
           /*
@@ -3317,21 +3314,12 @@ export const useProfileStore = defineStore('profile', {
 
           if (pt.propertyURI=='http://id.loc.gov/ontologies/bibframe/subject' && firstSubject === null){
             let subjectUserValue = pt.userValue
-
             if (subjectUserValue && subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'] && subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'].length > 0 && subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0] && subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label']){
               if (subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'] && subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'].length>0 && subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'][0] && subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']){
-
                 firstSubject = subjectUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
-
-
               }
-
             }
-
           }
-
-
-
         }
       }
 
@@ -3583,18 +3571,17 @@ export const useProfileStore = defineStore('profile', {
     */
 
     makeSubjectHeadingPrimary: async function(componentGuid){
-
+      console.info("make primary: ", this.activeProfile)
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
       if (pt !== false){
-
-
 
         // loop through all the headings and find the place the headings start
         let firstHeading = null
         let workRtId = null
         for (let rtId in this.activeProfile.rt){
           if (rtId.indexOf(":Work") > -1){
+            console.info("starting order: ", JSON.parse(JSON.stringify(this.activeProfile.rt[rtId].ptOrder)))
             workRtId = rtId
             for (let ptId of this.activeProfile.rt[rtId].ptOrder){
               if (this.activeProfile.rt[rtId].pt[ptId].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'){
@@ -3616,13 +3603,11 @@ export const useProfileStore = defineStore('profile', {
           // insert where the first heading is
           this.activeProfile.rt[workRtId].ptOrder.splice(firstHeadingPos, 0, pt.id);
 
+          console.info("ending order: ", JSON.parse(JSON.stringify(this.activeProfile.rt[workRtId].ptOrder)))
+
           this.dataChanged()
         }
-
-
-
       }
-
     },
 
 
@@ -5030,7 +5015,7 @@ export const useProfileStore = defineStore('profile', {
             // we are adding a sigle one here so groups are individual (group of 1) in this case
             console.log("Adding thisone",group)
             let component = JSON.parse(JSON.stringify(group.structure))
-            
+
 
             // see if we can find its counter part in the acutal profile
             if (this.activeProfile.rt[component.parentId]){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -80,6 +80,7 @@ export const useProfileStore = defineStore('profile', {
     activeProfile: {},
 
     activeProfileSaved: true,
+    activeProfilePosted: false,
 
     showPostModal: false,
     showRecoveryModal: false,

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3674,8 +3674,6 @@ export const useProfileStore = defineStore('profile', {
     // locate the correct pt to work on in the activeProfile
     let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
-    console.info("------pt: ", pt)
-
     //Delete related items from the cache, loading from the cache
     // sometimes causes errors after inserting defaults
     if (Object.keys(cachePt).includes(componentGuid)){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3668,14 +3668,13 @@ export const useProfileStore = defineStore('profile', {
       */
 
   insertDefaultValuesComponent: async function(componentGuid, structure){
-    console.info("\n\n        insertDefaultValuesComponent")
-    console.info("        componentGuid: ", componentGuid)
-    console.info("        ", structure.propertyLabel ,": ", structure)
     // console.log(componentGuid)
     // console.log("structure",structure)
 
     // locate the correct pt to work on in the activeProfile
     let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
+
+    console.info("------pt: ", pt)
 
     //Delete related items from the cache, loading from the cache
     // sometimes causes errors after inserting defaults
@@ -3685,8 +3684,6 @@ export const useProfileStore = defineStore('profile', {
     for (let guid of Object.keys(cacheGuid)){
       cleanCacheGuid(cacheGuid,  JSON.parse(JSON.stringify(pt.userValue)), guid)
     }
-
-    console.info("        pt: ", JSON.parse(JSON.stringify(pt)))
 
     let isParentTop = false
 
@@ -3709,11 +3706,8 @@ export const useProfileStore = defineStore('profile', {
           if (this.rtLookup[structure.parentId]){
               for (let p of this.rtLookup[structure.parentId].propertyTemplates){
                 // dose it have a default value?
-                console.info("p: ", p)
                 if (p.valueConstraint.defaults && p.valueConstraint.defaults.length>0){
-                  console.info("    >0", p)
                   if (p.valueConstraint.valueTemplateRefs && p.valueConstraint.valueTemplateRefs.length>0){
-                    console.info("        >0", p)
                     // they are linking to another template in this template, so if we ant to populate the imformation we would need to know what predicate to use :(((((
                     if (this.rtLookup[p.valueConstraint.valueTemplateRefs[0]] && this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates && this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates.length==1){
                       let defaultPropertyToUse = this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates[0].propertyURI
@@ -3784,13 +3778,6 @@ export const useProfileStore = defineStore('profile', {
                           value['@type'] = blankNodeType
                         }
                       }
-                      console.info("***********************")
-                      console.info("isParentTop: ", isParentTop)
-                      console.info("p.propertyURI: ", p.propertyURI)
-                      console.info("baseURI: ", baseURI)
-                      console.info("value: ", value)
-                      console.info("pt: ", pt)
-                      console.info("p: ", p)
                       // if we're not working at the top level, just add the default values
                       if (!isParentTop){
                         userValue[p.propertyURI].push(value)
@@ -3824,7 +3811,6 @@ export const useProfileStore = defineStore('profile', {
     }else{
       console.error('insertDefaultValuesComponent: Cannot locate the component by guid', componentGuid, this.activeProfile)
     }
-    console.info("        final pt: ", JSON.parse(JSON.stringify(pt)))
   },
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3572,7 +3572,6 @@ export const useProfileStore = defineStore('profile', {
     */
 
     makeSubjectHeadingPrimary: async function(componentGuid){
-      console.info("make primary: ", this.activeProfile)
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
       if (pt !== false){
@@ -3582,7 +3581,6 @@ export const useProfileStore = defineStore('profile', {
         let workRtId = null
         for (let rtId in this.activeProfile.rt){
           if (rtId.indexOf(":Work") > -1){
-            console.info("starting order: ", JSON.parse(JSON.stringify(this.activeProfile.rt[rtId].ptOrder)))
             workRtId = rtId
             for (let ptId of this.activeProfile.rt[rtId].ptOrder){
               if (this.activeProfile.rt[rtId].pt[ptId].propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'){
@@ -3603,8 +3601,6 @@ export const useProfileStore = defineStore('profile', {
           this.activeProfile.rt[workRtId].ptOrder.splice(currentHeadingPos, 1);
           // insert where the first heading is
           this.activeProfile.rt[workRtId].ptOrder.splice(firstHeadingPos, 0, pt.id);
-
-          console.info("ending order: ", JSON.parse(JSON.stringify(this.activeProfile.rt[workRtId].ptOrder)))
 
           this.dataChanged()
         }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3668,6 +3668,9 @@ export const useProfileStore = defineStore('profile', {
       */
 
   insertDefaultValuesComponent: async function(componentGuid, structure){
+    console.info("\n\n        insertDefaultValuesComponent")
+    console.info("        componentGuid: ", componentGuid)
+    console.info("        ", structure.propertyLabel ,": ", structure)
     // console.log(componentGuid)
     // console.log("structure",structure)
 
@@ -3683,6 +3686,7 @@ export const useProfileStore = defineStore('profile', {
       cleanCacheGuid(cacheGuid,  JSON.parse(JSON.stringify(pt.userValue)), guid)
     }
 
+    console.info("        pt: ", JSON.parse(JSON.stringify(pt)))
 
     let isParentTop = false
 
@@ -3705,8 +3709,11 @@ export const useProfileStore = defineStore('profile', {
           if (this.rtLookup[structure.parentId]){
               for (let p of this.rtLookup[structure.parentId].propertyTemplates){
                 // dose it have a default value?
+                console.info("p: ", p)
                 if (p.valueConstraint.defaults && p.valueConstraint.defaults.length>0){
+                  console.info("    >0", p)
                   if (p.valueConstraint.valueTemplateRefs && p.valueConstraint.valueTemplateRefs.length>0){
+                    console.info("        >0", p)
                     // they are linking to another template in this template, so if we ant to populate the imformation we would need to know what predicate to use :(((((
                     if (this.rtLookup[p.valueConstraint.valueTemplateRefs[0]] && this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates && this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates.length==1){
                       let defaultPropertyToUse = this.rtLookup[p.valueConstraint.valueTemplateRefs[0]].propertyTemplates[0].propertyURI
@@ -3777,7 +3784,13 @@ export const useProfileStore = defineStore('profile', {
                           value['@type'] = blankNodeType
                         }
                       }
-
+                      console.info("***********************")
+                      console.info("isParentTop: ", isParentTop)
+                      console.info("p.propertyURI: ", p.propertyURI)
+                      console.info("baseURI: ", baseURI)
+                      console.info("value: ", value)
+                      console.info("pt: ", pt)
+                      console.info("p: ", p)
                       // if we're not working at the top level, just add the default values
                       if (!isParentTop){
                         userValue[p.propertyURI].push(value)
@@ -3787,36 +3800,7 @@ export const useProfileStore = defineStore('profile', {
                       }
                     }
                   }
-                } else {
-                  // check if the defaults are available in rtLookup
-                  let targetRef = p.valueConstraint.valueTemplateRefs[0]
-                  if (this.rtLookup[targetRef]){
-                    let defaultPropertyToUse = this.rtLookup[targetRef].propertyTemplates[0].propertyURI
-                    userValue[p.propertyURI] = []
-                    for (let d of this.rtLookup[targetRef].propertyTemplates[0].valueConstraint.defaults){
-                      let value = {
-                        '@guid': short.generate(d.defaultLiteral, d.defaultURI)
-                      }
-                      let useType = utilsRDF.suggestTypeProfile(p.propertyURI,pt)
-                      if (useType === false){
-                        // did not find it in the profile, look to the network
-                        useType = await utilsRDF.suggestTypeNetwork(p.propertyURI)
-                      }
-                      if (useType && useType != 'http://www.w3.org/2000/01/rdf-schema#Literal'){
-                        value['@type'] = useType
-                        value[defaultPropertyToUse] = [{
-                          '@guid': short.generate(d.defaultLiteral, d.defaultURI)
-                        }]
-                        if (d.defaultLiteral && d.defaultLiteral != ''){
-                          value[defaultPropertyToUse][0][defaultPropertyToUse] = this.replaceDefaultPlaceHolder(d.defaultLiteral)
-                        }
-                        if (d.defaultURI && d.defaultURI != ''){
-                          value['@id'] = d.defaultURI
-                        }
-                      }
-                      userValue[p.propertyURI].push(value)
-                    }
-                  }
+
                 }
               }
 
@@ -3840,6 +3824,7 @@ export const useProfileStore = defineStore('profile', {
     }else{
       console.error('insertDefaultValuesComponent: Cannot locate the component by guid', componentGuid, this.activeProfile)
     }
+    console.info("        final pt: ", JSON.parse(JSON.stringify(pt)))
   },
 
 


### PR DESCRIPTION
Some smaller fixes and adjustments

* [BFP-317](https://staff.loc.gov/tasks/browse/BFP-317) - Moving subjects wasn't updating the cutter tool
* [BFP-309](https://staff.loc.gov/tasks/browse/BFP-309) - Change the icon of the "Post" icon to green after using
* Small `AdminMetadata` fields were still showing in dual edit view
* [BFP-322](https://staff.loc.gov/tasks/browse/BFP-322) - Local identifier is `read-only`
* [BFP-297](https://staff.loc.gov/tasks/browse/BFP-297) - "Add All Defaults" under tools
* For subjects, don't overwrite the type set by the user...sometimes.