### PR TITLE
Admin metadata comp lib fix local

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -800,7 +800,7 @@ export default {
       if (event.target.tagName === 'SPAN'){
         currentPos = this.getCaretCharOffset(event.target)
       }
-      console.log("3 v:",v)
+      // console.log("3 v:",v)
       await this.profileStore.setValueLiteral(this.guid,event.target.dataset.guid,this.propertyPath,v,useLang)
 
       if (setFocus){
@@ -831,7 +831,7 @@ export default {
       // it seems like when the content editable span is updated via the vue variable the cursor pos is lost
       // so reset it back to where it was before the content was updated
       if (event.target.tagName === 'SPAN'){
-        console.log(currentPos,addedTextMacroIncreasedSizeBy)
+        
         
         if (addedTextMacroIncreasedSizeBy>0){ 
           setCurrentCursorPosition(currentPos+addedTextMacroIncreasedSizeBy,event.target)

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -258,7 +258,7 @@ export default {
       if (this.readOnly && values.length==0){
         this.showField=false
       }
-      console.log("values",values)
+      
       return values
 
     },

--- a/src/components/panels/edit/modals/LiteralLang.vue
+++ b/src/components/panels/edit/modals/LiteralLang.vue
@@ -247,7 +247,7 @@
               <select @change="setLanguage($event,v)" :ref="v['@guid']+'-'+'lang'">
                 <option value="" :selected="(returnLangScript(v['@language']).lang === null)">Select Language</option>
                 <template v-for="l in languages">
-                  <option v-if="returnLangScript(v['@language']).lang.toLowerCase() == l.code.toLowerCase()"  :value="l.code" selected>{{ l.name }}</option>
+                  <option v-if="returnLangScript(v['@language']).lang && l.code && returnLangScript(v['@language']).lang.toLowerCase() == l.code.toLowerCase()"  :value="l.code" selected>{{ l.name }}</option>
                   <option v-else :value="l.code">{{ l.name }}</option>
                 </template>                   
               </select>
@@ -255,7 +255,7 @@
                 <option value="" :selected="(returnLangScript(v['@language']).script === null)">Select Script</option>
 
                 <template v-for="s in scripts">
-                  <option v-if="returnLangScript(v['@language']).script.toLowerCase() == s.code.toLowerCase()"  :value="s.code" selected>{{ s.name }}</option>
+                  <option v-if="returnLangScript(v['@language']).script && s.code && returnLangScript(v['@language']).script.toLowerCase() == s.code.toLowerCase()"  :value="s.code" selected>{{ s.name }}</option>
                   <option v-else :value="s.code">{{ s.name }}</option>
                 </template>                  
               </select>

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 51,
+    versionPatch: 52,
 
     regionUrls: {
 


### PR DESCRIPTION
When inserting an adminMetadata from component library it will correctly reuse the localId and 040 note from the adminMetaData being replaced.