### PR TITLE
Fix name lookups being broken for new additions

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -611,10 +611,10 @@ const utilsNetwork = {
 
 
           //if we are in production use preprod
-          // if (returnUrls.env == 'production'){
-          //   jsonuri = jsonuri.replace('http://id.', 'https://preprod-8080.id.')
-          //   jsonuri = jsonuri.replace('https://id.', 'https://preprod-8080.id.')
-          // }
+          if (returnUrls.env == 'production' && jsonuri.includes("authorities/names")){
+            jsonuri = jsonuri.replace('http://id.', 'https://preprod-8080.id.')
+            jsonuri = jsonuri.replace('https://id.', 'https://preprod-8080.id.')
+          }
 
           // rewrite the url to the config if we are using staging
           if (returnUrls.env == 'staging' && !returnUrls.dev){

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 8,
+    versionPatch: 9,
 
     regionUrls: {
 


### PR DESCRIPTION
8080 doesn't have `marcKeys` for subjects, but it does for names. So we check if the request is for names, and update the URI to 8080 if it is. Otherwise, newly added names won't appear correctly in the lookup. But keep subjects looking at Production ID so it can get the marcKey.