### PR TITLE
Improve Typing for Geographic Subjects

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2551,13 +2551,15 @@ methods: {
     // remove our werid hyphens before we send it back
     for (let c of this.components){
       c.label = c.label.replaceAll('‑','-')
-
       // we have the full mads type from the build process, check if the component is a id name authortiy
       // if so over write the user defined type with the full type from the authority file so that
       // something like a name becomes a madsrdf:PersonalName instead of madsrdf:Topic
       if (c.uri && c.uri.includes('id.loc.gov/authorities/names/') && this.localContextCache && this.localContextCache[c.uri]){
         let tempType = this.localContextCache[c.uri].typeFull.replace('http://www.loc.gov/mads/rdf/v1#','madsrdf:')
         if (!Object.keys(this.activeTypes).includes(tempType)){
+          c.type = tempType
+        }
+        if (c.type == 'madsrdf:Topic'){
           c.type = tempType
         }
       }

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 15,
+    versionPatch: 16,
 
     regionUrls: {
 


### PR DESCRIPTION
When doing the final type setting, if the current type is `topic` and there is a more specific type available, use the more specific type.

Complex heading that began with a GEO heading, were being built as `Topic` in the XML and so the conversion created 650s instead of 651.