### PR TITLE
Loosen logic for when to hide admin metadata

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -262,13 +262,7 @@
 
         isReadOnly: function(component){
 
-          let lotsOfFields = component.userValue["http://id.loc.gov/ontologies/bibframe/adminMetadata"] ? Object.keys(component.userValue["http://id.loc.gov/ontologies/bibframe/adminMetadata"][0]).length > 7 : false
-
-          if(component.propertyLabel == 'Admin Metadata'){
-            console.info("    ", lotsOfFields, "--",component)
-          }
-
-          if (component.adminMetadataType && component.adminMetadataType == 'secondary' && !lotsOfFields){
+          if (component.adminMetadataType && component.adminMetadataType == 'secondary'){
             return true
           }
 

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -108,13 +108,13 @@
                         <div v-if="profileName.split(':').slice(-1)[0] == 'Work'" class="inline-mode-resource-color-work">&nbsp;</div>
                         <div v-if="profileName.indexOf(':Instance') > -1 && profileName.indexOf(':Item') == -1" class="inline-mode-resource-color-instance">&nbsp;</div>
                         <template v-if="profileStore.cammModeErrors[activeProfile.rt[profileName].pt[profileCompoent]['@guid']]">
-                          
+
                           <span class="material-icons inline-mode-error-icon simptip-position-right" @click="showErrors(activeProfile.rt[profileName].pt[profileCompoent]['@guid'])">warning</span>
                         </template>
                         <template v-else>
                           <button @mouseenter="inlineRowButtonMouseEnter" :class="{'inline-mode-mian-button': true, 'inline-mode-mian-button-has-ref' : profileStore.ptHasRefComponent(activeProfile.rt[profileName].pt[profileCompoent]) }"></button>
                         </template>
-                        
+
                       </template>
 
                       <!-- index == -1 means it's the work, so just add the work -->
@@ -262,7 +262,13 @@
 
         isReadOnly: function(component){
 
-          if (component.adminMetadataType && component.adminMetadataType == 'secondary'){
+          let lotsOfFields = component.userValue["http://id.loc.gov/ontologies/bibframe/adminMetadata"] ? Object.keys(component.userValue["http://id.loc.gov/ontologies/bibframe/adminMetadata"][0]).length > 7 : false
+
+          if(component.propertyLabel == 'Admin Metadata'){
+            console.info("    ", lotsOfFields, "--",component)
+          }
+
+          if (component.adminMetadataType && component.adminMetadataType == 'secondary' && !lotsOfFields){
             return true
           }
 
@@ -277,6 +283,7 @@
         //We only want the editable admin field under instances to show up
         // Don't show READONLY ADMIN fields in the instance, Don't show any admin fields in the work
         hideAdminField: function(component, profileName){
+
           let readOnly = this.isReadOnly(component)
           let isWork = profileName.includes(':Work')
           let isAdminField = component.propertyURI.includes('adminMetadata')

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -802,7 +802,12 @@
           for (let pt in this.activeProfile.rt[rt].pt){
             let component = this.activeProfile.rt[rt].pt[pt]
             let structure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
-            if (structure.propertyLabel != 'Admin Metadata') {
+            if (structure.propertyLabel != 'Admin Metadata' || structure.adminMetadataType == 'primary') {
+
+              if (structure.propertyLabel == 'Admin Metadata'){
+                console.info("admin field defaults: ", structure)
+              }
+
               if ( component.valueConstraint.defaults.length > 0){
                 // top level component
                 if (Object.keys(component.userValue).every(k => k.startsWith("@"))){ // it's empty

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -803,11 +803,6 @@
             let component = this.activeProfile.rt[rt].pt[pt]
             let structure = this.profileStore.returnStructureByComponentGuid(component['@guid'])
             if (structure.propertyLabel != 'Admin Metadata' || structure.adminMetadataType == 'primary') {
-
-              if (structure.propertyLabel == 'Admin Metadata'){
-                console.info("admin field defaults: ", structure)
-              }
-
               if ( component.valueConstraint.defaults.length > 0){
                 // top level component
                 if (Object.keys(component.userValue).every(k => k.startsWith("@"))){ // it's empty

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1743,7 +1743,8 @@ const utilsParse = {
           // remain and should continue to be editable.
 
           if (userValue){
-            if (!userValue['http://id.loc.gov/ontologies/bibframe/status'] || Object.keys(userValue).length > 7){
+
+            if (profile.rt[pkey].pt[key].parentId.includes(":Instance") && (!userValue['http://id.loc.gov/ontologies/bibframe/status'] || Object.keys(userValue).length > 7)){
               profile.rt[pkey].pt[key].adminMetadataType = 'primary'
               adminMedtataPrimary = key
             }else{

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1,5 +1,6 @@
 import {useConfigStore} from "../stores/config";
 import {useProfileStore} from "../stores/profile";
+import {usePreferenceStore} from "../stores/preference";
 
 import short from 'short-uuid'
 
@@ -1718,14 +1719,15 @@ const utilsParse = {
           let userValue = profile.rt[pkey].pt[key].userValue['http://id.loc.gov/ontologies/bibframe/adminMetadata'][0]
 
           // // if it doesnt already have a cataloger id use ours
-          // if (!userValue['http://id.loc.gov/ontologies/bflc/catalogerId']){
-          //   userValue['http://id.loc.gov/ontologies/bflc/catalogerId'] = [
-          //     {
-          //       "@guid": short.generate(),
-          //       "http://id.loc.gov/ontologies/bflc/catalogerId": useProfileStore().catInitials
-          //     }
-          //   ]
-          // }
+          if (!userValue['http://id.loc.gov/ontologies/bflc/catalogerId']){
+            console.info("profileStore: ", usePreferenceStore())
+            userValue['http://id.loc.gov/ontologies/bflc/catalogerId'] = [
+              {
+                "@guid": short.generate(),
+                "http://id.loc.gov/ontologies/bflc/catalogerId": usePreferenceStore().catInitals
+              }
+            ]
+          }
 
           // // we need to set the procInfo, so use whatever we have in the profile
           // userValue['http://id.loc.gov/ontologies/bflc/procInfo'] = [
@@ -1736,10 +1738,12 @@ const utilsParse = {
           // ]
 
           // using MARC2BF rules 2.6+ we need to find the admin metadata that does not have a status
-          // that will be our primary adminMetadat that they edit
+          // that will be our primary adminMetadata that they edit. Except, we want the `primary` Admin field to stay primary
+          // even after it gets a status. Most of the admin fields will be hidden, but the Primary field in the instance will
+          // remain and should continue to be editable.
 
           if (userValue){
-            if (!userValue['http://id.loc.gov/ontologies/bibframe/status']){
+            if (!userValue['http://id.loc.gov/ontologies/bibframe/status'] || Object.keys(userValue).length > 7){
               profile.rt[pkey].pt[key].adminMetadataType = 'primary'
               adminMedtataPrimary = key
             }else{

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1720,7 +1720,6 @@ const utilsParse = {
 
           // // if it doesnt already have a cataloger id use ours
           if (!userValue['http://id.loc.gov/ontologies/bflc/catalogerId']){
-            console.info("profileStore: ", usePreferenceStore())
             userValue['http://id.loc.gov/ontologies/bflc/catalogerId'] = [
               {
                 "@guid": short.generate(),

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 17,
-    versionPatch: 53,
+    versionPatch: 54,
 
     regionUrls: {
 


### PR DESCRIPTION
Sometimes catalogers might need to edit the admin metadata after posting. `adminMetadataType` is set to `secondary` if `bf:status` is present, which happens on posting. This adds a second check that the largest admin metadata field doesn't get flagged as readOnly.