### PR TITLE
Validation update

### DIFF
--- a/src/components/panels/nav/ValidateModal.vue
+++ b/src/components/panels/nav/ValidateModal.vue
@@ -255,4 +255,8 @@
   .action-jump {
     cursor: pointer;
   }
+  .action-jump::after {
+    content: ":: Jump to component";
+    font-weight: bold;
+  }
 </style>

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -398,7 +398,9 @@ const utilsProfile = {
 
       if (isLocator){
         // deleting this avoids the creation of a "rdf:Resource" tag for "URL of Instance"
-        delete pointer[0]["@type"]
+        if (pointer[0]["@type"] != 'http://id.loc.gov/ontologies/bibframe/SupplementaryContent'){
+          delete pointer[0]["@type"]
+        }
       }
 
       return pointer

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 11,
+    versionPatch: 12,
 
     regionUrls: {
 
@@ -322,7 +322,7 @@ export const useConfigStore = defineStore('config', {
 
     {lccn:'2025363067',label:"test4", idUrl:'https://id.loc.gov/resources/instances/2025363067.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
-    
+
 
 
   ],
@@ -1027,7 +1027,7 @@ export const useConfigStore = defineStore('config', {
     returnUrls: (state) => {
       // testing for window here because of running unit tests in node
       if (typeof window !== 'undefined'){
-        if (window && (window.location.href.startsWith('http://localhost') || window.location.href.startsWith('http://127.0.0.1'))){          
+        if (window && (window.location.href.startsWith('http://localhost') || window.location.href.startsWith('http://127.0.0.1'))){
           return state.regionUrls.dev
         }else if (window && window.location.href.startsWith('https://preprod-3001')){
           return state.regionUrls.staging

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -219,6 +219,18 @@ export const useProfileStore = defineStore('profile', {
       }
     },
 
+    returnComponentByPropertyLabel: (state) => {
+      return (label) => {
+        for (let rt in state.activeProfile.rt){
+          for (let pt in state.activeProfile.rt[rt].pt){
+            if (state.activeProfile.rt[rt].pt[pt]['propertyLabel'].toLowerCase() === label.toLowerCase()){
+              return state.activeProfile.rt[rt].pt[pt]
+            }
+          }
+        }
+      }
+    },
+
 
     /** Groups the library components into a array ready to render
      *

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -129,7 +129,7 @@ export const useProfileStore = defineStore('profile', {
     mostCommonNonLatinScript: null,
     nonLatinScriptAgents: {},
 
-    
+
 
     // bf:title component/predicate for example, value will be the structure object for this component
 
@@ -5038,8 +5038,8 @@ export const useProfileStore = defineStore('profile', {
       let xml = await utilsExport.createNacoStubXML(oneXX,fourXX,mainTitle,lccn,workURI)
 
       return xml
-      
-      
+
+
 
 
 


### PR DESCRIPTION
Some updates to validation that allow the user to jump to the component when the `proportyLabel` is in the return message and it is surrounded by `**` > `**proportyLabel**`

There's also a fix for the `supplementaryContent` not building correctly in the XML. This was caused by some work to get the `electronicLocator` to work with Marva. It was deleting the `@type` which Marva needed to assemble the XML correctly.