### PR TITLE
Subject Exact Match

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -101,10 +101,12 @@
                   <div v-if="activeSearch!==false">{{activeSearch}}</div>
                   <div v-if="searchResults !== null" style="height: 95%">
 
-                    <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
-                      <span class="subject-results-heading">Exact</span>
-                      <div v-for="(subject,idx) in searchResults.exact" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != idx ), 'selected':(pickPostion == idx ), 'picked': (pickLookup[idx] && pickLookup[idx].picked) }]" >
+                    <div v-if="searchResults && searchResults.exact.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                      <span class="subject-results-heading">Exact Match</span>
+                      <div v-for="(subject,idx) in searchResults.exact" @click="selectContext((searchResults.names.length - idx)*-1-2)" @mouseover="loadContext((searchResults.names.length - idx)*-1-2)" :data-id="((searchResults.names.length - idx)*-1-2)" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1-2 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1-2 ), 'picked': (pickLookup[(searchResults.names.length - idx)*-1-2] && pickLookup[(searchResults.names.length - idx)*-1-2].picked) }]" >
                         {{subject.label}}
+                        <span v-if="subject.collections.includes('LCNAF')"> [LCNAF]</span>
+                        <span v-if="subject.collections"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
                       </div>
                     </div>
 
@@ -1472,6 +1474,10 @@ methods: {
       that.pickLookup[(that.searchResults.names.length - x)*-1] = that.searchResults.names[x]
     }
 
