### PR TITLE
Default component library monographs

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2257,7 +2257,6 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
-    console.info("subjectStringChanged: ", event)
     this.subjectString=this.subjectString.replace("—", "--")
     this.validateOkayToAdd()
 
@@ -2333,8 +2332,6 @@ methods: {
         if (event.target.selectionStart >= c.posStart && event.target.selectionStart <= c.posEnd+1){
           this.activeComponent = c
           this.activeComponentIndex = c.id
-
-          console.info("active: ", this.activeComponent)
 
           // it is not empty
           // it dose not end with "-" so it the '--' typing doesn't trigger

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -541,20 +541,19 @@ import { isReadonly } from 'vue';
 
     <AccordionList  :open-multiple-items="true">
 
-      <template v-for="clProfile in returnComponentLibrary" :key="clProfile">
+      <template v-for="(clProfile, idx) in returnComponentLibrary" :key="clProfile">
         <AccordionItem style="color: white;" :id="'accordion_'+clProfile.profileId" default-closed>
           <template #summary>
             <div> <span class="material-icons" style="font-size: 18px;padding-left: 2px;">library_add</span> <span style="vertical-align: text-bottom;" class="sidebar-header-text">{{ clProfile.type == 'default' ? 'Default' : 'Library' }}: {{ clProfile.label }}</span></div>
           </template>
           <ul class="sidebar-property-ul" role="list">
-            <template v-for="group in clProfile.groups" >
-
-                <template v-if="group.length>1">
+            <template v-for="(group, idx) in clProfile.groupsOrder" >
+                <template v-if="clProfile.groups[group].length>1">
                   <li class="component-librart-group-line"></li>
                 </template>
 
-                <template v-for="component in group">
-                  <li class="sidebar-property-li sidebar-property-li-cl ">
+                <template v-for="component in clProfile.groups[group]">
+                   <li class="sidebar-property-li sidebar-property-li-cl ">
 
                   <button :class="{'material-icons' : true, 'component-library-settings-button': true, 'component-library-settings-button-invert': (activeComponentLibrary == component.id)  }" @click="configComponentLibrary(component.id)">settings_applications</button>
 
@@ -604,12 +603,9 @@ import { isReadonly } from 'vue';
                   </li>
                 </template>
 
-              <template v-if="group.length>1">
-
-                <button class="component-librart-group-button" @click="addComponentLibraryGroup(group[0].groupId)"><span class="material-icons">arrow_upward</span>Add {{clProfile.type != 'default' ? 'Group' : ''}} {{ group[0].groupId }} <span class="material-icons">arrow_upward</span></button>
+              <template v-if="clProfile.groups[group].length>1">
+                <button class="component-librart-group-button" @click="addComponentLibraryGroup(clProfile.groups[group][0].groupId)"><span class="material-icons">arrow_upward</span>Add {{clProfile.type != 'default' ? 'Group' : ''}} {{ clProfile.groups[group][0].groupId }} <span class="material-icons">arrow_upward</span></button>
               </template>
-
-
 
             </template>
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -542,7 +542,7 @@ import { isReadonly } from 'vue';
     <AccordionList  :open-multiple-items="true">
 
       <template v-for="clProfile in returnComponentLibrary" :key="clProfile">
-        <AccordionItem style="color: white;" :id="'accordion_'+clProfile.label" default-closed>
+        <AccordionItem style="color: white;" :id="'accordion_'+clProfile.profileId" default-closed>
           <template #summary>
             <div> <span class="material-icons" style="font-size: 18px;padding-left: 2px;">library_add</span> <span style="vertical-align: text-bottom;" class="sidebar-header-text">{{ clProfile.type == 'default' ? 'Default' : 'Library' }}: {{ clProfile.label }}</span></div>
           </template>
@@ -606,7 +606,7 @@ import { isReadonly } from 'vue';
 
               <template v-if="group.length>1">
 
-                <button class="component-librart-group-button" @click="addComponentLibraryGroup(group[0].groupId)"><span class="material-icons">arrow_upward</span>Add Group {{ group[0].groupId }} <span class="material-icons">arrow_upward</span></button>
+                <button class="component-librart-group-button" @click="addComponentLibraryGroup(group[0].groupId)"><span class="material-icons">arrow_upward</span>Add {{clProfile.type != 'default' ? 'Group' : ''}} {{ group[0].groupId }} <span class="material-icons">arrow_upward</span></button>
               </template>
 
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -116,9 +116,6 @@ import { isReadonly } from 'vue';
         }
 
         let newId = this.profileStore.addFromComponentLibrary(clId)
-
-        console.info("newID: ", newId)
-
         this.activeComponent = this.activeProfile.rt[newId[0]].pt[newId[1]]
 
         // for (let rt in this.activeProfile.rt){

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -548,6 +548,7 @@ import { isReadonly } from 'vue';
           </template>
           <ul class="sidebar-property-ul" role="list">
             <template v-for="(group, idx) in clProfile.groupsOrder" >
+              <div class="component-group">
                 <template v-if="clProfile.groups[group].length>1">
                   <li class="component-librart-group-line"></li>
                 </template>
@@ -603,10 +604,10 @@ import { isReadonly } from 'vue';
                   </li>
                 </template>
 
-              <template v-if="clProfile.groups[group].length>1">
-                <button class="component-librart-group-button" @click="addComponentLibraryGroup(clProfile.groups[group][0].groupId)"><span class="material-icons">arrow_upward</span>Add {{clProfile.type != 'default' ? 'Group' : ''}} {{ clProfile.groups[group][0].groupId }} <span class="material-icons">arrow_upward</span></button>
-              </template>
-
+                <template v-if="clProfile.groups[group].length>1">
+                  <button class="component-librart-group-button" @click="addComponentLibraryGroup(clProfile.groups[group][0].groupId)"><span class="material-icons">arrow_upward</span>Add {{clProfile.type != 'default' ? 'Group' : ''}} {{ clProfile.groups[group][0].groupId }} <span class="material-icons">arrow_upward</span></button>
+                </template>
+              </div>
             </template>
 
           </ul>
@@ -870,6 +871,13 @@ li.not-populated-hide:before{
   font-family: 'Material Icons';
   content: 'visibility_off';
   color: white !important;
+}
+
+.sidebar-property-ul .component-group:nth-child(even){
+  background-color: grey;
+}
+.sidebar-property-ul li {
+  list-style: none;
 }
 
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -563,10 +563,9 @@ import { isReadonly } from 'vue';
                   <div class="component-library-item-container sidebar-property-li-empty" @click="addComponentLibrary($event,component.id)" >
                     <a href="#" @click="addComponentLibrary($event,component.id)">{{ component.label }}</a>
                   </div>
-                    <template v-if="activeComponentLibrary == component.id">
+                    <template v-if="activeComponentLibrary == component.id && clProfile.type != 'default'">
                       <div class="component-library-settings">
 
-                        <template v-if="clProfile.type != 'default'">
                           <button class="material-icons simptip-position-right" data-tooltip="DELETE" @click="delComponentLibrary($event,component.id)">delete_forever</button>
                           <button class="material-icons simptip-position-right" data-tooltip="RENAME" @click="renameComponentLibrary($event,component.id,component.label)">new_label</button>
                           <select @change="configComponentLibraryAssignGroup($event,component.id)">
@@ -598,7 +597,6 @@ import { isReadonly } from 'vue';
                             <option value="Y" :selected="(component.groupId==='Y')">Group Y</option>
                             <option value="Z" :selected="(component.groupId==='Z')">Group Z</option>
                           </select>
-                        </template>
 
 
                       </div>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -566,38 +566,39 @@ import { isReadonly } from 'vue';
                     <template v-if="activeComponentLibrary == component.id">
                       <div class="component-library-settings">
 
-
-                        <button class="material-icons simptip-position-right" data-tooltip="DELETE" @click="delComponentLibrary($event,component.id)">delete_forever</button>
-                        <button class="material-icons simptip-position-right" data-tooltip="RENAME" @click="renameComponentLibrary($event,component.id,component.label)">new_label</button>
-                        <select @change="configComponentLibraryAssignGroup($event,component.id)">
-                          <option value="" :selected="(component.groupId===null)">No Group</option>
-                          <option value="A" :selected="(component.groupId==='A')">Group A</option>
-                          <option value="B" :selected="(component.groupId==='B')">Group B</option>
-                          <option value="C" :selected="(component.groupId==='C')">Group C</option>
-                          <option value="D" :selected="(component.groupId==='D')">Group D</option>
-                          <option value="E" :selected="(component.groupId==='E')">Group E</option>
-                          <option value="F" :selected="(component.groupId==='F')">Group F</option>
-                          <option value="G" :selected="(component.groupId==='G')">Group G</option>
-                          <option value="H" :selected="(component.groupId==='H')">Group H</option>
-                          <option value="I" :selected="(component.groupId==='I')">Group I</option>
-                          <option value="J" :selected="(component.groupId==='J')">Group J</option>
-                          <option value="K" :selected="(component.groupId==='K')">Group K</option>
-                          <option value="L" :selected="(component.groupId==='L')">Group L</option>
-                          <option value="M" :selected="(component.groupId==='M')">Group M</option>
-                          <option value="N" :selected="(component.groupId==='N')">Group N</option>
-                          <option value="O" :selected="(component.groupId==='O')">Group O</option>
-                          <option value="P" :selected="(component.groupId==='P')">Group P</option>
-                          <option value="Q" :selected="(component.groupId==='Q')">Group Q</option>
-                          <option value="R" :selected="(component.groupId==='R')">Group R</option>
-                          <option value="S" :selected="(component.groupId==='S')">Group S</option>
-                          <option value="T" :selected="(component.groupId==='T')">Group T</option>
-                          <option value="U" :selected="(component.groupId==='U')">Group U</option>
-                          <option value="V" :selected="(component.groupId==='V')">Group V</option>
-                          <option value="W" :selected="(component.groupId==='W')">Group W</option>
-                          <option value="X" :selected="(component.groupId==='X')">Group X</option>
-                          <option value="Y" :selected="(component.groupId==='Y')">Group Y</option>
-                          <option value="Z" :selected="(component.groupId==='Z')">Group Z</option>
-                        </select>
+                        <template v-if="clProfile.type != 'default'">
+                          <button class="material-icons simptip-position-right" data-tooltip="DELETE" @click="delComponentLibrary($event,component.id)">delete_forever</button>
+                          <button class="material-icons simptip-position-right" data-tooltip="RENAME" @click="renameComponentLibrary($event,component.id,component.label)">new_label</button>
+                          <select @change="configComponentLibraryAssignGroup($event,component.id)">
+                            <option value="" :selected="(component.groupId===null)">No Group</option>
+                            <option value="A" :selected="(component.groupId==='A')">Group A</option>
+                            <option value="B" :selected="(component.groupId==='B')">Group B</option>
+                            <option value="C" :selected="(component.groupId==='C')">Group C</option>
+                            <option value="D" :selected="(component.groupId==='D')">Group D</option>
+                            <option value="E" :selected="(component.groupId==='E')">Group E</option>
+                            <option value="F" :selected="(component.groupId==='F')">Group F</option>
+                            <option value="G" :selected="(component.groupId==='G')">Group G</option>
+                            <option value="H" :selected="(component.groupId==='H')">Group H</option>
+                            <option value="I" :selected="(component.groupId==='I')">Group I</option>
+                            <option value="J" :selected="(component.groupId==='J')">Group J</option>
+                            <option value="K" :selected="(component.groupId==='K')">Group K</option>
+                            <option value="L" :selected="(component.groupId==='L')">Group L</option>
+                            <option value="M" :selected="(component.groupId==='M')">Group M</option>
+                            <option value="N" :selected="(component.groupId==='N')">Group N</option>
+                            <option value="O" :selected="(component.groupId==='O')">Group O</option>
+                            <option value="P" :selected="(component.groupId==='P')">Group P</option>
+                            <option value="Q" :selected="(component.groupId==='Q')">Group Q</option>
+                            <option value="R" :selected="(component.groupId==='R')">Group R</option>
+                            <option value="S" :selected="(component.groupId==='S')">Group S</option>
+                            <option value="T" :selected="(component.groupId==='T')">Group T</option>
+                            <option value="U" :selected="(component.groupId==='U')">Group U</option>
+                            <option value="V" :selected="(component.groupId==='V')">Group V</option>
+                            <option value="W" :selected="(component.groupId==='W')">Group W</option>
+                            <option value="X" :selected="(component.groupId==='X')">Group X</option>
+                            <option value="Y" :selected="(component.groupId==='Y')">Group Y</option>
+                            <option value="Z" :selected="(component.groupId==='Z')">Group Z</option>
+                          </select>
+                        </template>
 
 
                       </div>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -540,10 +540,9 @@ import { isReadonly } from 'vue';
     <AccordionList  :open-multiple-items="true">
 
       <template v-for="clProfile in returnComponentLibrary" :key="clProfile">
-
         <AccordionItem style="color: white;" :id="'accordion_'+clProfile.label" default-closed>
           <template #summary>
-            <div> <span class="material-icons" style="font-size: 18px;padding-left: 2px;">library_add</span> <span style="vertical-align: text-bottom;" class="sidebar-header-text">Library: {{ clProfile.label }}</span></div>
+            <div> <span class="material-icons" style="font-size: 18px;padding-left: 2px;">library_add</span> <span style="vertical-align: text-bottom;" class="sidebar-header-text">{{ clProfile.type == 'default' ? 'Default' : 'Library' }}: {{ clProfile.label }}</span></div>
           </template>
           <ul class="sidebar-property-ul" role="list">
             <template v-for="group in clProfile.groups" >
@@ -554,8 +553,6 @@ import { isReadonly } from 'vue';
 
                 <template v-for="component in group">
                   <li class="sidebar-property-li sidebar-property-li-cl ">
-
-
 
                   <button :class="{'material-icons' : true, 'component-library-settings-button': true, 'component-library-settings-button-invert': (activeComponentLibrary == component.id)  }" @click="configComponentLibrary(component.id)">settings_applications</button>
 

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -117,6 +117,8 @@ import { isReadonly } from 'vue';
 
         let newId = this.profileStore.addFromComponentLibrary(clId)
 
+        console.info("newID: ", newId)
+
         this.activeComponent = this.activeProfile.rt[newId[0]].pt[newId[1]]
 
         // for (let rt in this.activeProfile.rt){

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -541,7 +541,7 @@ import { isReadonly } from 'vue';
       <template v-for="(clProfile, idx) in returnComponentLibrary" :key="clProfile">
         <AccordionItem style="color: white;" :id="'accordion_'+clProfile.profileId" default-closed>
           <template #summary>
-            <div> <span class="material-icons" style="font-size: 18px;padding-left: 2px;">library_add</span> <span style="vertical-align: text-bottom;" class="sidebar-header-text">{{ clProfile.type == 'default' ? 'Default' : 'Library' }}: {{ clProfile.label }}</span></div>
+            <div> <span class="material-icons" style="font-size: 18px;padding-left: 2px;">library_add</span> <span style="vertical-align: text-bottom;" class="sidebar-header-text">{{ clProfile.type == 'default' ? 'Defaults' : 'Library' }}: {{ clProfile.type == 'default' ? '' : clProfile.label }}</span></div>
           </template>
           <ul class="sidebar-property-ul" role="list">
             <template v-for="(group, idx) in clProfile.groupsOrder" >

--- a/src/lib/defaults/default_components.json
+++ b/src/lib/defaults/default_components.json
@@ -1,0 +1,2995 @@
+{
+    "DefaultComponentLibrary": {
+        "profiles": {
+            "lc:RT:bf2:Monograph:Work": {
+                "groups": [
+                    {
+                        "id": "qujRRCigqesRdsog8yL6HY",
+                        "groupId": null,
+                        "position": 0,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "a27MUdmvmYfmEDKkfSewot",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2021026043",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "irinHaKTENoZyBAXL6YjDC",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Board books",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "dD8Sdf9cmgXNkJeKRNRHQZ",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aBoard books"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Board Books (Genre/Form)"
+                    },
+                    {
+                        "id": "fNoqo5cVP3oNrE685CLHre",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 1,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "aeHsUyLZnszcdjzWLXThe7",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/ill",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "fXvedNnjenASq8uhMygDwR",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (ill cntnt1)"
+                    },
+                    {
+                        "id": "9Dirnr9snKff9P7vYn3Lpj",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 2,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "nURNYc8Er9DDiXb5wHNTAz",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/map",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "358fwogU4GxG8NaKt5FpGe",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (ill cntnt2)"
+                    },
+                    {
+                        "id": "rBSX7qsyApGfiLWippgdmq",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 3,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/mcolor"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ColorContent"
+                                },
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                            "propertyLabel": "Color content",
+                            "remark": "http://original.rdatoolkit.org/7.17.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/colorContent",
+                                "http://id.loc.gov/ontologies/bibframe/colorContent": [
+                                    {
+                                        "@guid": "8b1rfbuW5YeYDvGgcGxAaB",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/ColorContent",
+                                        "@id": "http://id.loc.gov/vocabulary/mcolor/mul",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "xo6K8tiasMJNEjKpSvPuX1",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "color (mul)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/colorContent|http://id.loc.gov/ontologies/bibframe/ColorContent",
+                            "id": "id_loc_gov_ontologies_bibframe_colorContent__color_content",
+                            "hashCode": -1472373724,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/colorContent|http://id.loc.gov/ontologies/bibframe/ColorContent",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (clr cntnt)"
+                    },
+                    {
+                        "id": "jSwCsjZDquD7UCxLWfihNH",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 4,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "tLQ4BsPTriYg62EuEu1pX5",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "6JcF5z1HNkKewqiSFGB3cW",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "8nAjKoPeugda6QsGzRUs8m",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (g/f)"
+                    },
+                    {
+                        "id": "qTZXJJC6fX7fs4KD9PEDDf",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 5,
+                        "structure": {
+                            "mandatory": "true",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/contentTypes"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                                },
+                                "editable": "false",
+                                "repeatable": "true",
+                                "defaults": [
+                                    {
+                                        "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                        "defaultLiteral": "text"
+                                    }
+                                ]
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                            "propertyLabel": "Content type",
+                            "remark": "http://original.rdatoolkit.org/6.9.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/content",
+                                "http://id.loc.gov/ontologies/bibframe/content": [
+                                    {
+                                        "@guid": "kuESMVdS71VxoAJqKxF8wR",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Content",
+                                        "@id": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "hLqxQLdPf59U9Gn4hyL5fq",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "id": "id_loc_gov_ontologies_bibframe_content__content_type",
+                            "hashCode": -211358670,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (cntnt type)"
+                    },
+                    {
+                        "id": "vShrp7HNvp3GQFmywkgfUg",
+                        "groupId": "Conference w/ Place",
+                        "position": 6,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "riuKNMyqFWT8bir4eKahuS",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "d9vqmqDR8op5kxyuKURh5a",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Conference papers and proceedings",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "sriGPU7mwQVV9Sjuvtz6GX",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aConference papers and proceedings"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Conference w/ place (g/f)"
+                    },
+                    {
+                        "id": "5tK2pM8iEJLrPWrGDKopfU",
+                        "groupId": "Conference Paper",
+                        "position": 7,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "riuKNMyqFWT8bir4eKahuS",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "d9vqmqDR8op5kxyuKURh5a",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Conference papers and proceedings",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "sriGPU7mwQVV9Sjuvtz6GX",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aConference papers and proceedings"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Conference papers (g/f)"
+                    },
+                    {
+                        "id": "7yazpDhLc4ZsV94Pp1VyB8",
+                        "groupId": "Filmographies",
+                        "position": 8,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "iCL2fBzb6xRTcFda83nYH4",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2019026014",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "rr2VJjT4AfKTVFYednCTkH",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Filmographies",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "9TYu55qFU88rq2MaTFXQEx",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aFilmographies"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Filmographies (g/f)"
+                    },
+                    {
+                        "id": "tnaJzZNtvj8PrT1x84togJ",
+                        "groupId": "Illustrations",
+                        "position": 9,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "eDCQo8XGWVmk91wot6Z7VE",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/ill",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "bvAxNseSFHR4qXhqH4zdZr",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Illustrations (ill cntnt)"
+                    },
+                    {
+                        "id": "aM1Nq8frmrdqhbLbnqqDzR",
+                        "groupId": "Illustrations, Maps",
+                        "position": 10,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "eDCQo8XGWVmk91wot6Z7VE",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/ill",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "bvAxNseSFHR4qXhqH4zdZr",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "illustrations, maps (ill cntnt1)"
+                    },
+                    {
+                        "id": "o6qKexmBexoosGKduseGFQ",
+                        "groupId": "Illustrations, Maps",
+                        "position": 11,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "dSMzQ8FphdLHCmmq9zQS3L",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/map",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "vBk7gGdRCiz1qjbYTiATBS",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "illustrations, maps (ill cntnt2)"
+                    },
+                    {
+                        "id": "fjDFHjGjdi6d8uSDGWguJ3",
+                        "groupId": "Illustrations, Maps",
+                        "position": 12,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "nfqSRTVjRBpoyncmEhLax8",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "8b7M64cbp42sHW9CvJ6bBA",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "pdXFfKpE9MjUDtWP6avEcZ",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "illustrations, maps (g/f)"
+                    },
+                    {
+                        "id": "b9cY83wahc8fkcUcuv7VGL",
+                        "groupId": "Maps",
+                        "position": 13,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "nfqSRTVjRBpoyncmEhLax8",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "8b7M64cbp42sHW9CvJ6bBA",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "pdXFfKpE9MjUDtWP6avEcZ",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Maps (g/f)"
+                    },
+                    {
+                        "id": "aLUUU2dm9qTuaFhoDosjk2",
+                        "groupId": "Maps",
+                        "position": 14,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "dSMzQ8FphdLHCmmq9zQS3L",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/map",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "vBk7gGdRCiz1qjbYTiATBS",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Maps (ill cntnt)"
+                    },
+                    {
+                        "id": "4zytgeKUuAqVNhSusXBwSD",
+                        "groupId": "Maps",
+                        "position": 15,
+                        "structure": {
+                            "mandatory": "true",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/contentTypes"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                                },
+                                "editable": "false",
+                                "repeatable": "true",
+                                "defaults": [
+                                    {
+                                        "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                        "defaultLiteral": "text"
+                                    }
+                                ]
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                            "propertyLabel": "Content type",
+                            "remark": "http://original.rdatoolkit.org/6.9.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/content",
+                                "http://id.loc.gov/ontologies/bibframe/content": [
+                                    {
+                                        "@guid": "4ncDt2zwJQU4sJWySGrqMi",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Content",
+                                        "@id": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "sjtEeE82dGVQwFsUPcavEf",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "id": "id_loc_gov_ontologies_bibframe_content__content_type",
+                            "hashCode": -211358670,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Maps (cntnt type)"
+                    },
+                    {
+                        "id": "rfhb6VKo9F2rrBqdVi1i8V",
+                        "groupId": null,
+                        "position": 16,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "a7HcoopzA4coReKbxAZKNu",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "hi67V8Q2uP52Hh9k1fa2Mh",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Translated from <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "rQkXNtRHHuYwo3GS7hDLm3",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/lang",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "hdiB3Nnsq4jngLueJ8D8cz",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "language (lang)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Note on translation"
+                    },
+                    {
+                        "id": "9Cq5toFGDrPbcx2k1ES5PM",
+                        "groupId": "Published In",
+                        "position": 17,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "gNAXCyNcvBxoWoYLb9LWwt",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "m1ingF2SkyDtYfww77c1VH",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Published in (wrk note)"
+                    },
+                    {
+                        "id": "r2uLjeuCCjphBSLvawgt6W",
+                        "groupId": null,
+                        "position": 18,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "tHAoCS2zmxsPpyeK4cX2SG",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "wpu1viVFQAgioAvv8CdkET",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in conjunction with the <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Published in conjunction (Exhibit)"
+                    },
+                    {
+                        "id": "ws3Fdw19MKx3Zw3tFe4PWx",
+                        "groupId": null,
+                        "position": 19,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "eoo8Ma7LF4mj5qVGYDdQ7k",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "8fs536bZZn5ttNXqt3rPmc",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": " Published on the occasion of the <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": " Published on the occasion of"
+                    },
+                    {
+                        "id": "o6ymbCUzy3pPXyXjih8oq2",
+                        "groupId": "Catalog of an Exhibition",
+                        "position": 20,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "59v1XWzsqwhTJoQfs1Ysw8",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "aMMyBjTPPYi2PVoirtfeXU",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Catalog of an exhibition held at <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Catalog of an exhibition (wrk note)"
+                    },
+                    {
+                        "id": "3hLb6FQPjxhc6Z67qkuJqL",
+                        "groupId": "Catalog of an Exhibition",
+                        "position": 21,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "uuJL5EWVXT445ZdsDhosB2",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026098",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "gvUVir8x91QPvxQUJqaxh4",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Exhibition catalogs",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "nhZ76boYm2MTDMi7dpsFMR",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aExhibition catalogs"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Catalog of an exhibition (g/f)"
+                    },
+                    {
+                        "id": "4yywMMQAUZ8np45Yz3Gr8k",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 22,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "kET4tMveAUtShu9ennkEQp",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/map",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "1EinUGLjPtH1tPYd8Wdors",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": -1055901801,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map (in Pocket) note (ill cntnt)"
+                    },
+                    {
+                        "id": "45sF8AhKB6QXfw6GCzn98C",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 23,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Form"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "jWkhVDAqpj6EJutzLUrnrR",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "1Qk2SrfticPmcpvwgikyVA",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "jqc9fyjs77GL36aC46Akf2",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": 490027258,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map (in Pocket) note (g/f)"
+                    },
+                    {
+                        "id": "kX2Fwq5tccgUwAakkPAfFF",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 24,
+                        "structure": {
+                            "mandatory": "true",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/contentTypes"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                                },
+                                "editable": "false",
+                                "repeatable": "true",
+                                "defaults": [
+                                    {
+                                        "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                        "defaultLiteral": "text"
+                                    }
+                                ]
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                            "propertyLabel": "Content type",
+                            "remark": "https://original.rdatoolkit.org/6.9.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/content",
+                                "http://id.loc.gov/ontologies/bibframe/content": [
+                                    {
+                                        "@guid": "8E1iLaJxGxuVTmPA7LeV9y",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Content",
+                                        "@id": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "vkHR5UHcigC7MMuzkyfRx7",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "id": "id_loc_gov_ontologies_bibframe_content__content_type",
+                            "hashCode": 411074621,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map (in Pocket) note (cntnt type)"
+                    },
+                    {
+                        "id": "aH56AhrvWU9HXdjX4ucsxA",
+                        "groupId": "Index",
+                        "position": 25,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "false",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                },
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                            "propertyLabel": "Supplementary content",
+                            "remark": "https://original.rdatoolkit.org/7.16.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
+                                    {
+                                        "@guid": "txrmecvoN2s7ioKEooQnLC",
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/index",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "tRtZnHXX47oUFmZwqLgCdS",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
+                            "hashCode": -2006168873,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Index (supp cntnt)"
+                    },
+                    {
+                        "id": "4ZQtdTGpsJpDec9H2UR1EN",
+                        "groupId": "Bib/Index",
+                        "position": 26,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "false",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                },
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                            "propertyLabel": "Supplementary content",
+                            "remark": "https://original.rdatoolkit.org/7.16.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
+                                    {
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/bibliography",
+                                        "@guid": "2uWByuKZ9qrfxeWnReGWsg",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "fKYNMCmUp7N6nLck99QuUM",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (bibliography)"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/index",
+                                        "@guid": "s4YZD1TPZ8mTs8zmApR2zh",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "5rzDeGmBtqbc9SthA95pqj",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
+                            "hashCode": -2006168873,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Bib/Index (supp cntnt)"
+                    },
+                    {
+                        "id": "nUj5Y62BoKQGc8XZR4kizx",
+                        "groupId": "Bib",
+                        "position": 27,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "false",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                },
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                            "propertyLabel": "Supplementary content",
+                            "remark": "https://original.rdatoolkit.org/7.16.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
+                                    {
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/bibliography",
+                                        "@guid": "2uWByuKZ9qrfxeWnReGWsg",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "fKYNMCmUp7N6nLck99QuUM",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (bibliography)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
+                            "hashCode": -2006168873,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Bib (supp cntnt)"
+                    }
+                ]
+            },
+            "lc:RT:bf2:Monograph:Instance": {
+                "groups": [
+                    {
+                        "id": "ci9onu1M8WZDTEZCqVQA2r",
+                        "groupId": null,
+                        "position": 0,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "fPrwd5xeWVS1U1QyzxoTZF",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "o9x8bT8tmFWDyp2ySnaoRb",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "At head of title: #######"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "At head"
+                    },
+                    {
+                        "id": "bWXwVC4UrVZznzPdFDYot7",
+                        "groupId": null,
+                        "position": 2,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "4YYxfq9CZGR9ytTkqW2Gyp",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "8NwPdsk3phgHBBc3ZdQs3T",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Title from caption."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "pZKnxPJiMm1QkJEZWBw9wN",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/descsource",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "vQ8QZAq5tE865yRU4vBE9z",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "description source (descsource)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Caption Title"
+                    },
+                    {
+                        "id": "mpW2ARKSNnSQgU4haowiVg",
+                        "groupId": null,
+                        "position": 3,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "vFmMY9ji79CxFtZyqajvBp",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "aqpeLBXYcv1PsZHEzaCgYw",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "On board pages."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Board Books"
+                    },
+                    {
+                        "id": "bxiumi2WzGErraKbAf8y2Z",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 3,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "cuYsaTA36XUP3BkVEQHjWJ",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "iqPdxhuNapUNp6SUNLHpMS",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (some color), maps (some color)"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "duD17oiwf6Yd3hR2aa9FWb",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/physical",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "n2dwAy96nwPPDJ6uPCLpwQ",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (inst note)"
+                    },
+                    {
+                        "id": "oHp1xjoBmvPWYup1SeJAGV",
+                        "groupId": "Conference w/ Place",
+                        "position": 4,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "5FAYLubqNb2YPBLCw9hTYx",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "cHW51G4jbPFizwaPsAaQ57",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Proceedings of <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Conference w/ place (inst note)"
+                    },
+                    {
+                        "id": "a34454Xvp2qwUqYA4P5WSE",
+                        "groupId": "Conference Paper",
+                        "position": 5,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "mJYKZJpFWLFQTFHZxCKhF5",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "mS6Dwmh1FUbUrrKSPKD8Zj",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Papers presented at the <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Conference papers (inst note)"
+                    },
+                    {
+                        "id": "un7VFJCzBENCDCDnTox7Li",
+                        "groupId": null,
+                        "position": 6,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "41gUDJPhW8p8z1ra3tGiyZ",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "fCesrrZbsRkP3mYuzaAjN6",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Title from cover."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Cover Title"
+                    },
+                    {
+                        "id": "jbxGp2kvRTgb8Zsx5gagF3",
+                        "groupId": null,
+                        "position": 7,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "rshpJPMV39LhRx7z8f637f",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "5pDP1m1y3bTUy6tXHq6pj4",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Also issued in electronic format."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "ggFa6HUsGvWrLtvJF7UW2p",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/addphys",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "nEkCVV5PvPJ9eTWTFQt8W4",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "additional physical form (addphys)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Electronic format"
+                    },
+                    {
+                        "id": "hoDnZgM8dpCi5v1tKn8mUj",
+                        "groupId": null,
+                        "position": 8,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "etAgr731fPUrLbWnZGuXG3",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "tpjsTP4dfJAJsHszbzktyr",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Errata slip inserted."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Errata"
+                    },
+                    {
+                        "id": "rbDPaA6aoSemAoNy7WXF1w",
+                        "groupId": "Filmographies",
+                        "position": 9,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "43KXJsDK3YdFESgQsWpsfg",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "3PdL2Js6G7SV92RQLE1Ubt",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Filmography: pages <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "ba8yCiJm5xFk4G5Hy6z82w",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "r7jbmo2ek3zvkt4QZdNpHf",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Filmographies (inst note)"
+                    },
+                    {
+                        "id": "6a2LEGznBDoWCgfC2pSHEU",
+                        "groupId": "Illustrations",
+                        "position": 10,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "fMr41wxHVmdbC9eBwgPYrG",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "8N1ypqgb3uewmxUTZC16eh",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "aPs4sDpRNbkoB7goupawA8",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/physical",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "kjpwjYNXoEYbHDajuU1yjg",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Illustrations (inst note)"
+                    },
+                    {
+                        "id": "5TKn4YXXJLqMGPWyTroz5X",
+                        "groupId": "Illustrations, Maps",
+                        "position": 11,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "ezFqjZVGQA3ZqQm6148sgb",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "4QKccRuymHT1XettzczEd2",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations, maps"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "34mGopKFGYAozdYf2aKbPH",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/physical",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "68HQGmijWkjBcCY81ZZc7g",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "illustrations, maps (inst note)"
+                    },
+                    {
+                        "id": "2Bn8c484HuufhwEBGTnvA7",
+                        "groupId": null,
+                        "position": 12,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "9Qs5RRRASnY4e9DzhsFxr2",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "fs8KTkyVUZ2EUDbyZm4KEW",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Map on lining papers."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map on lining"
+                    },
+                    {
+                        "id": "9JrmDww9V1wtkU9QuTuuZT",
+                        "groupId": null,
+                        "position": 13,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "tqmiuB4YNzm5oRdhxdz2ws",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "6yeoDwvubszE33L5J6Ujv7",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Originally published in <#####> under the title <#####>."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Originally published in"
+                    },
+                    {
+                        "id": "1wQq36r5nfrcubTudufpwY",
+                        "groupId": "Published In",
+                        "position": 14,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "hnno1uTLLCVMag6XDam49m",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "chEuLvho4qzQaNFmj2g1JK",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Published in (inst note)"
+                    },
+                    {
+                        "id": "s8VPQ8s61sVbsDJ5fpehn5",
+                        "groupId": null,
+                        "position": 15,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "i8JwqpCQtLKSgjZWZZShcG",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "cdPgazSxxBr9eF4ow3x24Z",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Reprint from the <#####>, <#####> edition"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Reprint from"
+                    },
+                    {
+                        "id": "nViLxKYkPzhhDvXhyD5BSu",
+                        "groupId": "Tête-beche ",
+                        "position": 16,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "1V3zFrnG3CRo2FYvjxDbQr",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "2RHgZ2Ty44peoAc9cjePTJ",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Titles from separate title pages"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "tête-beche (inst note1)"
+                    },
+                    {
+                        "id": "uFpoUjKRSD9tjgkhWD3rnK",
+                        "groupId": "Tête-beche ",
+                        "position": 17,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@guid": "wA5rLRvJwoBnDJK9GzD1ZA",
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "sLE9FNS7t6KAxzkANfNDSb",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "2a9sMzGrz4f3URrgKg3x9M",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Bound tête-beche."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "tête-beche (inst note2)"
+                    },
+                    {
+                        "id": "u25VubPFYL9vneMnzFvLDV",
+                        "groupId": null,
+                        "position": 18,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "oEyPf6D244wgDSvH12eVx6",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "32b5agfNwyPr8QFwWSgeSP",
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/accmat",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "8zbxNzMkXQjchQJn6gxnzy",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "rEZeqK6RWDvqNkFHamT7FB",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "errata"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": 1144029139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Errata for 300"
+                    },
+                    {
+                        "id": "sMUFPC5f3WLCkZ4UYj5wmo",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 19,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "oEyPf6D244wgDSvH12eVx6",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "32b5agfNwyPr8QFwWSgeSP",
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/accmat",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "8zbxNzMkXQjchQJn6gxnzy",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "rEZeqK6RWDvqNkFHamT7FB",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "1 map (<#####>cm x <#####>cm folded to <#####>cm)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": 1144029139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map (in Pocket) note (inst note 1)"
+                    },
+                    {
+                        "id": "oKdUHq1rfjmF2KqvzftoR1",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 20,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "aPtELCDzXKoVyY9wppB21J",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "dzZUv218ZC5Ciw6H3HkNsk",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes folded map in pocket"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": 1144029139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map (in Pocket) note (inst note 2)"
+                    },
+                    {
+                        "id": "tUXrKNmoqyzsCbA3ds5BwH",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 21,
+                        "structure": {
+                            "propertyLabel": "Carrier type",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
+                            "repeatable": "true",
+                            "resourceTemplates": [],
+                            "type": "lookup",
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/carriers"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": [
+                                    {
+                                        "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                        "defaultLiteral": "volume"
+                                    }
+                                ]
+                            },
+                            "mandatory": "true",
+                            "remark": "https://original.rdatoolkit.org/3.3.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/carrier",
+                                "http://id.loc.gov/ontologies/bibframe/carrier": [
+                                    {
+                                        "@guid": "sALQXQjwbccSbrycUXrjeU",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Carrier",
+                                        "@id": "http://id.loc.gov/vocabulary/carriers/nb",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "sJeEEeY9aqauMKCMLSVZKV",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "sheet (nb)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/carrier|http://id.loc.gov/ontologies/bibframe/Carrier",
+                            "id": "id_loc_gov_ontologies_bibframe_carrier__carrier_type",
+                            "hashCode": 505732971,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/carrier|http://id.loc.gov/ontologies/bibframe/Carrier",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map (in Pocket) note (carr type)"
+                    },
+                    {
+                        "id": "a73kDKzy8ZHrydBw4jHYgg",
+                        "groupId": "Bib",
+                        "position": 22,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "jebvh31R44hMRF3VJ63FqP",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "2KBmJKDYx1K83NvTaykSS2",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes bibliographical references (pages <#####>)"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "ezpj9yMKdkDWPmN4T9Jh9E",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "icWr6SJCWKjuXPSJzy21uk",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Bib (inst note)"
+                    },
+                    {
+                        "id": "wboCqChLqq3ePAAvMN4Jkd",
+                        "groupId": "Index",
+                        "position": 24,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "jebvh31R44hMRF3VJ63FqP",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "2KBmJKDYx1K83NvTaykSS2",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes index."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/index",
+                                                "@guid": "wnKsweffoEGfPiBpyQFhPf",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "h1isHramUc1czfK1KZVhVn",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Index (instance note)"
+                    },
+                    {
+                        "id": "eam9xJ4An2v1xSMWZjkGey",
+                        "groupId": "Bib/Index",
+                        "position": 24,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "wyqrcnknWL3SG55xE42Y39",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "aHgdrLHeb3qhKQrmywcA5Y",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes bibliographical references (pages <#####>) and index."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "gPrhhBM3sdTUdnKUagQTZd",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "j9m4gygavZ1VPLmzZ5Wxne",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            },
+                                            {
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/index",
+                                                "@guid": "fjAQUfwF4F1Sogd2Y9QGfC",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "9DuGPe9yKWFZqFWU4S7BMR",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Bib/Index (inst note)"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/lib/defaults/default_components.json
+++ b/src/lib/defaults/default_components.json
@@ -5,7 +5,7 @@
                 "groups": [
                     {
                         "id": "uPGPwtgYsvoh8E9NjJAKED",
-                        "groupId": "A",
+                        "groupId": "Bib",
                         "position": 0,
                         "structure": {
                             "mandatory": "false",
@@ -56,7 +56,7 @@
                     },
                     {
                         "id": "oQi93DZwLFw6wz4VNdwShV",
-                        "groupId": "B",
+                        "groupId": "Bib/Index",
                         "position": 1,
                         "structure": {
                             "mandatory": "false",
@@ -118,7 +118,7 @@
                     },
                     {
                         "id": "wxMKo6adfY9AYw9iSkDoEB",
-                        "groupId": "C",
+                        "groupId": "Board Books",
                         "position": 2,
                         "structure": {
                             "mandatory": "false",
@@ -181,7 +181,7 @@
                     },
                     {
                         "id": "uiwUFXh79yw5yq2kSVVsAo",
-                        "groupId": "D",
+                        "groupId": "Color Ill., Color Maps",
                         "position": 3,
                         "structure": {
                             "mandatory": "false",
@@ -235,7 +235,7 @@
                     },
                     {
                         "id": "knAoj72CTJBEMUGWX482cW",
-                        "groupId": "D",
+                        "groupId": "Color Ill., Color Maps",
                         "position": 4,
                         "structure": {
                             "mandatory": "false",
@@ -287,7 +287,7 @@
                     },
                     {
                         "id": "psg5S4vFBYoUkKLueaQsFs",
-                        "groupId": "D",
+                        "groupId": "Color Ill., Color Maps",
                         "position": 5,
                         "structure": {
                             "mandatory": "false",
@@ -350,7 +350,7 @@
                     },
                     {
                         "id": "12U79Pa2gsD43GNcx3BeRM",
-                        "groupId": "D",
+                        "groupId": "Color Ill., Color Maps",
                         "position": 6,
                         "structure": {
                             "mandatory": "true",
@@ -409,7 +409,7 @@
                     },
                     {
                         "id": "e23K4t6fH8tbAzuaB8uzM4",
-                        "groupId": "E",
+                        "groupId": "Conference w/ place",
                         "position": 7,
                         "structure": {
                             "mandatory": "false",
@@ -472,7 +472,7 @@
                     },
                     {
                         "id": "ejJEAw1h2bYhjcqDh3ZnN5",
-                        "groupId": "F",
+                        "groupId": "Conference Papers",
                         "position": 8,
                         "structure": {
                             "mandatory": "false",
@@ -535,7 +535,7 @@
                     },
                     {
                         "id": "n4HWqpLb89b4YXkkYMUwGo",
-                        "groupId": "G",
+                        "groupId": "Filmographies",
                         "position": 9,
                         "structure": {
                             "mandatory": "false",
@@ -598,7 +598,7 @@
                     },
                     {
                         "id": "szfB3VDbDQvxKWzBs4A6cY",
-                        "groupId": "H",
+                        "groupId": "Illustrations",
                         "position": 10,
                         "structure": {
                             "mandatory": "false",
@@ -652,7 +652,7 @@
                     },
                     {
                         "id": "45J7S6wFR9MxMyLTsgXQjM",
-                        "groupId": "I",
+                        "groupId": "Illustrations, Map",
                         "position": 11,
                         "structure": {
                             "mandatory": "false",
@@ -717,7 +717,7 @@
                     },
                     {
                         "id": "ahEhfXn41MtA9EaUMCweev",
-                        "groupId": "J",
+                        "groupId": "Index",
                         "position": 12,
                         "structure": {
                             "mandatory": "false",
@@ -768,7 +768,7 @@
                     },
                     {
                         "id": "3wkzw5RdkEm2DxCKsyTxFF",
-                        "groupId": "K",
+                        "groupId": "Maps",
                         "position": 13,
                         "structure": {
                             "mandatory": "false",
@@ -822,7 +822,7 @@
                     },
                     {
                         "id": "8uUfFdgFt1c7drrUSNJWet",
-                        "groupId": "K",
+                        "groupId": "Maps",
                         "position": 14,
                         "structure": {
                             "mandatory": "false",
@@ -885,7 +885,7 @@
                     },
                     {
                         "id": "qUqxWicHaSrbJULDi1QLoh",
-                        "groupId": "K",
+                        "groupId": "Maps",
                         "position": 15,
                         "structure": {
                             "mandatory": "true",
@@ -944,7 +944,7 @@
                     },
                     {
                         "id": "f9mmBUXVSjkfTupSAoskUS",
-                        "groupId": "L",
+                        "groupId": "Map (in Pocket)",
                         "position": 16,
                         "structure": {
                             "mandatory": "true",
@@ -1003,7 +1003,7 @@
                     },
                     {
                         "id": "boJBYBqeSzK9XrAwGyZDxC",
-                        "groupId": "L",
+                        "groupId": "Map (in Pocket)",
                         "position": 17,
                         "structure": {
                             "mandatory": "false",
@@ -1057,7 +1057,7 @@
                     },
                     {
                         "id": "3j6BUnq5xXB6u21VBPDAY7",
-                        "groupId": "L",
+                        "groupId": "Map (in Pocket)",
                         "position": 18,
                         "structure": {
                             "mandatory": "false",
@@ -1181,7 +1181,7 @@
                     },
                     {
                         "id": "1MtRxZnnBuKwo67ASuzGAY",
-                        "groupId": "M",
+                        "groupId": "Published in",
                         "position": 20,
                         "structure": {
                             "mandatory": "false",
@@ -1325,7 +1325,7 @@
                     },
                     {
                         "id": "cXTrRSB9GRLEZy89AWxjq3",
-                        "groupId": "N",
+                        "groupId": "Catalog of an Exhibition",
                         "position": 23,
                         "structure": {
                             "mandatory": "false",
@@ -1373,7 +1373,7 @@
                     },
                     {
                         "id": "mrAx2R3PDdjjoAEp2AmRYp",
-                        "groupId": "N",
+                        "groupId": "Catalog of an Exhibition",
                         "position": 24,
                         "structure": {
                             "mandatory": "false",
@@ -1484,7 +1484,7 @@
                     },
                     {
                         "id": "aQTMQyRAWtJHDGSeA8HWMk",
-                        "groupId": "P",
+                        "groupId": "Discography",
                         "position": 26,
                         "structure": {
                             "mandatory": "false",
@@ -1600,7 +1600,7 @@
                     },
                     {
                         "id": "8RXuQHsvWb9LgYBFaZqHuM",
-                        "groupId": "A",
+                        "groupId": "Bib",
                         "position": 1,
                         "structure": {
                             "mandatory": "false",
@@ -1662,7 +1662,7 @@
                     },
                     {
                         "id": "wbxmhnds2SNgeCkXgv3xZ2",
-                        "groupId": "B",
+                        "groupId": "Bib/Index",
                         "position": 2,
                         "structure": {
                             "mandatory": "false",
@@ -1724,7 +1724,7 @@
                     },
                     {
                         "id": "oz9cCaZRCmBUdxxNQvTvY3",
-                        "groupId": "C",
+                        "groupId": "Board Books",
                         "position": 3,
                         "structure": {
                             "mandatory": "false",
@@ -1822,7 +1822,7 @@
                     },
                     {
                         "id": "bEHyUxP7ceGphmXFoNX6pE",
-                        "groupId": "E",
+                        "groupId": "Conference w/ place",
                         "position": 5,
                         "structure": {
                             "mandatory": "false",
@@ -1871,7 +1871,7 @@
                     },
                     {
                         "id": "cukFCz5NZC8gRwhKhoyvH8",
-                        "groupId": "F",
+                        "groupId": "Conference Papers",
                         "position": 6,
                         "structure": {
                             "mandatory": "false",
@@ -2142,7 +2142,7 @@
                     },
                     {
                         "id": "mxLHLbmugmEaqLvu1VgJYV",
-                        "groupId": "G",
+                        "groupId": "Filmographies",
                         "position": 11,
                         "structure": {
                             "mandatory": "false",
@@ -2191,7 +2191,7 @@
                     },
                     {
                         "id": "awdinUMoF7FU5hhzZ948fJ",
-                        "groupId": "H",
+                        "groupId": "Illustrations",
                         "position": 12,
                         "structure": {
                             "mandatory": "false",
@@ -2240,7 +2240,7 @@
                     },
                     {
                         "id": "rA9Dofs4QZ38hUxrjxqRcY",
-                        "groupId": "I",
+                        "groupId": "Illustrations, Map",
                         "position": 13,
                         "structure": {
                             "mandatory": "false",
@@ -2302,7 +2302,7 @@
                     },
                     {
                         "id": "8gb8rhJrQ85HuQCM2BP1J3",
-                        "groupId": "J",
+                        "groupId": "Index",
                         "position": 14,
                         "structure": {
                             "mandatory": "false",
@@ -2364,7 +2364,7 @@
                     },
                     {
                         "id": "jcLrzSYYYzhQqnLCcLr88p",
-                        "groupId": "L",
+                        "groupId": "Map (in Pocket)",
                         "position": 15,
                         "structure": {
                             "mandatory": "false",
@@ -2413,7 +2413,7 @@
                     },
                     {
                         "id": "tpj8RUpNkZne2mQjMuERsq",
-                        "groupId": "L",
+                        "groupId": "Map (in Pocket)",
                         "position": 16,
                         "structure": {
                             "mandatory": "false",
@@ -2573,7 +2573,7 @@
                     },
                     {
                         "id": "9Eu87Dh9Wrh1njyH5zoBAB",
-                        "groupId": "M",
+                        "groupId": "Published in",
                         "position": 19,
                         "structure": {
                             "mandatory": "false",
@@ -2671,7 +2671,7 @@
                     },
                     {
                         "id": "wKUYcGAPPwFLZ5NxvjNhWC",
-                        "groupId": "O",
+                        "groupId": "Tete-beche",
                         "position": 21,
                         "structure": {
                             "mandatory": "false",
@@ -2720,7 +2720,7 @@
                     },
                     {
                         "id": "jLcj1twxTNA3TKKUELojcB",
-                        "groupId": "O",
+                        "groupId": "Tete-beche",
                         "position": 22,
                         "structure": {
                             "mandatory": "false",
@@ -2769,7 +2769,7 @@
                     },
                     {
                         "id": "fxGfrvxDfxD2k2dLpwrGBx",
-                        "groupId": "P",
+                        "groupId": "Discography",
                         "position": 23,
                         "structure": {
                             "mandatory": "false",

--- a/src/lib/defaults/default_components_staging.json
+++ b/src/lib/defaults/default_components_staging.json
@@ -4,8 +4,8 @@
             "lc:RT:bf2:Monograph:Work:Default": {
                 "groups": [
                     {
-                        "id": "uPGPwtgYsvoh8E9NjJAKED",
-                        "groupId": "A",
+                        "id": "qujRRCigqesRdsog8yL6HY",
+                        "groupId": null,
                         "position": 0,
                         "structure": {
                             "mandatory": "false",
@@ -15,121 +15,8 @@
                             "valueConstraint": {
                                 "valueTemplateRefs": [],
                                 "useValuesFrom": [
-                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                    "http://id.loc.gov/authorities/genreForms"
                                 ],
-                                "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-                                },
-                                "defaults": []
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-                            "propertyLabel": "Supplementary content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
-                                    {
-                                        "@guid": "vCgCdTmcmhcjy3PGHDAXDn",
-                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/bibliography",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "tFys4XBvT8izGPUncnT7Za",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (bibliography)"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
-                            "hashCode": -13789748,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Bib (supp cntnt)"
-                    },
-                    {
-                        "id": "oQi93DZwLFw6wz4VNdwShV",
-                        "groupId": "B",
-                        "position": 1,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "lookup",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [],
-                                "useValuesFrom": [
-                                    "http://id.loc.gov/vocabulary/msupplcont"
-                                ],
-                                "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-                                },
-                                "defaults": []
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-                            "propertyLabel": "Supplementary content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
-                                    {
-                                        "@guid": "vCgCdTmcmhcjy3PGHDAXDn",
-                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/bibliography",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "tFys4XBvT8izGPUncnT7Za",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (bibliography)"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/index",
-                                        "@guid": "6SoYJVRKoWciyxoZRRCEqe",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "4CddwJ7aKRReFHJJqTZh77",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
-                                            }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
-                            "hashCode": -13789748,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Bib/Index (supp cntnt)"
-                    },
-                    {
-                        "id": "wxMKo6adfY9AYw9iSkDoEB",
-                        "groupId": "C",
-                        "position": 2,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
-                                ],
-                                "useValuesFrom": [],
                                 "valueDataType": {
                                     "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
                                     "dataTypeLabel": "",
@@ -148,19 +35,19 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
                                 "http://id.loc.gov/ontologies/bibframe/genreForm": [
                                     {
-                                        "@guid": "9YZCLqbsbzVzLgA9iXPx27",
+                                        "@guid": "a27MUdmvmYfmEDKkfSewot",
                                         "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
                                         "@id": "http://id.loc.gov/authorities/genreForms/gf2021026043",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "9RcZxiRWSUxuPaX9NowJNR",
+                                                "@guid": "irinHaKTENoZyBAXL6YjDC",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "Board books",
                                                 "@language": "en"
                                             }
                                         ],
                                         "http://id.loc.gov/ontologies/bflc/marcKey": [
                                             {
-                                                "@guid": "vEf2pGiN9qE6duxF1u87Ca",
+                                                "@guid": "dD8Sdf9cmgXNkJeKRNRHQZ",
                                                 "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aBoard books"
                                             }
                                         ]
@@ -171,18 +58,18 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
+                            "hashCode": -1521279090,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Board books (gf)"
+                        "label": "Board Books (Genre/Form)"
                     },
                     {
-                        "id": "uiwUFXh79yw5yq2kSVVsAo",
-                        "groupId": "D",
-                        "position": 3,
+                        "id": "fNoqo5cVP3oNrE685CLHre",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 1,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
@@ -202,19 +89,19 @@
                             },
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                             "propertyLabel": "Illustrative content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
                                 "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                                 "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
                                     {
-                                        "@guid": "n9eYH8NiiPZwQtALcfevb9",
+                                        "@guid": "aeHsUyLZnszcdjzWLXThe7",
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
                                         "@id": "http://id.loc.gov/vocabulary/millus/ill",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "sZPoL2RYygF9KZUctb6Cxi",
+                                                "@guid": "fXvedNnjenASq8uhMygDwR",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
                                             }
                                         ]
@@ -225,18 +112,72 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
-                            "hashCode": 205380255,
+                            "hashCode": 1504301028,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Color ill, color maps (ill cntnt)"
+                        "label": "Color ill, color maps (ill cntnt1)"
                     },
                     {
-                        "id": "knAoj72CTJBEMUGWX482cW",
-                        "groupId": "D",
-                        "position": 4,
+                        "id": "9Dirnr9snKff9P7vYn3Lpj",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 2,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "nURNYc8Er9DDiXb5wHNTAz",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/map",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "358fwogU4GxG8NaKt5FpGe",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (ill cntnt2)"
+                    },
+                    {
+                        "id": "rBSX7qsyApGfiLWippgdmq",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 3,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
@@ -254,19 +195,19 @@
                             },
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
                             "propertyLabel": "Color content",
-                            "remark": "https://original.rdatoolkit.org/7.17.html",
+                            "remark": "http://original.rdatoolkit.org/7.17.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
                                 "@root": "http://id.loc.gov/ontologies/bibframe/colorContent",
                                 "http://id.loc.gov/ontologies/bibframe/colorContent": [
                                     {
-                                        "@guid": "syKd3NRZEA42jPSuMkSc8Z",
+                                        "@guid": "8b1rfbuW5YeYDvGgcGxAaB",
                                         "@type": "http://id.loc.gov/ontologies/bibframe/ColorContent",
                                         "@id": "http://id.loc.gov/vocabulary/mcolor/mul",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "ajYpkVgxDKGf7DLPS2XjT7",
+                                                "@guid": "xo6K8tiasMJNEjKpSvPuX1",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "color (mul)"
                                             }
                                         ]
@@ -277,7 +218,7 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/colorContent|http://id.loc.gov/ontologies/bibframe/ColorContent",
                             "id": "id_loc_gov_ontologies_bibframe_colorContent__color_content",
-                            "hashCode": -1574658025,
+                            "hashCode": -1472373724,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/colorContent|http://id.loc.gov/ontologies/bibframe/ColorContent",
                             "hasData": true,
                             "userModified": true,
@@ -286,19 +227,19 @@
                         "label": "Color ill, color maps (clr cntnt)"
                     },
                     {
-                        "id": "psg5S4vFBYoUkKLueaQsFs",
-                        "groupId": "D",
-                        "position": 5,
+                        "id": "jSwCsjZDquD7UCxLWfihNH",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 4,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
-                            "type": "resource",
+                            "type": "lookup",
                             "resourceTemplates": [],
                             "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
                                 ],
-                                "useValuesFrom": [],
                                 "valueDataType": {
                                     "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
                                     "dataTypeLabel": "",
@@ -317,19 +258,19 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
                                 "http://id.loc.gov/ontologies/bibframe/genreForm": [
                                     {
-                                        "@guid": "qRhz8woQ1yRzmjbaWXk4DS",
+                                        "@guid": "tLQ4BsPTriYg62EuEu1pX5",
                                         "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
                                         "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "4pyZvdkgggczcsEq6DfwXK",
+                                                "@guid": "6JcF5z1HNkKewqiSFGB3cW",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
                                                 "@language": "en"
                                             }
                                         ],
                                         "http://id.loc.gov/ontologies/bflc/marcKey": [
                                             {
-                                                "@guid": "hAHYQn2h2u52Msp13Lm1LG",
+                                                "@guid": "8nAjKoPeugda6QsGzRUs8m",
                                                 "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
                                             }
                                         ]
@@ -340,18 +281,18 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
+                            "hashCode": -1521279090,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Color ill, color maps (gf)"
+                        "label": "Color ill, color maps (g/f)"
                     },
                     {
-                        "id": "12U79Pa2gsD43GNcx3BeRM",
-                        "groupId": "D",
-                        "position": 6,
+                        "id": "qTZXJJC6fX7fs4KD9PEDDf",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 5,
                         "structure": {
                             "mandatory": "true",
                             "repeatable": "true",
@@ -376,19 +317,19 @@
                             },
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
                             "propertyLabel": "Content type",
-                            "remark": "https://original.rdatoolkit.org/6.9.html",
+                            "remark": "http://original.rdatoolkit.org/6.9.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
                                 "@root": "http://id.loc.gov/ontologies/bibframe/content",
                                 "http://id.loc.gov/ontologies/bibframe/content": [
                                     {
-                                        "@guid": "qs7i2KErdfpxQebeXxBdHS",
+                                        "@guid": "kuESMVdS71VxoAJqKxF8wR",
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Content",
                                         "@id": "http://id.loc.gov/vocabulary/contentTypes/cri",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "dRVVUgVuBu9aP4Wy9CKVAi",
+                                                "@guid": "hLqxQLdPf59U9Gn4hyL5fq",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
                                             }
                                         ]
@@ -399,7 +340,7 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
                             "id": "id_loc_gov_ontologies_bibframe_content__content_type",
-                            "hashCode": -821362884,
+                            "hashCode": -211358670,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
                             "hasData": true,
                             "userModified": true,
@@ -408,19 +349,82 @@
                         "label": "Color ill, color maps (cntnt type)"
                     },
                     {
-                        "id": "e23K4t6fH8tbAzuaB8uzM4",
-                        "groupId": "E",
+                        "id": "vShrp7HNvp3GQFmywkgfUg",
+                        "groupId": "Conference w/ Place",
+                        "position": 6,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "riuKNMyqFWT8bir4eKahuS",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "d9vqmqDR8op5kxyuKURh5a",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Conference papers and proceedings",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "sriGPU7mwQVV9Sjuvtz6GX",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aConference papers and proceedings"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Conference w/ place (g/f)"
+                    },
+                    {
+                        "id": "5tK2pM8iEJLrPWrGDKopfU",
+                        "groupId": "Conference Paper",
                         "position": 7,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
-                            "type": "resource",
+                            "type": "lookup",
                             "resourceTemplates": [],
                             "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
                                 ],
-                                "useValuesFrom": [],
                                 "valueDataType": {
                                     "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
                                     "dataTypeLabel": "",
@@ -439,19 +443,19 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
                                 "http://id.loc.gov/ontologies/bibframe/genreForm": [
                                     {
-                                        "@guid": "k1cjSh9tjemEcqok5uqvLe",
+                                        "@guid": "riuKNMyqFWT8bir4eKahuS",
                                         "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
                                         "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "ksV3J7H9oUa32BD1WaZ56j",
+                                                "@guid": "d9vqmqDR8op5kxyuKURh5a",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "Conference papers and proceedings",
                                                 "@language": "en"
                                             }
                                         ],
                                         "http://id.loc.gov/ontologies/bflc/marcKey": [
                                             {
-                                                "@guid": "1p8Kp8Xvaq3QdDJP2PFit9",
+                                                "@guid": "sriGPU7mwQVV9Sjuvtz6GX",
                                                 "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aConference papers and proceedings"
                                             }
                                         ]
@@ -462,28 +466,28 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
+                            "hashCode": -1521279090,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Conference w/ place (gf)"
+                        "label": "Conference papers (g/f)"
                     },
                     {
-                        "id": "ejJEAw1h2bYhjcqDh3ZnN5",
-                        "groupId": "F",
+                        "id": "7yazpDhLc4ZsV94Pp1VyB8",
+                        "groupId": "Filmographies",
                         "position": 8,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
-                            "type": "resource",
+                            "type": "lookup",
                             "resourceTemplates": [],
                             "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
                                 ],
-                                "useValuesFrom": [],
                                 "valueDataType": {
                                     "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
                                     "dataTypeLabel": "",
@@ -502,82 +506,19 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
                                 "http://id.loc.gov/ontologies/bibframe/genreForm": [
                                     {
-                                        "@guid": "k1cjSh9tjemEcqok5uqvLe",
-                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
-                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026068",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "ksV3J7H9oUa32BD1WaZ56j",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Conference papers and proceedings",
-                                                "@language": "en"
-                                            }
-                                        ],
-                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
-                                            {
-                                                "@guid": "1p8Kp8Xvaq3QdDJP2PFit9",
-                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aConference papers and proceedings"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
-                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Conference papers (gf)"
-                    },
-                    {
-                        "id": "n4HWqpLb89b4YXkkYMUwGo",
-                        "groupId": "G",
-                        "position": 9,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
-                                ],
-                                "useValuesFrom": [],
-                                "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
-                                    "dataTypeLabel": "",
-                                    "remark": ""
-                                },
-                                "defaults": [],
-                                "editable": "true",
-                                "repeatable": "true"
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
-                            "propertyLabel": "Genre/Form",
-                            "remark": "",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
-                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
-                                    {
-                                        "@guid": "9JeaKnwoPmMCVrR7mZtHyW",
+                                        "@guid": "iCL2fBzb6xRTcFda83nYH4",
                                         "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
                                         "@id": "http://id.loc.gov/authorities/genreForms/gf2019026014",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "bAUWw3AhB4n3bTTEPfDA5s",
+                                                "@guid": "rr2VJjT4AfKTVFYednCTkH",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "Filmographies",
                                                 "@language": "en"
                                             }
                                         ],
                                         "http://id.loc.gov/ontologies/bflc/marcKey": [
                                             {
-                                                "@guid": "qRgAdCRKMExkJrpU8fgXuu",
+                                                "@guid": "9TYu55qFU88rq2MaTFXQEx",
                                                 "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aFilmographies"
                                             }
                                         ]
@@ -588,17 +529,71 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
+                            "hashCode": -1521279090,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Filmographies (gf)"
+                        "label": "Filmographies (g/f)"
                     },
                     {
-                        "id": "szfB3VDbDQvxKWzBs4A6cY",
-                        "groupId": "H",
+                        "id": "tnaJzZNtvj8PrT1x84togJ",
+                        "groupId": "Illustrations",
+                        "position": 9,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
+                                    {
+                                        "@guid": "eDCQo8XGWVmk91wot6Z7VE",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/ill",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "bvAxNseSFHR4qXhqH4zdZr",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": 1504301028,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Illustrations (ill cntnt)"
+                    },
+                    {
+                        "id": "aM1Nq8frmrdqhbLbnqqDzR",
+                        "groupId": "Illustrations, Maps",
                         "position": 10,
                         "structure": {
                             "mandatory": "false",
@@ -619,19 +614,19 @@
                             },
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                             "propertyLabel": "Illustrative content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
                                 "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                                 "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
                                     {
-                                        "@guid": "hpvtRuXNBDn4S7Nr6464KS",
+                                        "@guid": "eDCQo8XGWVmk91wot6Z7VE",
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
                                         "@id": "http://id.loc.gov/vocabulary/millus/ill",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7im4k2Mc8ajvA2crzRiDRX",
+                                                "@guid": "bvAxNseSFHR4qXhqH4zdZr",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
                                             }
                                         ]
@@ -642,17 +637,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
-                            "hashCode": 205380255,
+                            "hashCode": 1504301028,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Illustrations (ill cntnt)"
+                        "label": "illustrations, maps (ill cntnt1)"
                     },
                     {
-                        "id": "45J7S6wFR9MxMyLTsgXQjM",
-                        "groupId": "I",
+                        "id": "o6qKexmBexoosGKduseGFQ",
+                        "groupId": "Illustrations, Maps",
                         "position": 11,
                         "structure": {
                             "mandatory": "false",
@@ -673,33 +668,22 @@
                             },
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                             "propertyLabel": "Illustrative content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
                                 "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                                 "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
                                     {
-                                        "@guid": "hpvtRuXNBDn4S7Nr6464KS",
+                                        "@guid": "dSMzQ8FphdLHCmmq9zQS3L",
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
-                                        "@id": "http://id.loc.gov/vocabulary/millus/ill",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "7im4k2Mc8ajvA2crzRiDRX",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "@id": "http://id.loc.gov/vocabulary/millus/map",
-                                        "@guid": "eQ9QtzNbKng5FDCBcRVWky",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "kqX2rkDfLYFenRerG5q8JU",
+                                                "@guid": "vBk7gGdRCiz1qjbYTiATBS",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
                                             }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                        ]
                                     }
                                 ]
                             },
@@ -707,17 +691,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
-                            "hashCode": 205380255,
+                            "hashCode": 1504301028,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Illustrations , map (ill cntnt)"
+                        "label": "illustrations, maps (ill cntnt2)"
                     },
                     {
-                        "id": "ahEhfXn41MtA9EaUMCweev",
-                        "groupId": "J",
+                        "id": "fjDFHjGjdi6d8uSDGWguJ3",
+                        "groupId": "Illustrations, Maps",
                         "position": 12,
                         "structure": {
                             "mandatory": "false",
@@ -727,28 +711,40 @@
                             "valueConstraint": {
                                 "valueTemplateRefs": [],
                                 "useValuesFrom": [
-                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                    "http://id.loc.gov/authorities/genreForms"
                                 ],
                                 "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
                                 },
-                                "defaults": []
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
                             },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-                            "propertyLabel": "Supplementary content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
                                     {
-                                        "@guid": "3qh93DGTBCFvYYkfQALFcn",
-                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/index",
+                                        "@guid": "nfqSRTVjRBpoyncmEhLax8",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "19FHxbw63W4arnVSZTzxVG",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                                "@guid": "8b7M64cbp42sHW9CvJ6bBA",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "pdXFfKpE9MjUDtWP6avEcZ",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
                                             }
                                         ]
                                     }
@@ -756,20 +752,83 @@
                             },
                             "@guid": null,
                             "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
-                            "hashCode": -13789748,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Index (supp cntnt)"
+                        "label": "illustrations, maps (g/f)"
                     },
                     {
-                        "id": "3wkzw5RdkEm2DxCKsyTxFF",
-                        "groupId": "K",
+                        "id": "b9cY83wahc8fkcUcuv7VGL",
+                        "groupId": "Maps",
                         "position": 13,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                                    "dataTypeLabel": "",
+                                    "remark": ""
+                                },
+                                "defaults": [],
+                                "editable": "true",
+                                "repeatable": "true"
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                            "propertyLabel": "Genre/Form",
+                            "remark": "",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
+                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
+                                    {
+                                        "@guid": "nfqSRTVjRBpoyncmEhLax8",
+                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "8b7M64cbp42sHW9CvJ6bBA",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
+                                                "@language": "en"
+                                            }
+                                        ],
+                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
+                                            {
+                                                "@guid": "pdXFfKpE9MjUDtWP6avEcZ",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
+                            "hashCode": -1521279090,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Maps (g/f)"
+                    },
+                    {
+                        "id": "aLUUU2dm9qTuaFhoDosjk2",
+                        "groupId": "Maps",
+                        "position": 14,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
@@ -789,19 +848,19 @@
                             },
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                             "propertyLabel": "Illustrative content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
+                            "remark": "http://original.rdatoolkit.org/7.15.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
                                 "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
                                 "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
                                     {
-                                        "@guid": "qc4pP1eCwYZMwixTWDHmXF",
+                                        "@guid": "dSMzQ8FphdLHCmmq9zQS3L",
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
                                         "@id": "http://id.loc.gov/vocabulary/millus/map",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "opYvbRLVQbFgU7m7YGm34a",
+                                                "@guid": "vBk7gGdRCiz1qjbYTiATBS",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
                                             }
                                         ]
@@ -812,7 +871,7 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
-                            "hashCode": 205380255,
+                            "hashCode": 1504301028,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "hasData": true,
                             "userModified": true,
@@ -821,71 +880,8 @@
                         "label": "Maps (ill cntnt)"
                     },
                     {
-                        "id": "8uUfFdgFt1c7drrUSNJWet",
-                        "groupId": "K",
-                        "position": 14,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
-                                ],
-                                "useValuesFrom": [],
-                                "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
-                                    "dataTypeLabel": "",
-                                    "remark": ""
-                                },
-                                "defaults": [],
-                                "editable": "true",
-                                "repeatable": "true"
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
-                            "propertyLabel": "Genre/Form",
-                            "remark": "",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
-                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
-                                    {
-                                        "@guid": "cp5hbZz1yQxixdaHTALL3a",
-                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
-                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "9hzApQdbgZS7Q6cHyE3fmo",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
-                                                "@language": "en"
-                                            }
-                                        ],
-                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
-                                            {
-                                                "@guid": "6MKvMd1rpPgBVygrhvt1SW",
-                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
-                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Maps (gf)"
-                    },
-                    {
-                        "id": "qUqxWicHaSrbJULDi1QLoh",
-                        "groupId": "K",
+                        "id": "4zytgeKUuAqVNhSusXBwSD",
+                        "groupId": "Maps",
                         "position": 15,
                         "structure": {
                             "mandatory": "true",
@@ -911,19 +907,19 @@
                             },
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
                             "propertyLabel": "Content type",
-                            "remark": "https://original.rdatoolkit.org/6.9.html",
+                            "remark": "http://original.rdatoolkit.org/6.9.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
                                 "@root": "http://id.loc.gov/ontologies/bibframe/content",
                                 "http://id.loc.gov/ontologies/bibframe/content": [
                                     {
-                                        "@guid": "gDFt4MLp1suNhA7CwZoq4B",
+                                        "@guid": "4ncDt2zwJQU4sJWySGrqMi",
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Content",
                                         "@id": "http://id.loc.gov/vocabulary/contentTypes/cri",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "srLcpXUjoCpefAV4LGD1U4",
+                                                "@guid": "sjtEeE82dGVQwFsUPcavEf",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
                                             }
                                         ]
@@ -934,7 +930,7 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
                             "id": "id_loc_gov_ontologies_bibframe_content__content_type",
-                            "hashCode": -821362884,
+                            "hashCode": -211358670,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
                             "hasData": true,
                             "userModified": true,
@@ -943,185 +939,9 @@
                         "label": "Maps (cntnt type)"
                     },
                     {
-                        "id": "f9mmBUXVSjkfTupSAoskUS",
-                        "groupId": "L",
-                        "position": 16,
-                        "structure": {
-                            "mandatory": "true",
-                            "repeatable": "true",
-                            "type": "lookup",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [],
-                                "useValuesFrom": [
-                                    "http://id.loc.gov/vocabulary/contentTypes"
-                                ],
-                                "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
-                                },
-                                "editable": "false",
-                                "repeatable": "true",
-                                "defaults": [
-                                    {
-                                        "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-                                        "defaultLiteral": "text"
-                                    }
-                                ]
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
-                            "propertyLabel": "Content type",
-                            "remark": "https://original.rdatoolkit.org/6.9.html",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/content",
-                                "http://id.loc.gov/ontologies/bibframe/content": [
-                                    {
-                                        "@guid": "gDFt4MLp1suNhA7CwZoq4B",
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Content",
-                                        "@id": "http://id.loc.gov/vocabulary/contentTypes/cri",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "srLcpXUjoCpefAV4LGD1U4",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
-                            "id": "id_loc_gov_ontologies_bibframe_content__content_type",
-                            "hashCode": -821362884,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Map (in Pocket) note (cntnt type)"
-                    },
-                    {
-                        "id": "boJBYBqeSzK9XrAwGyZDxC",
-                        "groupId": "L",
-                        "position": 17,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "lookup",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [],
-                                "useValuesFrom": [
-                                    "http://id.loc.gov/vocabulary/millus"
-                                ],
-                                "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
-                                },
-                                "repeatable": "true",
-                                "editable": "false",
-                                "defaults": []
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
-                            "propertyLabel": "Illustrative content",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
-                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
-                                    {
-                                        "@guid": "qc4pP1eCwYZMwixTWDHmXF",
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
-                                        "@id": "http://id.loc.gov/vocabulary/millus/map",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "opYvbRLVQbFgU7m7YGm34a",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
-                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
-                            "hashCode": 205380255,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Map (in Pocket) note (ill cntnt)"
-                    },
-                    {
-                        "id": "3j6BUnq5xXB6u21VBPDAY7",
-                        "groupId": "L",
-                        "position": 18,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
-                                ],
-                                "useValuesFrom": [],
-                                "valueDataType": {
-                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
-                                    "dataTypeLabel": "",
-                                    "remark": ""
-                                },
-                                "defaults": [],
-                                "editable": "true",
-                                "repeatable": "true"
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
-                            "propertyLabel": "Genre/Form",
-                            "remark": "",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
-                                "http://id.loc.gov/ontologies/bibframe/genreForm": [
-                                    {
-                                        "@guid": "cp5hbZz1yQxixdaHTALL3a",
-                                        "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
-                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "9hzApQdbgZS7Q6cHyE3fmo",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
-                                                "@language": "en"
-                                            }
-                                        ],
-                                        "http://id.loc.gov/ontologies/bflc/marcKey": [
-                                            {
-                                                "@guid": "6MKvMd1rpPgBVygrhvt1SW",
-                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
-                            "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Map (in Pocket) note (gf)"
-                    },
-                    {
-                        "id": "sN7iJ39gEyYfrioEaxAP4e",
+                        "id": "rfhb6VKo9F2rrBqdVi1i8V",
                         "groupId": null,
-                        "position": 19,
+                        "position": 16,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
@@ -1143,21 +963,21 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "cXFF4SRtXLwvX35EV4eSUh",
+                                        "@guid": "a7HcoopzA4coReKbxAZKNu",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "k6F8LzhU2XCVvERsFz4sTT",
+                                                "@guid": "hi67V8Q2uP52Hh9k1fa2Mh",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "Translated from <#####>"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note",
                                         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
                                             {
-                                                "@guid": "fmB29thzMU3Bda7Uy9wsND",
+                                                "@guid": "rQkXNtRHHuYwo3GS7hDLm3",
                                                 "@id": "http://id.loc.gov/vocabulary/mnotetype/lang",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
-                                                        "@guid": "t94yFoZdB8mVeBy9pYQnsA",
+                                                        "@guid": "hdiB3Nnsq4jngLueJ8D8cz",
                                                         "http://www.w3.org/2000/01/rdf-schema#label": "language (lang)"
                                                     }
                                                 ],
@@ -1177,11 +997,155 @@
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Note on translation (wrk note)"
+                        "label": "Note on translation"
                     },
                     {
-                        "id": "1MtRxZnnBuKwo67ASuzGAY",
-                        "groupId": "M",
+                        "id": "9Cq5toFGDrPbcx2k1ES5PM",
+                        "groupId": "Published In",
+                        "position": 17,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "gNAXCyNcvBxoWoYLb9LWwt",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "m1ingF2SkyDtYfww77c1VH",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Published in (wrk note)"
+                    },
+                    {
+                        "id": "r2uLjeuCCjphBSLvawgt6W",
+                        "groupId": null,
+                        "position": 18,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "tHAoCS2zmxsPpyeK4cX2SG",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "wpu1viVFQAgioAvv8CdkET",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in conjunction with the <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Published in conjunction (Exhibit)"
+                    },
+                    {
+                        "id": "ws3Fdw19MKx3Zw3tFe4PWx",
+                        "groupId": null,
+                        "position": 19,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "propertyLabel": "Notes about the Work",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "eoo8Ma7LF4mj5qVGYDdQ7k",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "8fs536bZZn5ttNXqt3rPmc",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": " Published on the occasion of the <#####>"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
+                            "hashCode": 1203075139,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": " Published on the occasion of"
+                    },
+                    {
+                        "id": "o6ymbCUzy3pPXyXjih8oq2",
+                        "groupId": "Catalog of an Exhibition",
                         "position": 20,
                         "structure": {
                             "mandatory": "false",
@@ -1204,155 +1168,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "cXFF4SRtXLwvX35EV4eSUh",
+                                        "@guid": "59v1XWzsqwhTJoQfs1Ysw8",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "k6F8LzhU2XCVvERsFz4sTT",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in <#####>."
-                                            }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
-                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
-                            "hashCode": 1203075139,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Published in (wrk note)"
-                    },
-                    {
-                        "id": "3Je6D61QzhhLntQPiSXMDj",
-                        "groupId": null,
-                        "position": 21,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Note"
-                                ],
-                                "useValuesFrom": [],
-                                "valueDataType": {},
-                                "defaults": []
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-                            "propertyLabel": "Notes about the Work",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
-                                "http://id.loc.gov/ontologies/bibframe/note": [
-                                    {
-                                        "@guid": "cXFF4SRtXLwvX35EV4eSUh",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "k6F8LzhU2XCVvERsFz4sTT",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in conjunction with the <#####>."
-                                            }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
-                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
-                            "hashCode": 1203075139,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Published in conjunction (Exhibit) (wrk note)"
-                    },
-                    {
-                        "id": "qGKRjGBEn6Ds8mcURqxYmC",
-                        "groupId": null,
-                        "position": 22,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Note"
-                                ],
-                                "useValuesFrom": [],
-                                "valueDataType": {},
-                                "defaults": []
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-                            "propertyLabel": "Notes about the Work",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
-                                "http://id.loc.gov/ontologies/bibframe/note": [
-                                    {
-                                        "@guid": "cXFF4SRtXLwvX35EV4eSUh",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "k6F8LzhU2XCVvERsFz4sTT",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": " Published on the occasion of the <#####>."
-                                            }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
-                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
-                            "hashCode": 1203075139,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Published on the occasion of (wrk note)"
-                    },
-                    {
-                        "id": "cXTrRSB9GRLEZy89AWxjq3",
-                        "groupId": "N",
-                        "position": 23,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Note"
-                                ],
-                                "useValuesFrom": [],
-                                "valueDataType": {},
-                                "defaults": []
-                            },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-                            "propertyLabel": "Notes about the Work",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Work",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
-                                "http://id.loc.gov/ontologies/bibframe/note": [
-                                    {
-                                        "@guid": "cXFF4SRtXLwvX35EV4eSUh",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "k6F8LzhU2XCVvERsFz4sTT",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Catalog of an exhibition held at <#####>."
+                                                "@guid": "aMMyBjTPPYi2PVoirtfeXU",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Catalog of an exhibition held at <#####>"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -1372,19 +1192,19 @@
                         "label": "Catalog of an exhibition (wrk note)"
                     },
                     {
-                        "id": "mrAx2R3PDdjjoAEp2AmRYp",
-                        "groupId": "N",
-                        "position": 24,
+                        "id": "3hLb6FQPjxhc6Z67qkuJqL",
+                        "groupId": "Catalog of an Exhibition",
+                        "position": 21,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
-                            "type": "resource",
+                            "type": "lookup",
                             "resourceTemplates": [],
                             "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Form"
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/authorities/genreForms"
                                 ],
-                                "useValuesFrom": [],
                                 "valueDataType": {
                                     "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
                                     "dataTypeLabel": "",
@@ -1403,19 +1223,19 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
                                 "http://id.loc.gov/ontologies/bibframe/genreForm": [
                                     {
-                                        "@guid": "goEYVomK5Su1LJLH1t7fK2",
+                                        "@guid": "uuJL5EWVXT445ZdsDhosB2",
                                         "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
                                         "@id": "http://id.loc.gov/authorities/genreForms/gf2014026098",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7AB7FEte29KYoHAFrtiNbK",
+                                                "@guid": "gvUVir8x91QPvxQUJqaxh4",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": "Exhibition catalogs",
                                                 "@language": "en"
                                             }
                                         ],
                                         "http://id.loc.gov/ontologies/bflc/marcKey": [
                                             {
-                                                "@guid": "8CTdVBeaPo9r8kFxYkjBpn",
+                                                "@guid": "nhZ76boYm2MTDMi7dpsFMR",
                                                 "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aExhibition catalogs"
                                             }
                                         ]
@@ -1426,66 +1246,72 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
+                            "hashCode": -1521279090,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Catalog of an exhibition (gf)"
+                        "label": "Catalog of an exhibition (g/f)"
                     },
                     {
-                        "id": "g6Md7cPHVEjo5HzhhxQC81",
-                        "groupId": null,
-                        "position": 25,
+                        "id": "4yywMMQAUZ8np45Yz3Gr8k",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 22,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
-                            "type": "resource",
+                            "type": "lookup",
                             "resourceTemplates": [],
                             "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Note"
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/millus"
                                 ],
-                                "useValuesFrom": [],
-                                "valueDataType": {},
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
                                 "defaults": []
                             },
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-                            "propertyLabel": "Notes about the Work",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                            "propertyLabel": "Illustrative content",
+                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-MonographConsiderations(andMARC008)",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Work",
                             "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
-                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                "@root": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
+                                "http://id.loc.gov/ontologies/bibframe/illustrativeContent": [
                                     {
-                                        "@guid": "cXFF4SRtXLwvX35EV4eSUh",
+                                        "@guid": "kET4tMveAUtShu9ennkEQp",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                                        "@id": "http://id.loc.gov/vocabulary/millus/map",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "k6F8LzhU2XCVvERsFz4sTT",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Originally presented as the author's thesis (<#####>)"
+                                                "@guid": "1EinUGLjPtH1tPYd8Wdors",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
                                             }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        ]
                                     }
                                 ]
                             },
                             "@guid": null,
                             "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Work",
-                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_work",
-                            "hashCode": 1203075139,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/note",
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
+                            "id": "id_loc_gov_ontologies_bibframe_illustrativeContent__illustrative_content",
+                            "hashCode": -1055901801,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/illustrativeContent|http://id.loc.gov/ontologies/bibframe/Illustration",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Thesis (note, no Uniform title) (wrk note)"
+                        "label": "Map (in Pocket) note (ill cntnt)"
                     },
                     {
-                        "id": "aQTMQyRAWtJHDGSeA8HWMk",
-                        "groupId": "P",
-                        "position": 26,
+                        "id": "45sF8AhKB6QXfw6GCzn98C",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 23,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
@@ -1514,20 +1340,20 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/genreForm",
                                 "http://id.loc.gov/ontologies/bibframe/genreForm": [
                                     {
-                                        "@guid": "sWs2xtoBtY8NBCP8K1yZVW",
+                                        "@guid": "jWkhVDAqpj6EJutzLUrnrR",
                                         "@type": "http://www.loc.gov/mads/rdf/v1#GenreForm",
-                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2014026088",
+                                        "@id": "http://id.loc.gov/authorities/genreForms/gf2011026387",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "6xheUZN6qcXweMUdyDVFgo",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Discographies",
+                                                "@guid": "1Qk2SrfticPmcpvwgikyVA",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Maps",
                                                 "@language": "en"
                                             }
                                         ],
                                         "http://id.loc.gov/ontologies/bflc/marcKey": [
                                             {
-                                                "@guid": "8ARgf7wcW1vTvzSoitbhc7",
-                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aDiscographies"
+                                                "@guid": "jqc9fyjs77GL36aC46Akf2",
+                                                "http://id.loc.gov/ontologies/bflc/marcKey": "155  $aMaps"
                                             }
                                         ]
                                     }
@@ -1537,20 +1363,243 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "id": "id_loc_gov_ontologies_bibframe_genreForm__genreform",
-                            "hashCode": -848088407,
+                            "hashCode": 490027258,
                             "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/genreForm|http://id.loc.gov/ontologies/bibframe/GenreForm",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Discography (gf)"
+                        "label": "Map (in Pocket) note (g/f)"
+                    },
+                    {
+                        "id": "kX2Fwq5tccgUwAakkPAfFF",
+                        "groupId": "Map (in Pocket) note",
+                        "position": 24,
+                        "structure": {
+                            "mandatory": "true",
+                            "repeatable": "true",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/contentTypes"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+                                },
+                                "editable": "false",
+                                "repeatable": "true",
+                                "defaults": [
+                                    {
+                                        "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                                        "defaultLiteral": "text"
+                                    }
+                                ]
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
+                            "propertyLabel": "Content type",
+                            "remark": "https://original.rdatoolkit.org/6.9.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/content",
+                                "http://id.loc.gov/ontologies/bibframe/content": [
+                                    {
+                                        "@guid": "8E1iLaJxGxuVTmPA7LeV9y",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Content",
+                                        "@id": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "vkHR5UHcigC7MMuzkyfRx7",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "id": "id_loc_gov_ontologies_bibframe_content__content_type",
+                            "hashCode": 411074621,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/content|http://id.loc.gov/ontologies/bibframe/Content",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Map (in Pocket) note (cntnt type)"
+                    },
+                    {
+                        "id": "aH56AhrvWU9HXdjX4ucsxA",
+                        "groupId": "Index",
+                        "position": 25,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "false",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                },
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                            "propertyLabel": "Supplementary content",
+                            "remark": "https://original.rdatoolkit.org/7.16.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
+                                    {
+                                        "@guid": "txrmecvoN2s7ioKEooQnLC",
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/index",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "tRtZnHXX47oUFmZwqLgCdS",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
+                            "hashCode": -2006168873,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Index (supp cntnt)"
+                    },
+                    {
+                        "id": "4ZQtdTGpsJpDec9H2UR1EN",
+                        "groupId": "Bib/Index",
+                        "position": 26,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "false",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                },
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                            "propertyLabel": "Supplementary content",
+                            "remark": "https://original.rdatoolkit.org/7.16.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
+                                    {
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/bibliography",
+                                        "@guid": "2uWByuKZ9qrfxeWnReGWsg",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "fKYNMCmUp7N6nLck99QuUM",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (bibliography)"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/index",
+                                        "@guid": "s4YZD1TPZ8mTs8zmApR2zh",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "5rzDeGmBtqbc9SthA95pqj",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
+                            "hashCode": -2006168873,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Bib/Index (supp cntnt)"
+                    },
+                    {
+                        "id": "nUj5Y62BoKQGc8XZR4kizx",
+                        "groupId": "Bib",
+                        "position": 27,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "false",
+                            "type": "lookup",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/msupplcont"
+                                ],
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+                                },
+                                "defaults": []
+                            },
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                            "propertyLabel": "Supplementary content",
+                            "remark": "https://original.rdatoolkit.org/7.16.html",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Workdaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Work",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+                                "http://id.loc.gov/ontologies/bibframe/supplementaryContent": [
+                                    {
+                                        "@id": "http://id.loc.gov/vocabulary/msupplcont/bibliography",
+                                        "@guid": "2uWByuKZ9qrfxeWnReGWsg",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "fKYNMCmUp7N6nLck99QuUM",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (bibliography)"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "id": "id_loc_gov_ontologies_bibframe_supplementaryContent__supplementary_content",
+                            "hashCode": -2006168873,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Work|http://id.loc.gov/ontologies/bibframe/supplementaryContent|http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Bib (supp cntnt)"
                     }
                 ]
             },
             "lc:RT:bf2:Monograph:Instance:Default": {
                 "groups": [
                     {
-                        "id": "iFsVEK43aufuCjXubh5jSa",
+                        "id": "ci9onu1M8WZDTEZCqVQA2r",
                         "groupId": null,
                         "position": 0,
                         "structure": {
@@ -1567,7 +1616,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1575,11 +1624,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "6q7jmW1aAudq1K7JF9VdES",
+                                        "@guid": "fPrwd5xeWVS1U1QyzxoTZF",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "8dPxqwKFtByQDoynGLCR9P",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "At head of title: <#####>"
+                                                "@guid": "o9x8bT8tmFWDyp2ySnaoRb",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "At head of title: #######"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -1590,7 +1639,7 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
@@ -1599,70 +1648,8 @@
                         "label": "At head"
                     },
                     {
-                        "id": "8RXuQHsvWb9LgYBFaZqHuM",
-                        "groupId": "A",
-                        "position": 1,
-                        "structure": {
-                            "mandatory": "false",
-                            "repeatable": "true",
-                            "type": "resource",
-                            "resourceTemplates": [],
-                            "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Note"
-                                ],
-                                "useValuesFrom": [],
-                                "valueDataType": {},
-                                "defaults": []
-                            },
-                            "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
-                            "parentId": "lc:RT:bf2:Monograph:Instance",
-                            "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
-                                "http://id.loc.gov/ontologies/bibframe/note": [
-                                    {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
-                                            {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes bibliographical references (pages <#####>)"
-                                            }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
-                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                                            {
-                                                "@guid": "ukqj5j3tjxrSgRJ4QFSCT6",
-                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": [
-                                                    {
-                                                        "@guid": "7EgLYVh5v5jk925H3bnY6t",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
-                                                    }
-                                                ],
-                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "@guid": null,
-                            "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
-                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
-                            "hasData": true,
-                            "userModified": true,
-                            "dataLoaded": false
-                        },
-                        "label": "Bib (inst note)"
-                    },
-                    {
-                        "id": "wbxmhnds2SNgeCkXgv3xZ2",
-                        "groupId": "B",
+                        "id": "bWXwVC4UrVZznzPdFDYot7",
+                        "groupId": null,
                         "position": 2,
                         "structure": {
                             "mandatory": "false",
@@ -1678,7 +1665,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1686,22 +1673,22 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "4YYxfq9CZGR9ytTkqW2Gyp",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes bibliographical references (pages <#####>) and index."
+                                                "@guid": "8NwPdsk3phgHBBc3ZdQs3T",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Title from caption."
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note",
                                         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
                                             {
-                                                "@guid": "ukqj5j3tjxrSgRJ4QFSCT6",
-                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
+                                                "@guid": "pZKnxPJiMm1QkJEZWBw9wN",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/descsource",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
-                                                        "@guid": "7EgLYVh5v5jk925H3bnY6t",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                        "@guid": "vQ8QZAq5tE865yRU4vBE9z",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "description source (descsource)"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -1714,17 +1701,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Bib/Index (inst note)"
+                        "label": "Caption Title"
                     },
                     {
-                        "id": "oz9cCaZRCmBUdxxNQvTvY3",
-                        "groupId": "C",
+                        "id": "mpW2ARKSNnSQgU4haowiVg",
+                        "groupId": null,
                         "position": 3,
                         "structure": {
                             "mandatory": "false",
@@ -1740,7 +1727,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1748,11 +1735,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "vFmMY9ji79CxFtZyqajvBp",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "On board pages"
+                                                "@guid": "aqpeLBXYcv1PsZHEzaCgYw",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "On board pages."
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -1763,17 +1750,79 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Board books (inst note)"
+                        "label": "Board Books"
                     },
                     {
-                        "id": "41MPwgVEr6dJLn3A2pAGeY",
-                        "groupId": null,
+                        "id": "bxiumi2WzGErraKbAf8y2Z",
+                        "groupId": "Color ill, Color Maps",
+                        "position": 3,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "cuYsaTA36XUP3BkVEQHjWJ",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "iqPdxhuNapUNp6SUNLHpMS",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (some color), maps (some color)"
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "duD17oiwf6Yd3hR2aa9FWb",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/physical",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "n2dwAy96nwPPDJ6uPCLpwQ",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Color ill, color maps (inst note)"
+                    },
+                    {
+                        "id": "oHp1xjoBmvPWYup1SeJAGV",
+                        "groupId": "Conference w/ Place",
                         "position": 4,
                         "structure": {
                             "mandatory": "false",
@@ -1789,7 +1838,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1797,11 +1846,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "5FAYLubqNb2YPBLCw9hTYx",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Title from caption"
+                                                "@guid": "cHW51G4jbPFizwaPsAaQ57",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Proceedings of <#####>"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -1812,17 +1861,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Caption title"
+                        "label": "Conference w/ place (inst note)"
                     },
                     {
-                        "id": "bEHyUxP7ceGphmXFoNX6pE",
-                        "groupId": "E",
+                        "id": "a34454Xvp2qwUqYA4P5WSE",
+                        "groupId": "Conference Paper",
                         "position": 5,
                         "structure": {
                             "mandatory": "false",
@@ -1838,7 +1887,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1846,11 +1895,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "mJYKZJpFWLFQTFHZxCKhF5",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Proceedings of <#####>"
+                                                "@guid": "mS6Dwmh1FUbUrrKSPKD8Zj",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Papers presented at the <#####>"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -1861,17 +1910,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Conference w/ place (inst note)"
+                        "label": "Conference papers (inst note)"
                     },
                     {
-                        "id": "cukFCz5NZC8gRwhKhoyvH8",
-                        "groupId": "F",
+                        "id": "un7VFJCzBENCDCDnTox7Li",
+                        "groupId": null,
                         "position": 6,
                         "structure": {
                             "mandatory": "false",
@@ -1887,7 +1936,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1895,11 +1944,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "41gUDJPhW8p8z1ra3tGiyZ",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Papers presented at the <#####>"
+                                                "@guid": "fCesrrZbsRkP3mYuzaAjN6",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Title from cover."
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -1910,16 +1959,16 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Conference papers (inst note)"
+                        "label": "Cover Title"
                     },
                     {
-                        "id": "pH4oyR9sYVuXvDGoZyM3kp",
+                        "id": "jbxGp2kvRTgb8Zsx5gagF3",
                         "groupId": null,
                         "position": 7,
                         "structure": {
@@ -1936,7 +1985,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1944,14 +1993,27 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "rshpJPMV39LhRx7z8f637f",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Title from cover."
+                                                "@guid": "5pDP1m1y3bTUy6tXHq6pj4",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Also issued in electronic format."
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "ggFa6HUsGvWrLtvJF7UW2p",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/addphys",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "nEkCVV5PvPJ9eTWTFQt8W4",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "additional physical form (addphys)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -1959,16 +2021,16 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Cover title (inst note)"
+                        "label": "Electronic format"
                     },
                     {
-                        "id": "vhBa3r1fd37s7voutfxsrV",
+                        "id": "hoDnZgM8dpCi5v1tKn8mUj",
                         "groupId": null,
                         "position": 8,
                         "structure": {
@@ -1985,7 +2047,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -1993,27 +2055,14 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "etAgr731fPUrLbWnZGuXG3",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Also issued in electronic format."
+                                                "@guid": "tpjsTP4dfJAJsHszbzktyr",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Errata slip inserted."
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
-                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                                            {
-                                                "@guid": "bYhgJRkzuGCRXnodeYPbFK",
-                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/addphys",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": [
-                                                    {
-                                                        "@guid": "jFeMwZq42vCmU3xxQ4uMdr",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "additional physical form (addphys)"
-                                                    }
-                                                ],
-                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
-                                            }
-                                        ]
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
                                     }
                                 ]
                             },
@@ -2021,17 +2070,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Electronic format (inst note)"
+                        "label": "Errata"
                     },
                     {
-                        "id": "9MCkgtPhRjBCF44ydfHPwT",
-                        "groupId": null,
+                        "id": "rbDPaA6aoSemAoNy7WXF1w",
+                        "groupId": "Filmographies",
                         "position": 9,
                         "structure": {
                             "mandatory": "false",
@@ -2047,7 +2096,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2055,14 +2104,27 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "43KXJsDK3YdFESgQsWpsfg",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Errata slip inserted."
+                                                "@guid": "3PdL2Js6G7SV92RQLE1Ubt",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Filmography: pages <#####>"
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "ba8yCiJm5xFk4G5Hy6z82w",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "r7jbmo2ek3zvkt4QZdNpHf",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -2070,17 +2132,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Errata (inst note)"
+                        "label": "Filmographies (inst note)"
                     },
                     {
-                        "id": "hEWXfQrLC3yfwnGADkV8Az",
-                        "groupId": null,
+                        "id": "6a2LEGznBDoWCgfC2pSHEU",
+                        "groupId": "Illustrations",
                         "position": 10,
                         "structure": {
                             "mandatory": "false",
@@ -2096,7 +2158,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2104,22 +2166,22 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "vSjPNQ5KbvxEmKCHU3f8JP",
+                                        "@guid": "fMr41wxHVmdbC9eBwgPYrG",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "7EuC3sfRBEqPEJY3xxKq87",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "1 errata"
+                                                "@guid": "8N1ypqgb3uewmxUTZC16eh",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note",
                                         "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
                                             {
-                                                "@guid": "7DDCytJaqv7cBwDHb8AbEt",
-                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/accmat",
+                                                "@guid": "aPs4sDpRNbkoB7goupawA8",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/physical",
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
-                                                        "@guid": "aaCQgTDGtdhNki7ijc837a",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
+                                                        "@guid": "kjpwjYNXoEYbHDajuU1yjg",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -2132,17 +2194,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Errata for 300 (inst note)"
+                        "label": "Illustrations (inst note)"
                     },
                     {
-                        "id": "mxLHLbmugmEaqLvu1VgJYV",
-                        "groupId": "G",
+                        "id": "5TKn4YXXJLqMGPWyTroz5X",
+                        "groupId": "Illustrations, Maps",
                         "position": 11,
                         "structure": {
                             "mandatory": "false",
@@ -2158,7 +2220,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2166,14 +2228,27 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "fLNvASvFAPg2yaYsvUiCAR",
+                                        "@guid": "ezFqjZVGQA3ZqQm6148sgb",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "rYzzZNx1JWMgeffT6petqr",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Filmography: pages <######>"
+                                                "@guid": "4QKccRuymHT1XettzczEd2",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations, maps"
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "34mGopKFGYAozdYf2aKbPH",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/physical",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "68HQGmijWkjBcCY81ZZc7g",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -2181,17 +2256,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Filmographies (inst note)"
+                        "label": "illustrations, maps (inst note)"
                     },
                     {
-                        "id": "awdinUMoF7FU5hhzZ948fJ",
-                        "groupId": "H",
+                        "id": "2Bn8c484HuufhwEBGTnvA7",
+                        "groupId": null,
                         "position": 12,
                         "structure": {
                             "mandatory": "false",
@@ -2207,7 +2282,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2215,11 +2290,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "fLNvASvFAPg2yaYsvUiCAR",
+                                        "@guid": "9Qs5RRRASnY4e9DzhsFxr2",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "rYzzZNx1JWMgeffT6petqr",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations"
+                                                "@guid": "fs8KTkyVUZ2EUDbyZm4KEW",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Map on lining papers."
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -2230,17 +2305,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Illustrations (inst note)"
+                        "label": "Map on lining"
                     },
                     {
-                        "id": "rA9Dofs4QZ38hUxrjxqRcY",
-                        "groupId": "I",
+                        "id": "9JrmDww9V1wtkU9QuTuuZT",
+                        "groupId": null,
                         "position": 13,
                         "structure": {
                             "mandatory": "false",
@@ -2256,7 +2331,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2264,27 +2339,14 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "fLNvASvFAPg2yaYsvUiCAR",
+                                        "@guid": "tqmiuB4YNzm5oRdhxdz2ws",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "rYzzZNx1JWMgeffT6petqr",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations, maps"
+                                                "@guid": "6yeoDwvubszE33L5J6Ujv7",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Originally published in <#####> under the title <#####>."
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
-                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                                            {
-                                                "@guid": "6VrsQH5PnLsxKUxsXbP3se",
-                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/physical",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": [
-                                                    {
-                                                        "@guid": "7TgqRM744nvSCsVANQhwKz",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
-                                                    }
-                                                ],
-                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
-                                            }
-                                        ]
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
                                     }
                                 ]
                             },
@@ -2292,17 +2354,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Illustrations, map (inst note)"
+                        "label": "Originally published in"
                     },
                     {
-                        "id": "8gb8rhJrQ85HuQCM2BP1J3",
-                        "groupId": "J",
+                        "id": "1wQq36r5nfrcubTudufpwY",
+                        "groupId": "Published In",
                         "position": 14,
                         "structure": {
                             "mandatory": "false",
@@ -2318,7 +2380,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2326,27 +2388,14 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "fLNvASvFAPg2yaYsvUiCAR",
+                                        "@guid": "hnno1uTLLCVMag6XDam49m",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "rYzzZNx1JWMgeffT6petqr",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes index."
+                                                "@guid": "chEuLvho4qzQaNFmj2g1JK",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in <#####>"
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
-                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                                            {
-                                                "@guid": "qsX92md9LjfZc2t3zmZWR9",
-                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/index",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": [
-                                                    {
-                                                        "@guid": "vuuMnZzB1zKcZdR8p4m8Y7",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
-                                                    }
-                                                ],
-                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
-                                            }
-                                        ]
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
                                     }
                                 ]
                             },
@@ -2354,17 +2403,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Index (inst note)"
+                        "label": "Published in (inst note)"
                     },
                     {
-                        "id": "jcLrzSYYYzhQqnLCcLr88p",
-                        "groupId": "L",
+                        "id": "s8VPQ8s61sVbsDJ5fpehn5",
+                        "groupId": null,
                         "position": 15,
                         "structure": {
                             "mandatory": "false",
@@ -2380,7 +2429,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2388,11 +2437,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "fLNvASvFAPg2yaYsvUiCAR",
+                                        "@guid": "i8JwqpCQtLKSgjZWZZShcG",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "rYzzZNx1JWMgeffT6petqr",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes folded map in pocket."
+                                                "@guid": "cdPgazSxxBr9eF4ow3x24Z",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Reprint from the <#####>, <#####> edition"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -2403,17 +2452,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Map (in Pocket) note (inst note 1)"
+                        "label": "Reprint from"
                     },
                     {
-                        "id": "tpj8RUpNkZne2mQjMuERsq",
-                        "groupId": "L",
+                        "id": "nViLxKYkPzhhDvXhyD5BSu",
+                        "groupId": "Tête-beche ",
                         "position": 16,
                         "structure": {
                             "mandatory": "false",
@@ -2429,7 +2478,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2437,27 +2486,14 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "w8mYHLZFzMn88G8ss4DE6Q",
+                                        "@guid": "1V3zFrnG3CRo2FYvjxDbQr",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "9EubXc6Goa8pmohrhC8tMB",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "map (<#####>cm x <#####>cm folded to <#####>cm)"
+                                                "@guid": "2RHgZ2Ty44peoAc9cjePTJ",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Titles from separate title pages"
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
-                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
-                                            {
-                                                "@guid": "iYBFrfi1SA5r9M5meY6JMf",
-                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/accmat",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": [
-                                                    {
-                                                        "@guid": "3ottSxjy5LpZGRsHYfrU2c",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
-                                                    }
-                                                ],
-                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
-                                            }
-                                        ]
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
                                     }
                                 ]
                             },
@@ -2465,17 +2501,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Map (in Pocket) note (inst note 2)"
+                        "label": "tête-beche (inst note1)"
                     },
                     {
-                        "id": "9StweLVx2eTg6tjoBkU1yU",
-                        "groupId": null,
+                        "id": "uFpoUjKRSD9tjgkhWD3rnK",
+                        "groupId": "Tête-beche ",
                         "position": 17,
                         "structure": {
                             "mandatory": "false",
@@ -2491,22 +2527,23 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
                             "userValue": {
+                                "@guid": "wA5rLRvJwoBnDJK9GzD1ZA",
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "4MrtJe1Unz6imegGfL7b8Q",
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "@guid": "sLE9FNS7t6KAxzkANfNDSb",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "iiHS9JdmdKMFAKFvH41YPe",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Map on lining papers."
+                                                "@guid": "2a9sMzGrz4f3URrgKg3x9M",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Bound tête-beche."
                                             }
-                                        ]
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
                                     }
                                 ]
                             },
@@ -2514,16 +2551,16 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Map on lining (inst note)"
+                        "label": "tête-beche (inst note2)"
                     },
                     {
-                        "id": "cnSwKrkpBYhJVNpabgZVDL",
+                        "id": "u25VubPFYL9vneMnzFvLDV",
                         "groupId": null,
                         "position": 18,
                         "structure": {
@@ -2548,14 +2585,27 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "6tDjvEwRgEavsumYC664df",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                        "@guid": "oEyPf6D244wgDSvH12eVx6",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
                                             {
-                                                "@guid": "woB3HZpHQnvBNawJQhPgV9",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Originally published in <#####> under the title <######>."
+                                                "@guid": "32b5agfNwyPr8QFwWSgeSP",
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/accmat",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "8zbxNzMkXQjchQJn6gxnzy",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
+                                                    }
+                                                ]
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "rEZeqK6RWDvqNkFHamT7FB",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "errata"
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -2563,17 +2613,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": 1144029139,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Originally published in (inst note)"
+                        "label": "Errata for 300"
                     },
                     {
-                        "id": "9Eu87Dh9Wrh1njyH5zoBAB",
-                        "groupId": "M",
+                        "id": "sMUFPC5f3WLCkZ4UYj5wmo",
+                        "groupId": "Map (in Pocket) note",
                         "position": 19,
                         "structure": {
                             "mandatory": "false",
@@ -2597,14 +2647,27 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "6tDjvEwRgEavsumYC664df",
-                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                        "@guid": "oEyPf6D244wgDSvH12eVx6",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
                                             {
-                                                "@guid": "woB3HZpHQnvBNawJQhPgV9",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Published in <#####>."
+                                                "@guid": "32b5agfNwyPr8QFwWSgeSP",
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/accmat",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "8zbxNzMkXQjchQJn6gxnzy",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
+                                                    }
+                                                ]
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "rEZeqK6RWDvqNkFHamT7FB",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "1 map (<#####>cm x <#####>cm folded to <#####>cm)"
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -2612,17 +2675,17 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": 1144029139,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Published in (inst note)"
+                        "label": "Map (in Pocket) note (inst note 1)"
                     },
                     {
-                        "id": "vQcwdzRhzsYTcdXAp4MYrU",
-                        "groupId": null,
+                        "id": "oKdUHq1rfjmF2KqvzftoR1",
+                        "groupId": "Map (in Pocket) note",
                         "position": 20,
                         "structure": {
                             "mandatory": "false",
@@ -2646,11 +2709,11 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "6tDjvEwRgEavsumYC664df",
+                                        "@guid": "aPtELCDzXKoVyY9wppB21J",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "woB3HZpHQnvBNawJQhPgV9",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Reprint from <#####>, <#####> edition."
+                                                "@guid": "dzZUv218ZC5Ciw6H3HkNsk",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes folded map in pocket"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"
@@ -2661,66 +2724,76 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": 1144029139,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Reprint from (inst note)"
+                        "label": "Map (in Pocket) note (inst note 2)"
                     },
                     {
-                        "id": "wKUYcGAPPwFLZ5NxvjNhWC",
-                        "groupId": "O",
+                        "id": "tUXrKNmoqyzsCbA3ds5BwH",
+                        "groupId": "Map (in Pocket) note",
                         "position": 21,
                         "structure": {
-                            "mandatory": "false",
+                            "propertyLabel": "Carrier type",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
                             "repeatable": "true",
-                            "type": "resource",
                             "resourceTemplates": [],
+                            "type": "lookup",
                             "valueConstraint": {
-                                "valueTemplateRefs": [
-                                    "lc:RT:bf2:Note"
+                                "valueTemplateRefs": [],
+                                "useValuesFrom": [
+                                    "http://id.loc.gov/vocabulary/carriers"
                                 ],
-                                "useValuesFrom": [],
-                                "valueDataType": {},
-                                "defaults": []
+                                "valueDataType": {
+                                    "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+                                },
+                                "repeatable": "true",
+                                "editable": "false",
+                                "defaults": [
+                                    {
+                                        "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                                        "defaultLiteral": "volume"
+                                    }
+                                ]
                             },
-                            "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
-                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "mandatory": "true",
+                            "remark": "https://original.rdatoolkit.org/3.3.html",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
                             "userValue": {
-                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
-                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                "@root": "http://id.loc.gov/ontologies/bibframe/carrier",
+                                "http://id.loc.gov/ontologies/bibframe/carrier": [
                                     {
-                                        "@guid": "6tDjvEwRgEavsumYC664df",
+                                        "@guid": "sALQXQjwbccSbrycUXrjeU",
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Carrier",
+                                        "@id": "http://id.loc.gov/vocabulary/carriers/nb",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "woB3HZpHQnvBNawJQhPgV9",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Titles from separate title pates."
+                                                "@guid": "sJeEEeY9aqauMKCMLSVZKV",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "sheet (nb)"
                                             }
-                                        ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        ]
                                     }
                                 ]
                             },
                             "@guid": null,
                             "canBeHidden": true,
-                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
-                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
-                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/carrier|http://id.loc.gov/ontologies/bibframe/Carrier",
+                            "id": "id_loc_gov_ontologies_bibframe_carrier__carrier_type",
+                            "hashCode": 505732971,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/carrier|http://id.loc.gov/ontologies/bibframe/Carrier",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "tête-beche (inst note 1)"
+                        "label": "Map (in Pocket) note (carr type)"
                     },
                     {
-                        "id": "jLcj1twxTNA3TKKUELojcB",
-                        "groupId": "O",
+                        "id": "a73kDKzy8ZHrydBw4jHYgg",
+                        "groupId": "Bib",
                         "position": 22,
                         "structure": {
                             "mandatory": "false",
@@ -2736,7 +2809,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2744,14 +2817,27 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "6tDjvEwRgEavsumYC664df",
+                                        "@guid": "jebvh31R44hMRF3VJ63FqP",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "woB3HZpHQnvBNawJQhPgV9",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Bound tête-beche."
+                                                "@guid": "2KBmJKDYx1K83NvTaykSS2",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes bibliographical references (pages <#####>)"
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "ezpj9yMKdkDWPmN4T9Jh9E",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "icWr6SJCWKjuXPSJzy21uk",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -2759,18 +2845,18 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "tête-beche (inst note 2)"
+                        "label": "Bib (inst note)"
                     },
                     {
-                        "id": "fxGfrvxDfxD2k2dLpwrGBx",
-                        "groupId": "P",
-                        "position": 23,
+                        "id": "wboCqChLqq3ePAAvMN4Jkd",
+                        "groupId": "Index",
+                        "position": 24,
                         "structure": {
                             "mandatory": "false",
                             "repeatable": "true",
@@ -2785,7 +2871,7 @@
                                 "defaults": []
                             },
                             "propertyLabel": "Notes about the Instance",
-                            "remark": "https://staff.loc.gov/wikis/display/BP2/Marva+cataloging+updates#Marvacatalogingupdates-Notesonnotes",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
                             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
                             "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
                             "parentId": "lc:RT:bf2:Monograph:Instance",
@@ -2793,14 +2879,27 @@
                                 "@root": "http://id.loc.gov/ontologies/bibframe/note",
                                 "http://id.loc.gov/ontologies/bibframe/note": [
                                     {
-                                        "@guid": "6tDjvEwRgEavsumYC664df",
+                                        "@guid": "jebvh31R44hMRF3VJ63FqP",
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
-                                                "@guid": "woB3HZpHQnvBNawJQhPgV9",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Discography: pages <#####>"
+                                                "@guid": "2KBmJKDYx1K83NvTaykSS2",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes index."
                                             }
                                         ],
-                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note"
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/index",
+                                                "@guid": "wnKsweffoEGfPiBpyQFhPf",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "h1isHramUc1czfK1KZVhVn",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
                                     }
                                 ]
                             },
@@ -2808,13 +2907,86 @@
                             "canBeHidden": true,
                             "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
                             "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
-                            "hashCode": 1294285788,
+                            "hashCode": -490787199,
                             "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
                             "hasData": true,
                             "userModified": true,
                             "dataLoaded": false
                         },
-                        "label": "Discography (inst note)"
+                        "label": "Index (instance note)"
+                    },
+                    {
+                        "id": "eam9xJ4An2v1xSMWZjkGey",
+                        "groupId": "Bib/Index",
+                        "position": 24,
+                        "structure": {
+                            "mandatory": "false",
+                            "repeatable": "true",
+                            "type": "resource",
+                            "resourceTemplates": [],
+                            "valueConstraint": {
+                                "valueTemplateRefs": [
+                                    "lc:RT:bf2:Note"
+                                ],
+                                "useValuesFrom": [],
+                                "valueDataType": {},
+                                "defaults": []
+                            },
+                            "propertyLabel": "Notes about the Instance",
+                            "remark": "http://original.rdatoolkit.org/2.17.html",
+                            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+                            "parent": "lc:profile:bf2:Monographlc:RT:bf2:Monograph:Instancedaaecaf9-6802-4881-9fd3-f8cb900ed605",
+                            "parentId": "lc:RT:bf2:Monograph:Instance",
+                            "userValue": {
+                                "@root": "http://id.loc.gov/ontologies/bibframe/note",
+                                "http://id.loc.gov/ontologies/bibframe/note": [
+                                    {
+                                        "@guid": "wyqrcnknWL3SG55xE42Y39",
+                                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                                            {
+                                                "@guid": "aHgdrLHeb3qhKQrmywcA5Y",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Includes bibliographical references (pages <#####>) and index."
+                                            }
+                                        ],
+                                        "@type": "http://id.loc.gov/ontologies/bibframe/Note",
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+                                            {
+                                                "@guid": "gPrhhBM3sdTUdnKUagQTZd",
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/biblio",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "j9m4gygavZ1VPLmzZ5Wxne",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            },
+                                            {
+                                                "@id": "http://id.loc.gov/vocabulary/mnotetype/index",
+                                                "@guid": "fjAQUfwF4F1Sogd2Y9QGfC",
+                                                "http://www.w3.org/2000/01/rdf-schema#label": [
+                                                    {
+                                                        "@guid": "9DuGPe9yKWFZqFWU4S7BMR",
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "index (index)"
+                                                    }
+                                                ],
+                                                "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "@guid": null,
+                            "canBeHidden": true,
+                            "preferenceId": "http://id.loc.gov/ontologies/bibframe/note|lc:RT:bf2:Monograph:Instance",
+                            "id": "id_loc_gov_ontologies_bibframe_note__notes_about_the_instance",
+                            "hashCode": -490787199,
+                            "hashCodeId": "lc:RT:bf2:Monograph:Instance|http://id.loc.gov/ontologies/bibframe/note",
+                            "hasData": true,
+                            "userModified": true,
+                            "dataLoaded": false
+                        },
+                        "label": "Bib/Index (inst note)"
                     }
                 ]
             }

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -25,8 +25,8 @@ export const useConfigStore = defineStore('config', {
         profiles : 'http://localhost:9401/util/profiles/profile/prod',
         starting: 'http://localhost:9401/util/profiles/starting/prod',
 
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
         id: 'https://id.loc.gov/',

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 1,
+    versionPatch: 2,
 
     regionUrls: {
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 2,
+    versionPatch: 3,
 
     regionUrls: {
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -199,33 +199,41 @@ export const usePreferenceStore = defineStore('preference', {
         unit: null,
         group: 'Sidebars - Property',
         range: [true,false]
+      },
+      '--b-edit-main-splitpane-properties-component-library-prompt-to-add' : {
+        desc: 'Ask before adding a component from the library.',
+        descShort: 'Prompt to add Library Component',
+        value: true,
+        type: 'boolean',
+        unit: null,
+        group: 'Sidebars - Property',
+        range: [true,false]
+      },
+      '--c-edit-main-splitpane-slider-color' : {
+          value:'#ffffff',
+          desc: 'Color of the dividing line / resize line.',
+          descShort: 'Resize Line Color',
+          type: 'color',
+          group: 'Sidebars - Property',
+          range: null
+      },
+      '--c-edit-main-splitpane-slider-border-color' : {
+        value:'#eee',
+        desc: 'Color of the dividing line / resize line Border.',
+        descShort: 'Resize Line Border Color',
+        type: 'color',
+        group: 'Sidebars - Property',
+        range: null
+      },
+      '--b-edit-main-splitpane-properties-show-defaults' : {
+        desc: 'Display the default Component Library in the Property Panel.',
+        descShort: 'Default Component Library',
+        value: false,
+        type: 'boolean',
+        unit: null,
+        group: 'Sidebars - Property',
+        range: [true,false]
     },
-    '--b-edit-main-splitpane-properties-component-library-prompt-to-add' : {
-      desc: 'Ask before adding a component from the library.',
-      descShort: 'Prompt to add Library Component',
-      value: true,
-      type: 'boolean',
-      unit: null,
-      group: 'Sidebars - Property',
-      range: [true,false]
-  },
-
-    '--c-edit-main-splitpane-slider-color' : {
-      value:'#ffffff',
-      desc: 'Color of the dividing line / resize line.',
-      descShort: 'Resize Line Color',
-      type: 'color',
-      group: 'Sidebars - Property',
-      range: null
-  },
-  '--c-edit-main-splitpane-slider-border-color' : {
-    value:'#eee',
-    desc: 'Color of the dividing line / resize line Border.',
-    descShort: 'Resize Line Border Color',
-    type: 'color',
-    group: 'Sidebars - Property',
-    range: null
-},
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -221,7 +221,6 @@ export const useProfileStore = defineStore('profile', {
      * @return {array}
      */
     returnComponentLibrary: (state) => {
-      console.info("returnComponentLibrary: ", state)
       // limit to the current profiles being used
       // console.log(state.activeProfile)
       // console.log(state.componentLibrary)
@@ -231,7 +230,6 @@ export const useProfileStore = defineStore('profile', {
       // }
       let results = []
       for (let key in state.activeProfile.rt){
-        console.info("key: ", key)
         // ther are components saved for this profile
         if (state.componentLibrary.profiles[key]){
           let groups = {}
@@ -256,8 +254,6 @@ export const useProfileStore = defineStore('profile', {
         if (usePreferenceStore().returnValue('--b-edit-main-splitpane-properties-show-defaults')){
           let groups = {}
           let groupsOrder = []
-          console.info("defaultComponents: ", defaultComponents.DefaultComponentLibrary)
-          console.info("defaultComponents.profiles: ", defaultComponents.DefaultComponentLibrary.profiles)
           for (let dKey in defaultComponents.DefaultComponentLibrary.profiles){
             if (dKey.includes(key)){
               for (let group of defaultComponents.DefaultComponentLibrary.profiles[dKey].groups.sort(({position:a}, {position:b}) => a-b)){
@@ -275,7 +271,6 @@ export const useProfileStore = defineStore('profile', {
               results.push({type: "default", groups:groups, groupsOrder:groupsOrder, profileId: dKey, label: key.split(":").slice(-1)[0]})
             }
           }
-          console.info("results: ", JSON.parse(JSON.stringify(results)))
         }
       }
 
@@ -288,7 +283,6 @@ export const useProfileStore = defineStore('profile', {
       for (let profileComponents of results){
 
         let type = profileComponents.type
-        console.info("type: ", type)
 
         for (let groupKey in profileComponents.groups){
           if (profileComponents.groups[groupKey].groupId !== null){
@@ -324,7 +318,6 @@ export const useProfileStore = defineStore('profile', {
       }
 
       let mergeComponents = function (results, groupsToMerge, title){
-        console.info("merging")
         if (groupsToMerge.length>0){
           // we have to MERGE
           let multiProfile = {
@@ -336,12 +329,10 @@ export const useProfileStore = defineStore('profile', {
           }
 
           for (let groupName of groupsToMerge){
-            console.info("??????: ", groupName)
             let tmpGroupComponents = []
             // remove them from the orginal group/profile and them to the multi profile
             for (let profileComponents of results){
               if (profileComponents.groups[groupName]){
-                console.info("!!!!!")
                 tmpGroupComponents=tmpGroupComponents.concat( JSON.parse(JSON.stringify(profileComponents.groups[groupName])) )
                 delete profileComponents.groups[groupName]
               }
@@ -359,8 +350,6 @@ export const useProfileStore = defineStore('profile', {
                 if (component.label.indexOf("(w)")>-1){ continue}
                 let initial = component.structure.parentId.split(':').slice(-1)[0].charAt(0).toLowerCase();
 
-                console.info("initial: ", initial)
-
                 component.label = `(${initial}) ${component.label}`
               }
             }
@@ -368,17 +357,12 @@ export const useProfileStore = defineStore('profile', {
           results.push(multiProfile)
         }
 
-        console.info("results: ", JSON.parse(JSON.stringify(results)))
         return results
       }
 
-      console.info("groupsToMergeDefault: ", groupsToMergeDefault)
-
       let r = mergeComponents(results, groupsToMerge, 'Multi')
-      console.info("r1: ", r)
       results.concat(r)
       r = mergeComponents(results, groupsToMergeDefault, 'Multi Default')
-      console.info("r2: ", r)
       results.concat(r)
 
       //merge the defaults into 1 list
@@ -395,7 +379,6 @@ export const useProfileStore = defineStore('profile', {
         }
         //merge into 1
         for (let item of defaults){
-          console.info("item: ", item)
           defaultObj.groups = Object.assign({}, defaultObj.groups, item.groups)
           defaultObj.groupsOrder = defaultObj.groupsOrder.concat(item.groupsOrder)
         }
@@ -421,14 +404,11 @@ export const useProfileStore = defineStore('profile', {
       // remove any empty ones that may have shifted fully into the multi profile
       results = results.filter((g) => {return (g.groupsOrder.length>0)})
 
-      console.info("results: ", results)
       results = results.sort((a,b) => {
-        console.info("sort: ", a.type)
         if (!a.type || a.type == null) { return -1}
         if (!b.type || b.type == null) { return 1}
         return (a.type < b.type) ? 1 : (a.type > b.type) ? -1 : 0
       })
-      console.info("results: ", results)
       return results
     },
 
@@ -5183,11 +5163,7 @@ export const useProfileStore = defineStore('profile', {
      * @param {string} guid - The GUID of the component
      */
     addToComponentLibrary: async function(guid){
-      console.info("addToComponentLibrary: ", guid)
-
       let structure = JSON.parse(JSON.stringify(this.returnStructureByComponentGuid(guid)))
-
-      console.info("structure: ", structure)
 
       // clean up component property values for storage
       structure['@guid'] = null
@@ -5255,30 +5231,19 @@ export const useProfileStore = defineStore('profile', {
      *
      */
     addFromComponentLibrary(id){
-      console.info("addFromComponentLibrary: ", id)
-      console.info("this.componentLibrary: ", this.componentLibrary)
-
       let defaultLibrary = null
       if (usePreferenceStore().returnValue('--b-edit-main-splitpane-properties-show-defaults')){
         defaultLibrary = defaultComponents.DefaultComponentLibrary.profiles
-        console.info("defaultLibrary: ", defaultLibrary)
         this.componentLibrary.profiles = Object.assign({}, this.componentLibrary.profiles, defaultLibrary)
       }
 
       for (let key in this.componentLibrary.profiles){
-        console.info("    key: ", key)
         for (let group of this.componentLibrary.profiles[key].groups){
-          console.info("        group: ", group)
-          console.info("        group.id: ", group.id)
-          console.info("        id: ", id)
           if (group.id == id){
 
             // we are adding a sigle one here so groups are individual (group of 1) in this case
             console.log("Adding thisone",group)
-            console.info("Adding this one: ",group)
             let component = JSON.parse(JSON.stringify(group.structure))
-            console.info("component: ", component)
-
 
             // see if we can find its counter part in the acutal profile
             if (this.activeProfile.rt[component.parentId]){
@@ -5392,10 +5357,6 @@ export const useProfileStore = defineStore('profile', {
 
               if (ptObjFound != false){
                 console.log("Found orignal here:",ptObjFound)
-                console.info("Found orignal here:",ptObjFound)
-                console.info("    ptObjFound.hashCode: ", ptObjFound.hashCode)
-                console.info("    component.hashCode: ", component.hashCode)
-
                 // let structureCopy = JSON.parse(JSON.stringify(ptObjFound))
 
                 if (ptObjFound.hashCode == component.hashCode){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -260,20 +260,23 @@ export const useProfileStore = defineStore('profile', {
           let groupsOrder = []
           console.info("defaultComponents: ", defaultComponents.DefaultComponentLibrary)
           console.info("defaultComponents.profiles: ", defaultComponents.DefaultComponentLibrary.profiles)
-          console.info("defaultComponents.profiles[key]: ", defaultComponents.DefaultComponentLibrary.profiles[key])
-          for (let group of defaultComponents.DefaultComponentLibrary.profiles[key].groups.sort(({position:a}, {position:b}) => a-b)){
-            if (group.groupId === null){
-              groups[group.id] = [group]
-              groupsOrder.push(group.id)
-            }else{
-                if (!groups[group.groupId]){groups[group.groupId]=[]}
-                groups[group.groupId].push(group)
-                if (groupsOrder.indexOf(group.groupId)==-1){
-                  groupsOrder.push(group.groupId)
+          for (let dKey in defaultComponents.DefaultComponentLibrary.profiles){
+            if (dKey.includes(key)){
+              for (let group of defaultComponents.DefaultComponentLibrary.profiles[dKey].groups.sort(({position:a}, {position:b}) => a-b)){
+                if (group.groupId === null){
+                  groups[group.id] = [group]
+                  groupsOrder.push(group.id)
+                }else{
+                    if (!groups[group.groupId]){groups[group.groupId]=[]}
+                    groups[group.groupId].push(group)
+                    if (groupsOrder.indexOf(group.groupId)==-1){
+                      groupsOrder.push(group.groupId)
+                    }
                 }
+              }
+              results.push({type: "default", groups:groups, groupsOrder:groupsOrder, profileId: dKey, label: key.split(":").slice(-1)[0]})
             }
           }
-          results.push({type: "default", groups:groups, groupsOrder:groupsOrder, profileId: key, label: key.split(":").slice(-1)[0]})
         }
       }
 
@@ -389,6 +392,7 @@ export const useProfileStore = defineStore('profile', {
         if (!b.type || b.type == null) { return 1}
         return (a.type < b.type) ? 1 : (a.type > b.type) ? -1 : 0
       })
+      console.info("results: ", results)
       return results
     },
 
@@ -5143,8 +5147,11 @@ export const useProfileStore = defineStore('profile', {
      * @param {string} guid - The GUID of the component
      */
     addToComponentLibrary: async function(guid){
+      console.info("addToComponentLibrary: ", guid)
 
       let structure = JSON.parse(JSON.stringify(this.returnStructureByComponentGuid(guid)))
+
+      console.info("structure: ", structure)
 
       // clean up component property values for storage
       structure['@guid'] = null
@@ -5213,16 +5220,28 @@ export const useProfileStore = defineStore('profile', {
      */
     addFromComponentLibrary(id){
       console.info("addFromComponentLibrary: ", id)
+      console.info("this.componentLibrary: ", this.componentLibrary)
+
+      let defaultLibrary = null
+      if (usePreferenceStore().returnValue('--b-edit-main-splitpane-properties-show-defaults')){
+        defaultLibrary = defaultComponents.DefaultComponentLibrary.profiles
+        console.info("defaultLibrary: ", defaultLibrary)
+        this.componentLibrary.profiles = Object.assign({}, this.componentLibrary.profiles, defaultLibrary)
+      }
+
       for (let key in this.componentLibrary.profiles){
         console.info("    key: ", key)
         for (let group of this.componentLibrary.profiles[key].groups){
           console.info("        group: ", group)
+          console.info("        group.id: ", group.id)
+          console.info("        id: ", id)
           if (group.id == id){
 
             // we are adding a sigle one here so groups are individual (group of 1) in this case
             console.log("Adding thisone",group)
-            console.info("Adding thisone",group)
+            console.info("Adding this one: ",group)
             let component = JSON.parse(JSON.stringify(group.structure))
+            console.info("component: ", component)
 
 
             // see if we can find its counter part in the acutal profile
@@ -5337,6 +5356,11 @@ export const useProfileStore = defineStore('profile', {
 
               if (ptObjFound != false){
                 console.log("Found orignal here:",ptObjFound)
+                console.info("Found orignal here:",ptObjFound)
+                console.info("    ptObjFound.hashCode: ", ptObjFound.hashCode)
+                console.info("    component.hashCode: ", component.hashCode)
+
+                // let structureCopy = JSON.parse(JSON.stringify(ptObjFound))
 
                 if (ptObjFound.hashCode == component.hashCode){
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -229,11 +229,9 @@ export const useProfileStore = defineStore('profile', {
       //   return [state.componentLibrary]
 
       // }
-      let broadType = ""
       let results = []
       for (let key in state.activeProfile.rt){
         console.info("key: ", key)
-        broadType = key.split(":")
         // ther are components saved for this profile
         if (state.componentLibrary.profiles[key]){
           let groups = {}
@@ -258,6 +256,7 @@ export const useProfileStore = defineStore('profile', {
         if (usePreferenceStore().returnValue('--b-edit-main-splitpane-properties-show-defaults')){
           let groups = {}
           let groupsOrder = []
+          let defaults = {}
           console.info("defaultComponents: ", defaultComponents.DefaultComponentLibrary)
           console.info("defaultComponents.profiles: ", defaultComponents.DefaultComponentLibrary.profiles)
           for (let dKey in defaultComponents.DefaultComponentLibrary.profiles){
@@ -277,6 +276,7 @@ export const useProfileStore = defineStore('profile', {
               results.push({type: "default", groups:groups, groupsOrder:groupsOrder, profileId: dKey, label: key.split(":").slice(-1)[0]})
             }
           }
+          console.info("results: ", JSON.parse(JSON.stringify(results)))
         }
       }
 
@@ -368,10 +368,12 @@ export const useProfileStore = defineStore('profile', {
           }
           results.push(multiProfile)
         }
+
+        console.info("results: ", JSON.parse(JSON.stringify(results)))
         return results
       }
 
-      //TODO: get them opening independently, maybe pull defaults gether under 1 heading?
+      //TODO: maybe pull defaults gether under 1 heading?
 
       console.info("groupsToMergeDefault: ", groupsToMergeDefault)
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5212,12 +5212,16 @@ export const useProfileStore = defineStore('profile', {
      *
      */
     addFromComponentLibrary(id){
+      console.info("addFromComponentLibrary: ", id)
       for (let key in this.componentLibrary.profiles){
+        console.info("    key: ", key)
         for (let group of this.componentLibrary.profiles[key].groups){
+          console.info("        group: ", group)
           if (group.id == id){
 
             // we are adding a sigle one here so groups are individual (group of 1) in this case
             console.log("Adding thisone",group)
+            console.info("Adding thisone",group)
             let component = JSON.parse(JSON.stringify(group.structure))
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -256,7 +256,6 @@ export const useProfileStore = defineStore('profile', {
         if (usePreferenceStore().returnValue('--b-edit-main-splitpane-properties-show-defaults')){
           let groups = {}
           let groupsOrder = []
-          let defaults = {}
           console.info("defaultComponents: ", defaultComponents.DefaultComponentLibrary)
           console.info("defaultComponents.profiles: ", defaultComponents.DefaultComponentLibrary.profiles)
           for (let dKey in defaultComponents.DefaultComponentLibrary.profiles){
@@ -406,6 +405,16 @@ export const useProfileStore = defineStore('profile', {
             results.splice(i, 1)
           }
         }
+        let sortFn = function(a, b){
+          let targetA = !defaultObj.groups[a][0].label.startsWith("(") ? defaultObj.groups[a][0].label : a
+          let targetB = !defaultObj.groups[b][0].label.startsWith("(") ? defaultObj.groups[b][0].label : b
+
+          let val = targetA < targetB ? -1 : targetA > targetB ? 1 : 0
+
+          return val
+        }
+        defaultObj.groupsOrder.sort(sortFn)
+
         results.push(defaultObj)
       }
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -373,8 +373,6 @@ export const useProfileStore = defineStore('profile', {
         return results
       }
 
-      //TODO: maybe pull defaults gether under 1 heading?
-
       console.info("groupsToMergeDefault: ", groupsToMergeDefault)
 
       let r = mergeComponents(results, groupsToMerge, 'Multi')
@@ -383,6 +381,33 @@ export const useProfileStore = defineStore('profile', {
       r = mergeComponents(results, groupsToMergeDefault, 'Multi Default')
       console.info("r2: ", r)
       results.concat(r)
+
+      //merge the defaults into 1 list
+      if (usePreferenceStore().returnValue('--b-edit-main-splitpane-properties-show-defaults')){
+        let defaultIdx = []
+        let defaults = []
+        let defaultObj = {type: "default", groups:{}, groupsOrder:[], profileId: 'defaults', label: 'Defaults'}
+        // Get the defaults
+        for (let item in results){
+          if (results[item].type == 'default'){
+            defaultIdx.push(Number(item))
+            defaults.push(results[item])
+          }
+        }
+        //merge into 1
+        for (let item of defaults){
+          console.info("item: ", item)
+          defaultObj.groups = Object.assign({}, defaultObj.groups, item.groups)
+          defaultObj.groupsOrder = defaultObj.groupsOrder.concat(item.groupsOrder)
+        }
+        //rebuild results
+        for (let i = results.length-1; i>=0; i--){
+          if (defaultIdx.includes(i)){
+            results.splice(i, 1)
+          }
+        }
+        results.push(defaultObj)
+      }
 
       // remove any empty ones that may have shifted fully into the multi profile
       results = results.filter((g) => {return (g.groupsOrder.length>0)})

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -368,6 +368,8 @@ export const useProfileStore = defineStore('profile', {
         return results
       }
 
+      //TODO: get them opening independently, maybe pull defaults gether under 1 heading?
+
       console.info("groupsToMergeDefault: ", groupsToMergeDefault)
 
       let r = mergeComponents(results, groupsToMerge, 'Multi')


### PR DESCRIPTION
Adds a number of default library components. These were provided by the catalogers and are, I think, based largely on macros available in MacroExpress.

All the defaults are together under 1 heading. They are sorted in alphabetical order, and they have some styling to tie related pieces together. The groups have unique names so there won't be a conflict/confusion with user defined groups. They are hidden by default and can be shown under `Preferences` > `Sidebars - Properties` > `Default Component Library`.

All of the editing options (Delete, rename...) are removed for the defaults. These only work for Production.

![image](https://github.com/user-attachments/assets/be6bf5c7-e03b-4a64-a3bf-ed46c71ac7f9)
