### PR TITLE
Conversion issues 2.9

### DIFF
--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -310,6 +310,9 @@ const utilsParse = {
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
       } else if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) &&  child.innerHTML.indexOf("vocabulary/relationship/series")>-1 && child.innerHTML.indexOf("vocabulary/mstatus/t")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
+      } else if ( (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bf/Uncontrolled")>-1) &&  child.innerHTML.indexOf("vocabulary/relationship/series")>-1 && child.innerHTML.indexOf("vocabulary/mstatus/t")>-1){
+          child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
+
        } else if ( (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bibframe/Uncontrolled")>-1) &&  child.innerHTML.indexOf("hasSeries")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
        }else if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) && child.innerHTML.indexOf("hasSeries")==-1){
@@ -326,9 +329,9 @@ const utilsParse = {
           // leave blank?
         }
 
-        // console.log("SETTING SNIFF TEST: ", child.getAttribute('local:pthint'))
-        // console.log("-->", child)
-        // console.log(child.innerHTML)
+        console.log("SETTING SNIFF TEST: ", child.getAttribute('local:pthint'))
+        console.log("-->", child)
+        console.log(child.innerHTML)
 
       }
     }

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -329,9 +329,9 @@ const utilsParse = {
           // leave blank?
         }
 
-        console.log("SETTING SNIFF TEST: ", child.getAttribute('local:pthint'))
-        console.log("-->", child)
-        console.log(child.innerHTML)
+        // console.log("SETTING SNIFF TEST: ", child.getAttribute('local:pthint'))
+        // console.log("-->", child)
+        // console.log(child.innerHTML)
 
       }
     }

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 10,
+    versionPatch: 11,
 
     regionUrls: {
 


### PR DESCRIPTION
Kind of interesting, I was testing this locally, reloading the record each time after making a change. The parsing of the xml into marva and then back out changed the pattern, so on the inital load the pattern was not the same moving from a bnode structure <bflc:Uncontrolled> to a `<rdf:type rdf:resource="http://id.loc.gov/ontologies/bflc/Uncontrolled"/>` format. Anyway something to be aware of looking for structural hint to assign the right PT based on if it is being reloaded from marva backend.