### PR TITLE
ignore server response of hub URI and used internal

### DIFF
--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1786,6 +1786,20 @@ const utilsExport = {
     },
 
 
+
+	creatHubStubURI: async function(hubCreatorObj,title){
+
+		let aap = utilsProfile.returnAap(hubCreatorObj.label,title)
+		
+		let aapHash = await md5(aap)
+		aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
+		let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
+
+		return hubUri
+
+	},
+
+
 	/**
 	 * Builds the Hub Stub XML to be sent off to post
 	 *
@@ -1822,11 +1836,13 @@ const utilsExport = {
 
 		
 
-		let aap = utilsProfile.returnAap(hubCreatorObj.label,title)
+		// let aap = utilsProfile.returnAap(hubCreatorObj.label,title)
 		
-		let aapHash = await md5(aap)
-		aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
-		let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
+		// let aapHash = await md5(aap)
+		// aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
+		// let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
+		let hubUri = await this.creatHubStubURI(hubCreatorObj,title)
+
 
 
 		// da hub

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4869,6 +4869,7 @@ export const useProfileStore = defineStore('profile', {
       let xml = await utilsExport.createHubStubXML(hubCreatorObj,title,langObj,catCode)
 
       console.log(xml)
+      console.log("hubCreatorObj",hubCreatorObj)
       let eid = 'e' + decimalTranslator.new()
       eid = eid.substring(0,8)
 
@@ -4882,40 +4883,10 @@ export const useProfileStore = defineStore('profile', {
         alert("There was an error creating your Hub. Please report this issue.")
       }
 
-      // pubResuts = {'postLocation': 'https://id.loc.gov/resources/hubs/a07eefde-6522-9b99-e760-5c92f7d396eb'}
-
-
-      return pubResuts
-
-
-
-    },
-
-  /**
-    * Builds and posts a Hub Stub
-    *
-    * @param {object} hubCreatorObj - obj with creator label, uri,marcKey
-    * @param {string} title - title string
-    * @param {string} langObj - {uri:"",label:""}
-    * @return {String}
-    */
-    async buildPostHubStub(hubCreatorObj,title,langObj,catCode){
-
-      // console.log("hubCreatorObj",hubCreatorObj)
-      let xml = await utilsExport.createHubStubXML(hubCreatorObj,title,langObj,catCode)
-
-      console.log(xml)
-      let eid = 'e' + decimalTranslator.new()
-      eid = eid.substring(0,8)
-
-      // pass a fake activeprofile with id == Hub to trigger hub protocols
-      let pubResuts
-      try{
-        pubResuts = await utilsNetwork.publish(xml, eid, {id: 'Hub'})
-
-      }catch (error){
-        console.log(error)
-        alert("There was an error creating your Hub. Please report this issue.")
+      if (pubResuts){
+        // get the URI used for this one and overwrite whatever the server sent to us
+        let hubUri = await utilsExport.creatHubStubURI(hubCreatorObj,title)
+        pubResuts.postLocation = hubUri
       }
 
       // pubResuts = {'postLocation': 'https://id.loc.gov/resources/hubs/a07eefde-6522-9b99-e760-5c92f7d396eb'}


### PR DESCRIPTION
Changes the stub Hub process to use the internal URI created when the post process returns instead of what the server returned.