### PR TITLE
Add All Defaults Removes `Input Transcribed Series`

### DIFF
--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -542,6 +542,10 @@
       },
 
       hasDefaultValues: function(){
+        console.info(">>> ", this.structure)
+        if (this.structure.parentId.includes("lc:RT:bf2:SeriesHub")){
+          return false
+        }
         // if the selected item has defaults
         if (this.structure.valueConstraint.defaults.length > 0){
           return true

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -542,7 +542,6 @@
       },
 
       hasDefaultValues: function(){
-        console.info(">>> ", this.structure)
         if (this.structure.parentId.includes("lc:RT:bf2:SeriesHub")){
           return false
         }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -812,6 +812,8 @@
               //go deeper
               for (let vRt of component.valueConstraint.valueTemplateRefs){
                 for (let template of this.profileStore.rtLookup[vRt].propertyTemplates){
+                  console.info("structure: ", structure.propertyURI)
+                  console.info("vRt: ", vRt)
                   if (template.valueConstraint.defaults && template.valueConstraint.defaults.length > 0){
                     // for classifiction, we want to make sure we're only working on the currently selected template
                     if (structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/classification'){
@@ -861,7 +863,7 @@
                           this.profileStore.insertDefaultValuesComponent(structure['@guid'], template)
                         }
                       }
-                    }else {
+                    }else if (vRt != 'lc:RT:bf2:SeriesHub'){
                       this.profileStore.insertDefaultValuesComponent(structure['@guid'], template)
                     }
                   }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -812,8 +812,6 @@
               //go deeper
               for (let vRt of component.valueConstraint.valueTemplateRefs){
                 for (let template of this.profileStore.rtLookup[vRt].propertyTemplates){
-                  console.info("structure: ", structure.propertyURI)
-                  console.info("vRt: ", vRt)
                   if (template.valueConstraint.defaults && template.valueConstraint.defaults.length > 0){
                     // for classifiction, we want to make sure we're only working on the currently selected template
                     if (structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/classification'){
@@ -840,15 +838,11 @@
                         }
                       }
                     } else if (structure.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'){
-                      console.info(structure.propertyURI)
                       let selection = document.getElementById(structure['@guid']+'-select')
-                      console.info(selection)
                       let selected
                       let target
                       if (selection){
                         selected = selection.options[selection.selectedIndex].text
-                        console.info("selected: ", selected)
-                        console.info("vRt: ", vRt)
                         switch (selected){
                           case 'CYAC subject':
                             target = "lc:RT:bf2:Topic:Childrens:Components"

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 44,
+    versionPatch: 45,
 
     regionUrls: {
 


### PR DESCRIPTION
This will prevent data in `Input Transcribed Series` from being removed. It also will remove the option `Insert Default Values` from the action button for fields in this component. 

The complicated nesting that happens in the component means that XML doesn't get build right when `Insert Default Values`. Related ticket: https://staff.loc.gov/tasks/browse/BFP-289