### PR TITLE
Fix ad hoc/layout interaction

### DIFF
--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -348,6 +348,12 @@
                 this.layoutActiveFilter=null
                 this.layoutHash=null
                 this.createLayoutMode=false
+
+                //if ad hoc mode is on cycle on/off, otherwise an initially hidden component will remain hidden
+                if (this.preferenceStore.returnValue('--c-general-ad-hoc')){
+                  this.showAllElements()
+                  this.hideAllElements()
+                }
               }
             }
           )

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 4,
+    versionPatch: 5,
 
     regionUrls: {
 


### PR DESCRIPTION
If a layout included an element that is hidden, making a change to it and closing the layout would results in that component continuing to be hidden when it should display.

Bit of a lazy fix. When layouts are turned off and ad hoc mode is on, Marva will cycle `Show/Hide All Elements` to update the list of elements that are hidden in ad hoc mode.