+    for (let x in that.searchResults.exact){
+      that.pickLookup[(that.searchResults.names.length - x)*-1-2] = that.searchResults.exact[x]
+    }
+
     for (let k in that.pickLookup){
       that.pickLookup[k].picked = false
       if (searchString.toLowerCase() == that.pickLookup[k].label.toLowerCase() && !that.pickLookup[k].literal ){
@@ -1822,6 +1828,9 @@ methods: {
 
 
   loadContext: async function(pickPostion){
+    console.info("loadContext: ", pickPostion)
+    console.info("this.pickLookup: ", this.pickLookup)
+    console.info("this.localContextCache: ", this.localContextCache)
     if (this.pickCurrent == null) {
       this.pickPostion = pickPostion
     } else {
@@ -1850,6 +1859,9 @@ methods: {
   },
 
   selectContext: async function(pickPostion, update=true){
+    console.info("selectContext: ", pickPostion)
+    console.info("this.pickLookup: ", this.pickLookup)
+    console.info("this.localContextCache: ", this.localContextCache)
     if (pickPostion != null){
       this.pickPostion=pickPostion
       this.pickCurrent=pickPostion

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -105,7 +105,7 @@
                       <span class="subject-results-heading">Exact Match</span>
                       <div v-for="(subject,idx) in searchResults.exact" @click="selectContext((searchResults.names.length - idx)*-1-2)" @mouseover="loadContext((searchResults.names.length - idx)*-1-2)" :data-id="((searchResults.names.length - idx)*-1-2)" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1-2 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1-2 ), 'picked': (pickLookup[(searchResults.names.length - idx)*-1-2] && pickLookup[(searchResults.names.length - idx)*-1-2].picked) }]" >
                         {{subject.label}}
-                        <span v-if="subject.collections.includes('LCNAF')"> [LCNAF]</span>
+                        <span v-if="subject.collections && subject.collections.includes('LCNAF')"> [LCNAF]</span>
                         <span v-if="subject.collections"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
                       </div>
                     </div>
@@ -1828,9 +1828,6 @@ methods: {
 
 
   loadContext: async function(pickPostion){
-    console.info("loadContext: ", pickPostion)
-    console.info("this.pickLookup: ", this.pickLookup)
-    console.info("this.localContextCache: ", this.localContextCache)
     if (this.pickCurrent == null) {
       this.pickPostion = pickPostion
     } else {
@@ -1859,9 +1856,6 @@ methods: {
   },
 
   selectContext: async function(pickPostion, update=true){
-    console.info("selectContext: ", pickPostion)
-    console.info("this.pickLookup: ", this.pickLookup)
-    console.info("this.localContextCache: ", this.localContextCache)
     if (pickPostion != null){
       this.pickPostion=pickPostion
       this.pickCurrent=pickPostion

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -100,6 +100,14 @@
 
                   <div v-if="activeSearch!==false">{{activeSearch}}</div>
                   <div v-if="searchResults !== null" style="height: 95%">
+
+                    <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
+                      <span class="subject-results-heading">Exact</span>
+                      <div v-for="(subject,idx) in searchResults.exact" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != idx ), 'selected':(pickPostion == idx ), 'picked': (pickLookup[idx] && pickLookup[idx].picked) }]" >
+                        {{subject.label}}
+                      </div>
+                    </div>
+
                     <div v-if="searchResults && searchResults.names.length>0 && !this.searching" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">LCNAF</span>
                       <div v-for="(name,idx) in searchResults.names" @click="selectContext((searchResults.names.length - idx)*-1)" @mouseover="loadContext((searchResults.names.length - idx)*-1)" :data-id="(searchResults.names.length - idx)*-1" :key="name.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1 ),'picked': (pickLookup[(searchResults.names.length - idx)*-1] && pickLookup[(searchResults.names.length - idx)*-1].picked)}]">

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1778,8 +1778,8 @@ const utilsNetwork = {
           // console.log("resultsSubjectsSimple",resultsSubjectsSimple)
 
           // there's an exact match on the Known-Label lookup
-          let exact = resultsExactSubject.concat(resultsExactName) // gives preference to Subjects
-          if (exact.length == 1){ // if there's only 1 exact match use it.
+          let exact = resultsExactSubject.concat(resultsExactName)
+          if (exact.length == 1){ // if there's only 1 exact match, use it.
             for (let r of exact){
               result.resultType = 'KNOWN-LABEL'
               if (!result.hit){ result.hit = [] }

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2251,7 +2251,7 @@ const utilsNetwork = {
       }
       let data = await this.fetchSimpleLookup(uri,true)
 
-      if (uri.indexOf('id.loc.gov')>-1){
+      if (data && uri.indexOf('id.loc.gov')>-1){
 
         for (let d of data){
           // loop through the graphs

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2113,7 +2113,6 @@ const utilsNetwork = {
 
 
       let marcKeyPromises = []
-
       // we want to double check the rdfType heading to make sure if we need to ask id to get more clarity about the rdfType
       if (Array.isArray(result.hit)){
         // it wont be an array if its a complex heading
@@ -2123,10 +2122,9 @@ const utilsNetwork = {
             if (responseUri){
               r.heading.rdfType = responseUri
             }
-
-            // also we need the MARCKeys
-            marcKeyPromises.push(this.returnMARCKey(r.uri + '.madsrdf_raw.jsonld'))
           }
+          // also we need the MARCKeys
+          marcKeyPromises.push(this.returnMARCKey(r.uri + '.madsrdf_raw.jsonld'))
         }
 
         let marcKeyPromisesResults = await Promise.all(marcKeyPromises);
@@ -2228,7 +2226,6 @@ const utilsNetwork = {
     * @return {string} - The URI of the likely MADSRDF rdf type
     */
     returnMARCKey: async function(uri){
-
       uri=uri.trim()
       let uriToLookFor = uri
 
@@ -2252,19 +2249,17 @@ const utilsNetwork = {
           uri=uri+'.json'
         }
       }
-
       let data = await this.fetchSimpleLookup(uri,true)
 
       if (uri.indexOf('id.loc.gov')>-1){
 
         for (let d of data){
-
           // loop through the graphs
           if (d && d['@id'] && d['@id'] == uriToLookFor){
             // this is the right graph
             if (d['http://id.loc.gov/ontologies/bflc/marcKey']){
               for (let marcKey of d['http://id.loc.gov/ontologies/bflc/marcKey']){
-                if (marcKey['@value']){
+                if (marcKey['@value'] && !marcKey['@language']){
                   return {marcKey: marcKey['@value'], uri: uriToLookFor}
                 }
               }

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2563,10 +2563,10 @@ const utilsNetwork = {
       console.info("subject: ", resultsExactSubject)
 
       if (resultsExactName){
-        resultsExactName.filter((term) => { Object.keys(term).includes("suggestLabel") })
+        resultsExactName = resultsExactName.filter((term) =>  Object.keys(term).includes("suggestLabel") )
       }
       if (resultsExactSubject){
-        resultsExactSubject.filter((term) => { Object.keys(term).includes("suggestLabel") })
+        resultsExactSubject = resultsExactSubject.filter((term) =>  Object.keys(term).includes("suggestLabel") )
       }
 
       let results = {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 45,
+    versionPatch: 46,
 
     regionUrls: {
 


### PR DESCRIPTION
Adds the `Known-Label` lookup into the searches to better support matching on exact terms. The lookup is performed against names and subjects, so there are occasion when there will be 2 'exact' matches

The terms do need to be _exact_. `library of congress` will match on a work, but won't surface the name authority. There's too many terms that start with "Library of Congress." `Library of Congress` will get a hit on the authorized form of the name.

This works in both the MARC entry and the builder. 
* MARC entry: if there's 1 exact match, that term will be used.
* Builder: has a section "Exact Match" at the top of the results that will show all exact matches and label them `(Auth Hd)` `[LCNAF]`

There's also some changes to getting the marcKey. It should only get the English marcKey and the MARC entry will get marcKeys for subjects, not just names.

This might be temporary. There might be a change to the `suggest2` that would give preference to exact matches. But for the time being there are terms that won't surface without this additional lookup.