### PR TITLE
Lookups with more

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -434,7 +434,6 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-      console.info("setComplexValue: ", contextValue)
       if (Object.keys(contextValue.extra).length == 0){
         // Intended audience mixes simple and complex lookups, so do check
         this.profileStore.setValueSimple(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title[0])

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -434,8 +434,10 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
+      console.info("setComplexValue: ", contextValue)
+      console.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>", contextValue.extra.rdftypes[0])
       delete contextValue.typeFull
-      this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.typeFull, contextValue.nodeMap, contextValue.marcKey)
+      this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.extra.rdftypes[0], contextValue.extra, contextValue.extra.marcKey)
       this.searchValue=''
       this.displayModal=false
 

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -434,13 +434,30 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-
+      console.info("setComplexValue: ", contextValue)
       if (Object.keys(contextValue.extra).length == 0){
         // Intended audience mixes simple and complex lookups, so do check
         this.profileStore.setValueSimple(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title[0])
       } else {
+        if (contextValue.uri.includes('/works/')){
+          contextValue.type = 'Work'
+          contextValue.typeFull='http://id.loc.gov/ontologies/bibframe/Work'
+        } else if (contextValue.uri.includes('/hubs/')){
+          contextValue.type = 'Hub'
+          contextValue.typeFull='http://id.loc.gov/ontologies/bibframe/Hub'
+        }
+
         delete contextValue.typeFull
-        this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.extra.rdftypes[0], contextValue.extra, contextValue.extra.marcKey)
+        this.profileStore.setValueComplex(
+          this.guid,
+          null,
+          this.propertyPath,
+          contextValue.uri,
+          contextValue.title,
+          null, //contextValue.type.includes("Hub") ? "Hub" : contextValue.extra.rdftypes[0],
+          contextValue.extra,
+          contextValue.extra.marcKey
+        )
       }
       this.searchValue=''
         this.displayModal=false

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -92,7 +92,7 @@
             <div class="lookup-fake-input-entities" v-if="marcDeliminatedLCSHMode == false">
 
 
-              <div v-for="(avl,idx) in complexLookupValues" class="selected-value-container">
+              <div v-for="(avl,idx) in complexLookupValues" :class="['selected-value-container']">
 
                 <div class="selected-value-container-auth">
                   <AuthTypeIcon passClass="complex-lookup-inline" v-if="avl.type && preferenceStore.returnValue('--b-edit-complex-use-value-icons')"  :type="avl.type"/>
@@ -100,10 +100,7 @@
                 <div class="selected-value-container-title">
                   <!-- <span class="material-icons check-mark">check_circle_outline</span> -->
                   <span v-if="!avl.needsDereference && !avl.uneditable " style="padding-right: 0.3em; font-weight: bold">
-                    <!-- <a v-if="!this.configStore.useSubjectEditor.includes(this.structure.propertyURI)" href="#" @click="openAuthority()" ref="el">{{avl.label}}</a>
-                    <span v-else>{{avl.label}}</span> -->
-                    <span v-if="avl.source && avl.source=='FAST'" style="font-weight: bold;">(FAST) </span>
-                    <a href="#" @click="openAuthority()" ref="el">{{avl.label}}</a>
+                    <a href="#" :class="['entity-link']" @click="openAuthority(avl.label)" :ref="avl.label">{{avl.label}}</a>
                     <ValidationIcon :value="avl" />
                     <!-- <span class="uncontrolled" v-if="avl.isLiteral">
                       (uncontrolled)
@@ -612,7 +609,7 @@ export default {
     },
 
     // Open the authority `panel` for an given authority
-    openAuthority: function() {
+    openAuthority: function(label) {
       //Get the type of search
       try{
         let selection = document.getElementById(this.guid+"-select")
@@ -620,10 +617,10 @@ export default {
         this.searchType = selected
       } catch {}
 
-      let label = this.$refs.el[0].innerHTML
+      // let label = this.$refs.el[0].innerHTML
       this.profileData = this.profileStore.returnStructureByGUID(this.guid)
 
-      let sibling = this.$refs.el[0].parentNode.childNodes[2]
+      let sibling = this.$refs[label][0].parentNode.childNodes[2]  //this.$refs.el[0].parentNode.childNodes[2]
       if (sibling.className == "uncontrolled") {
         this.isLiteral = true
       } else {
@@ -853,6 +850,15 @@ export default {
 
 .component .lookup-fake-input{
   border-top:solid 1px v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-edit-field-border-color')") !important;
+}
+
+.entity-link {
+  text-wrap: wrap;
+}
+
+.selected-value-container:has(> .selected-value-container-title > span > .entity-link){
+  height: fit-content;
+  padding: unset;
 }
 
 

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -455,7 +455,7 @@ export default {
           contextValue.extra.marcKey
         )
       }
-      this.searchValue=''
+        this.searchValue=''
         this.displayModal=false
 
         this.$nextTick(() => {
@@ -580,6 +580,7 @@ export default {
 
       }else{
         this.displayModal=true
+        this.searchValue = ''
       }
 
 
@@ -633,6 +634,7 @@ export default {
 
       if (!this.configStore.useSubjectEditor.includes(this.structure.propertyURI)) {
         this.displayModal = true
+        this.searchValue = ''
       } else {
         // we're opening the subject builder, turn this off
         this.marcDeliminatedLCSHMode = false
@@ -649,6 +651,7 @@ export default {
         // }
 
         this.displaySubjectModal = true
+        this.searchValue = ''
       }
     },
   }

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -580,7 +580,6 @@ export default {
 
       }else{
         this.displayModal=true
-        this.searchValue = ''
       }
 
 
@@ -634,7 +633,6 @@ export default {
 
       if (!this.configStore.useSubjectEditor.includes(this.structure.propertyURI)) {
         this.displayModal = true
-        this.searchValue = ''
       } else {
         // we're opening the subject builder, turn this off
         this.marcDeliminatedLCSHMode = false
@@ -651,7 +649,6 @@ export default {
         // }
 
         this.displaySubjectModal = true
-        this.searchValue = ''
       }
     },
   }

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -434,18 +434,22 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-      console.info("setComplexValue: ", contextValue)
-      console.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>", contextValue.extra.rdftypes[0])
-      delete contextValue.typeFull
-      this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.extra.rdftypes[0], contextValue.extra, contextValue.extra.marcKey)
-      this.searchValue=''
-      this.displayModal=false
 
-      this.$nextTick(() => {
-        window.setTimeout(()=>{
-          this.$refs.lookupInput.focus()
-        },10)
-      })
+      if (Object.keys(contextValue.extra).length == 0){
+        // Intended audience mixes simple and complex lookups, so do check
+        this.profileStore.setValueSimple(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title[0])
+      } else {
+        delete contextValue.typeFull
+        this.profileStore.setValueComplex(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title, contextValue.extra.rdftypes[0], contextValue.extra, contextValue.extra.marcKey)
+      }
+      this.searchValue=''
+        this.displayModal=false
+
+        this.$nextTick(() => {
+          window.setTimeout(()=>{
+            this.$refs.lookupInput.focus()
+          },10)
+        })
     },
 
 

--- a/src/components/panels/edit/fields/helpers/AuthTypeIcon.vue
+++ b/src/components/panels/edit/fields/helpers/AuthTypeIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <span :data-tooltip="useLabel" class="simptip-position-right" v-for="icon in useIcon" >
-    <span  :class="['material-icons-outlined',icon]">{{icon}}</span>  
-  </span>  
+    <span  :class="['material-icons-outlined',icon]">{{icon}}</span>
+  </span>
 </template>
 
 <script>
@@ -34,7 +34,7 @@ export default {
     useLabel(){
       let type = this.type
 
-      type = type.replace('http://www.loc.gov/mads/rdf/v1#','')     
+      type = type.replace('http://www.loc.gov/mads/rdf/v1#','')
 
       if (type == 'PersonalName') return "Personal Name"
       if (type == 'CorporateName') return "Corporate Name"
@@ -42,6 +42,7 @@ export default {
       if (type == 'Title') return "Title"
       if (type == 'ConferenceName') return "Conference Name"
       if (type == 'Geographic') return "Geographic"
+      if (type == 'HierarchicalGeographic') return "Geographic"
       if (type == 'GenreForm') return "Genre Form"
       if (type == 'ComplexSubject') return "Complex Subject"
       if (type == 'Topic') return "Topic Subject"
@@ -56,8 +57,10 @@ export default {
 
       if (type == 'http://id.loc.gov/ontologies/bibframe/Agent') return "Personal Name"
 
+      if (type == 'may subd geog') return "May Subd Geog"
+
     },
-    
+
 
     useIcon(){
 
@@ -71,11 +74,12 @@ export default {
       const iconGenre = ['bookmark']
       const iconSubjectComplex = ['topic']
       const iconSubjectTopic = ['topic','title']
+      const iconMaySubdGeog = ['public']
 
 
 
-      
- 
+
+
       if (this.type && typeof this.type === 'string'){
         let type = this.type
 
@@ -87,6 +91,7 @@ export default {
         if (type == 'Title') return iconTitle
         if (type == 'ConferenceName') return iconConference
         if (type == 'Geographic') return iconGeographic
+        if (type == 'HierarchicalGeographic') return iconGeographic
         if (type == 'GenreForm') return iconGenre
         if (type == 'ComplexSubject') return iconSubjectComplex
         if (type == 'Topic') return iconSubjectTopic
@@ -104,6 +109,8 @@ export default {
 
         if (type == 'http://id.loc.gov/ontologies/bibframe/Agent') return iconPersonal
 
+        if (type == 'may subd geog') return iconMaySubdGeog
+
 
         // if (result.label == 'xxxxxx') return iconPersonal
         // if (result.label == 'xxxxxx') return iconPersonal
@@ -114,7 +121,7 @@ export default {
       // console.log("no icon slected", this.type )
       return []
 
-    }, 
+    },
 
 
   },
@@ -136,9 +143,9 @@ export default {
 
 /*A custom class passed to style the icon to the context it is being used*/
 .complex-lookup-inline{
-  
 
-  
+
+
 }
 
 

--- a/src/components/panels/edit/fields/helpers/AuthTypeIcon.vue
+++ b/src/components/panels/edit/fields/helpers/AuthTypeIcon.vue
@@ -47,7 +47,7 @@ export default {
       if (type == 'ComplexSubject') return "Complex Subject"
       if (type == 'Topic') return "Topic Subject"
 
-      if (type == 'Authority') return iconSubjectComplex
+      if (type == 'Authority') return "Topic" //iconSubjectComplex
 
       if (type == 'http://id.loc.gov/ontologies/bibframe/Person') return "Personal Name"
       if (type == 'http://id.loc.gov/ontologies/bibframe/Place') return "Geographic"

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1016,7 +1016,8 @@
                             <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
                           </template>
                           <template v-else-if="key == 'lcclasss'">
-                            <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                            <!-- <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a> -->
+                            <a :href="'https://id.loc.gov/authorities/classification/'+v" target="_blank">{{v}}</a>
                           </template>
                           <template v-else-if="key == 'broaders'">
                             <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -662,7 +662,8 @@
             "precoordinated" : false,
             "literal": (toLoad && toLoad.literal) ? true : false,
             "loading":true,
-            "extra": toLoad.extra
+            "extra": toLoad.extra,
+            "gacs": toLoad.extra.gacs.length == 1 ? toLoad.extra.gacs[0] : null,
           }
 
         if (toLoad && toLoad.literal){
@@ -678,7 +679,7 @@
         if (toLoad.uri.includes('/works/')){
           results.type = 'Work'
           results.typeFull='http://id.loc.gov/ontologies/bibframe/Work'
-        }else{
+        } else if (toLoad.uri.includes('/hubs/')){
           results.type = 'Hub'
           results.typeFull='http://id.loc.gov/ontologies/bibframe/Hub'
         }

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -663,7 +663,7 @@
             "literal": (toLoad && toLoad.literal) ? true : false,
             "loading":true,
             "extra": toLoad.extra,
-            "gacs": toLoad.extra.gacs.length == 1 ? toLoad.extra.gacs[0] : null,
+            "gacs": toLoad.extra.gacs,
           }
 
         if (toLoad && toLoad.literal){

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1026,7 +1026,8 @@
 
               <template v-else-if="activeContext !== null">
                 <h3>
-                  {{ activeContext.title[0] }}
+                  {{ Array.isArray(activeContext.title) ? activeContext.title[0] : activeContext.title }}
+                  <span v-if="activeContext.literal">[Literal]</span>
                 </h3>
 
                 <a style="color:#2c3e50; float: none;    border: none;border-radius: 0;background-color: transparent;font-size: 1em;padding: 0;" v-if="activeContext.type!='Literal Value'" :href="rewriteURI(activeContext.uri)" target="_blank" :style="`${this.preferenceStore.styleModalTextColor()}`">view on id.loc.gov</a>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -146,6 +146,13 @@
     },
 
     methods: {
+      truncate: function(string){
+        let stg = string
+        if (string.length > 80){
+          stg = stg.slice(0, 80) + "..."
+        }
+        return string
+      },
       // Reset stored values
       // This is for when the modal is closed, we want to reset things so nothing is preloaded
       // and the user starts from zero
@@ -950,7 +957,10 @@
                       Searching...
                     </option>
                     <template v-if="!isSimpleLookup()">
-                      <option v-for="(r,idx) in activeComplexSearch" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result" v-html="' ' + (!r.literal ? r.suggestLabel : r.label) + ((r.literal) ? ' [Literal]' : '')">
+                      <option v-for="(r,idx) in activeComplexSearch" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
+                        <div class="option-text">
+                          {{ (!r.literal ? r.suggestLabel : r.label) + ((r.literal) ? ' [Literal]' : '') }}
+                        </div>
                       </option>
                     </template>
                     <template v-else-if="activeSimpleLookup && Object.keys(activeSimpleLookup).length > 0">
@@ -1353,7 +1363,10 @@
   top: 5px;
   position: absolute;
   z-index: 100000;
+}
 
+.option-text {
+  text-wrap: wrap;
 }
 
 </style>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -894,7 +894,7 @@
       :lock-scroll="true"
       class="complex-lookup-modal"
       content-class="complex-lookup-modal-content"
-      @before-close="reset();"
+      @before-close="$emit('hideComplexModal'); reset();"
       >
 
       <div ref="complexLookupModalContainer" class="complex-lookup-modal-container" :style="`${this.preferenceStore.styleModalBackgroundColor()}`">

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -662,8 +662,8 @@
             "precoordinated" : false,
             "literal": (toLoad && toLoad.literal) ? true : false,
             "loading":true,
-            "extra": toLoad.extra,
-            "gacs": toLoad.extra.gacs,
+            "extra": toLoad.extra ? toLoad.extra : {},
+            "gacs": toLoad.extra ? toLoad.extra.gacs : [],
           }
 
         if (toLoad && toLoad.literal){
@@ -976,8 +976,14 @@
 
             <div ref="complexLookupModalDisplay" class="complex-lookup-modal-display" :style="`${this.preferenceStore.styleModalTextColor()};`">
 
-              <template v-if="activeContext !== null">
-                  <h3><span class="modal-context-icon simptip-position-top" :data-tooltip="'Type: ' + activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0]"><AuthTypeIcon v-if="activeContext.extra.rdftypes" :type="activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0]"></AuthTypeIcon></span>{{ activeContext.title }}</h3>
+              <template v-if="activeContext !== null && Object.keys(activeContext.extra).length > 0">
+                  <h3>
+                    <span class="modal-context-icon simptip-position-top" :data-tooltip="'Type: ' + activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0] ">
+                      <AuthTypeIcon v-if="activeContext.extra.rdftypes" :type="activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0]">
+                      </AuthTypeIcon>
+                    </span>
+                    {{ activeContext.title }}
+                  </h3>
                   <div class="complex-lookup-modal-display-type-buttons">
                     <div>
                         <div class="modal-context-data-title">{{activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0]}}</div>
@@ -1022,6 +1028,36 @@
                       </ul>
                     </div>
                   </template>
+              </template>
+
+              <template v-else-if="activeContext !== null">
+                <h3>
+                  {{ activeContext.title[0] }}
+                </h3>
+
+                <a style="color:#2c3e50; float: none;    border: none;border-radius: 0;background-color: transparent;font-size: 1em;padding: 0;" v-if="activeContext.type!='Literal Value'" :href="rewriteURI(activeContext.uri)" target="_blank" :style="`${this.preferenceStore.styleModalTextColor()}`">view on id.loc.gov</a>
+
+                <br>
+
+                <div v-if="activeContext.uri">
+                  <div class="modal-context-data-title modal-context-data-title-add-gap">MADS Collections:</div>
+                  <ul>
+                    <li class="modal-context-data-li">
+                     <a :href="activeContext.uri" target="_blank">
+                      {{ activeContext.uri.split("/").at(-2) }}
+                     </a>
+                    </li>
+                  </ul>
+                </div>
+
+                <div class="complex-lookup-modal-display-type-buttons">
+                  <div class="complex-lookup-modal-display-type-buttons">
+                    <div class="complex-lookup-modal-display-buttons">
+                      <button @click="$emit('emitComplexValue', activeContext)">Add [Shift+Enter]</button>
+                      <button @click=" reset(); $emit('hideComplexModal')">Cancel [ESC]</button>
+                    </div>
+                  </div>
+                </div>
 
               </template>
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -610,6 +610,7 @@
           }
         }
         if (event.key==='Enter' && event.shiftKey){
+          console.info("emit: ", this.activeContext)
           console.log("emitComplexValue",this.activeContext)
           this.$emit('emitComplexValue', this.activeContext)
         }
@@ -670,6 +671,17 @@
 
         let results = null
         results = this.activeContext
+        console.info("activeContext: ", JSON.parse(JSON.stringify(results)))
+        // results = await utilsNetwork.returnContext(toLoad.uri)
+        // console.info(toLoad.uri, ": ", JSON.parse(JSON.stringify(results)))
+
+        if (toLoad.uri.includes('/works/')){
+          results.type = 'Work'
+          results.typeFull='http://id.loc.gov/ontologies/bibframe/Work'
+        }else{
+          results.type = 'Hub'
+          results.typeFull='http://id.loc.gov/ontologies/bibframe/Hub'
+        }
         // try {
         //     // results = await utilsNetwork.returnContext(toLoad.uri)
         //     results = this.activeContext

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -49,13 +49,30 @@
         offsetStep: 25,
         currentPage: 1,
         maxPage: 0,
-
         activeContext: null,
-
-
         nextInputIsVoyagerModeDiacritics: false,
-
 		    searchType: "left",
+
+
+        labelMap: {
+          "notes": "Notes",
+          "nonlatinLabels": "Non-Latin Authoritative Labels",
+          "variantLabels": "Variants",
+          "birthdates": "Date of Birth",
+          "birthplaces": "Place of Birth",
+          "locales": "Associated Locales",
+          "activityfields": "Fields of Activity",
+          "occupations": "Occupations",
+          "languages": "Associated Languages",
+          "lcclasss": "LC Classification",
+          "broaders": "Has Broader Authority",
+          "gacs": "GAC(s)",
+          "collections": "MADS Collections",
+          "sources": "Sources",
+          "marcKey": "MARC Key",
+        },
+        panelDetailOrder: ["notes","nonlatinLabels","variantLabels","birthdates","birthplaces","locales","activityfields","occupations","languages","lcclasss","broaders","gacs","collections","sources", "marcKey"],
+        excludeFields: ["rdftypes"]
       }
     },
     computed: {
@@ -144,6 +161,7 @@
 
       // watching the search input, when it changes kick off a search
       doSearch: async function(){
+        console.info("doSearch")
         //if there is an ongoing search, abort it
         if (this.activeComplexSearchInProgress){
           this.controller.abort()
@@ -231,6 +249,7 @@
             this.activeComplexSearchInProgress = true
             this.activeComplexSearch = []
             this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
+            console.info("this.activeComplexSearch: ", this.activeComplexSearch)
             this.activeComplexSearchInProgress = false
             this.initalSearchState =false
           }, 400)
@@ -599,6 +618,7 @@
       },
 
       selectChange: async function(){
+        console.info("selectChange")
         let toLoad = null
         if (this.authorityLookupLocal == null && this.$refs.selectOptions != null ){
           toLoad = this.activeComplexSearch[this.$refs.selectOptions.selectedIndex]
@@ -626,6 +646,7 @@
         }
 
         console.log("toLoad: ", toLoad)
+        console.info("toLoad: ", toLoad)
 
         this.activeContext = {
             "contextValue": true,
@@ -669,6 +690,7 @@
         }
 
         this.activeContext = results
+        console.info("this.activeContext: ", this.activeContext)
       },
 
       isStaging(){
@@ -943,10 +965,10 @@
             <div ref="complexLookupModalDisplay" class="complex-lookup-modal-display" :style="`${this.preferenceStore.styleModalTextColor()};`">
 
               <template v-if="activeContext !== null">
-                  <h3><span class="modal-context-icon simptip-position-top" :data-tooltip="'Type: ' + activeContext.extra.rdftypes[0]"><AuthTypeIcon v-if="activeContext.extra.rdftypes" :type="activeContext.extra.rdftypes[0]"></AuthTypeIcon></span>{{ activeContext.title }}</h3>
+                  <h3><span class="modal-context-icon simptip-position-top" :data-tooltip="'Type: ' + activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0]"><AuthTypeIcon v-if="activeContext.extra.rdftypes" :type="activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0]"></AuthTypeIcon></span>{{ activeContext.title }}</h3>
                   <div class="complex-lookup-modal-display-type-buttons">
                     <div>
-                        <div class="modal-context-data-title">{{activeContext.extra.rdftypes[0]}}</div>
+                        <div class="modal-context-data-title">{{activeContext.extra.rdftypes.includes('Hub') ? 'Hub' : activeContext.extra.rdftypes[0]}}</div>
                         <div v-if="activeContext.depreciated" style="background: pink;">
                           DEPRECIATED AUTHORITY
                         </div>
@@ -966,109 +988,25 @@
 
                   </div>
 
-                  <div v-if="activeContext.extra.notes && activeContext.extra.notes.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Notes:</div>
+                  <template v-for="key in panelDetailOrder">
+                    <div v-if="!excludeFields.includes(key) && activeContext.extra[key] && activeContext.extra[key].length>0">
+                    <div class="modal-context-data-title modal-context-data-title-add-gap">{{ this.labelMap[key] }}:</div>
                     <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.notes" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.nonlatinLabels.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Non-Latin Authoritative Labels:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.nonlatinLabels" v-bind:key="'auth' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.variantLabels && activeContext.extra.variantLabels.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Variants:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.variantLabels" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.birthdates && activeContext.extra.birthdates.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Birth Date:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.birthdates" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.birthplaces && activeContext.extra.birthplaces.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Birth Place:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.birthplaces" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.locales && activeContext.extra.locales.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Associated Locales:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.locales" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.activityfields && activeContext.extra.activityfields.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Fields of Activity:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.activityfields" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.occupations && activeContext.extra.occupations.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Occupations:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.occupations" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.languages && activeContext.extra.languages.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Associated Languages:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.languages" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.lcclasss && activeContext.extra.lcclasss.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">LC Classification:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.lcclasss" v-bind:key="v + idx">
-                        <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                      <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
+                        <template v-if="v.startsWith('http')">
+                          <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
+                        </template>
+                        <template v-else-if="key == 'lcclasss'">
+                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                        </template>
+                        <template v-else>
+                          {{v}}
+                        </template>
                       </li>
+                      <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ activeContext.extra[key] }}</li>
                     </ul>
                   </div>
-
-                  <div v-if="activeContext.extra.broaders && activeContext.extra.broaders.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Has Broader Authority:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.broaders" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.gacs && activeContext.extra.gacs.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">GAC(s):</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.gacs" v-bind:key="'var' + idx">{{v}}</li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.collections && activeContext.extra.collections.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">MADS Collections:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.collections" v-bind:key="v + idx">
-                        <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
-                      </li>
-                    </ul>
-                  </div>
-
-                  <div v-if="activeContext.extra.sources && activeContext.extra.sources.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Sources:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.sources" v-bind:key="'sources-'+idx">{{v}}</li>
-                    </ul>
-
-
-                  </div>
+                  </template>
 
               </template>
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -72,7 +72,6 @@
           "marcKey": "MARC Key",
         },
         panelDetailOrder: ["notes","nonlatinLabels","variantLabels","birthdates","birthplaces","locales","activityfields","occupations","languages","lcclasss","broaders","gacs","collections","sources", "marcKey"],
-        excludeFields: ["rdftypes"]
       }
     },
     computed: {
@@ -989,23 +988,26 @@
                   </div>
 
                   <template v-for="key in panelDetailOrder">
-                    <div v-if="!excludeFields.includes(key) && activeContext.extra[key] && activeContext.extra[key].length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">{{ this.labelMap[key] }}:</div>
-                    <ul>
-                      <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
-                        <template v-if="v.startsWith('http')">
-                          <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
-                        </template>
-                        <template v-else-if="key == 'lcclasss'">
-                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
-                        </template>
-                        <template v-else>
-                          {{v}}
-                        </template>
-                      </li>
-                      <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ activeContext.extra[key] }}</li>
-                    </ul>
-                  </div>
+                    <div v-if="activeContext.extra[key] && activeContext.extra[key].length>0">
+                      <div class="modal-context-data-title modal-context-data-title-add-gap">{{ this.labelMap[key] }}:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
+                          <template v-if="v.startsWith('http')">
+                            <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
+                          </template>
+                          <template v-else-if="key == 'lcclasss'">
+                            <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                          </template>
+                          <template v-else-if="key == 'broaders'">
+                            <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                          </template>
+                          <template v-else>
+                            {{v}}
+                          </template>
+                        </li>
+                        <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ activeContext.extra[key] }}</li>
+                      </ul>
+                    </div>
                   </template>
 
               </template>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -684,10 +684,11 @@
           results.typeFull='http://id.loc.gov/ontologies/bibframe/Hub'
         }
         // try {
-        //     // results = await utilsNetwork.returnContext(toLoad.uri)
-        //     results = this.activeContext
+        //   let r = await utilsNetwork.returnContext(toLoad.uri)
+        //   // r = this.activeContext
+        //   console.info("r: ", r)
         // } catch(err) {
-        //     results = this.activeContext
+        //     // r = this.activeContext
         // }
         results.loading = false
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -160,7 +160,6 @@
 
       // watching the search input, when it changes kick off a search
       doSearch: async function(){
-        console.info("doSearch")
         //if there is an ongoing search, abort it
         if (this.activeComplexSearchInProgress){
           this.controller.abort()
@@ -248,7 +247,6 @@
             this.activeComplexSearchInProgress = true
             this.activeComplexSearch = []
             this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
-            console.info("this.activeComplexSearch: ", this.activeComplexSearch)
             this.activeComplexSearchInProgress = false
             this.initalSearchState =false
           }, 400)
@@ -610,7 +608,6 @@
           }
         }
         if (event.key==='Enter' && event.shiftKey){
-          console.info("emit: ", this.activeContext)
           console.log("emitComplexValue",this.activeContext)
           this.$emit('emitComplexValue', this.activeContext)
         }
@@ -618,7 +615,6 @@
       },
 
       selectChange: async function(){
-        console.info("selectChange")
         let toLoad = null
         if (this.authorityLookupLocal == null && this.$refs.selectOptions != null ){
           toLoad = this.activeComplexSearch[this.$refs.selectOptions.selectedIndex]
@@ -646,7 +642,6 @@
         }
 
         console.log("toLoad: ", toLoad)
-        console.info("toLoad: ", toLoad)
 
         this.activeContext = {
             "contextValue": true,
@@ -672,9 +667,7 @@
 
         let results = null
         results = this.activeContext
-        console.info("activeContext: ", JSON.parse(JSON.stringify(results)))
         // results = await utilsNetwork.returnContext(toLoad.uri)
-        // console.info(toLoad.uri, ": ", JSON.parse(JSON.stringify(results)))
 
         if (toLoad.uri.includes('/works/')){
           results.type = 'Work'
@@ -703,7 +696,6 @@
         }
 
         this.activeContext = results
-        console.info("this.activeContext: ", this.activeContext)
       },
 
       isStaging(){

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -626,7 +626,6 @@
         }
 
         console.log("toLoad: ", toLoad)
-        console.info("toLoad: ", toLoad)
 
         this.activeContext = {
             "contextValue": true,
@@ -650,15 +649,13 @@
         }
 
         let results = null
-        try {
-            // results = await utilsNetwork.returnContext(toLoad.uri)
-            // console.info("results: ", results)
-
-
-            results = this.activeContext
-        } catch(err) {
-            results = this.activeContext
-        }
+        results = this.activeContext
+        // try {
+        //     // results = await utilsNetwork.returnContext(toLoad.uri)
+        //     results = this.activeContext
+        // } catch(err) {
+        //     results = this.activeContext
+        // }
         results.loading = false
 
         // if this happens it means they selected something else very quickly
@@ -671,10 +668,7 @@
 
         }
 
-
         this.activeContext = results
-
-        console.info("activeContext: ", this.activeContext)
       },
 
       isStaging(){
@@ -949,7 +943,7 @@
             <div ref="complexLookupModalDisplay" class="complex-lookup-modal-display" :style="`${this.preferenceStore.styleModalTextColor()};`">
 
               <template v-if="activeContext !== null">
-                  <h3><span class="modal-context-icon simptip-position-top" :data-tooltip="'Type: ' + activeContext.extra.rdftypes[0]"><AuthTypeIcon v-if="activeContext.extra.rdftypes" :type="activeContext.extra.rdftypes[0]"></AuthTypeIcon></span>{{returnContextTitle(activeContext.title)}}</h3>
+                  <h3><span class="modal-context-icon simptip-position-top" :data-tooltip="'Type: ' + activeContext.extra.rdftypes[0]"><AuthTypeIcon v-if="activeContext.extra.rdftypes" :type="activeContext.extra.rdftypes[0]"></AuthTypeIcon></span>{{ activeContext.title }}</h3>
                   <div class="complex-lookup-modal-display-type-buttons">
                     <div>
                         <div class="modal-context-data-title">{{activeContext.extra.rdftypes[0]}}</div>
@@ -1045,7 +1039,7 @@
                   </div>
 
                   <div v-if="activeContext.extra.broaders && activeContext.extra.broaders.length>0">
-                    <div class="modal-context-data-title modal-context-data-title-add-gap">Broader Headings:</div>
+                    <div class="modal-context-data-title modal-context-data-title-add-gap">Has Broader Authority:</div>
                     <ul>
                       <li class="modal-context-data-li" v-for="(v,idx) in activeContext.extra.broaders" v-bind:key="'var' + idx">{{v}}</li>
                     </ul>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -178,11 +178,11 @@
                         <span class="modal-context-icon simptip-position-top" v-if="contextData.rdftypes" :data-tooltip="'Type: ' + contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]">
                             <AuthTypeIcon :type="contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]"></AuthTypeIcon>
                         </span>
-                        {{Array.isArray(contextData.title) ? contextData.title[0]["@value"] : contextData.title }}
+                        {{ Array.isArray(contextData.title) ? contextData.title[0]["@value"] : contextData.title }}
                         <!-- <AuthTypeIcon v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon> -->
                         <sup style="font-size: .5em;" v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')">(may subd geog)</sup>
                     </h3>
-                    <h3 v-if="contextData.label">
+                    <h3 v-if="contextData.literal">
                       {{ contextData.label }} [Literal]
                     </h3>
 
@@ -1561,6 +1561,7 @@ methods: {
 
       // keep a local copy of it for looking up subject type
       if (that.contextData){
+        console.info("Making local copy.")
         that.localContextCache[that.contextData.uri] = JSON.parse(JSON.stringify(that.contextData))
       }
     }
@@ -1674,6 +1675,10 @@ methods: {
       if (Object.keys(this.contextData).includes("marcKey")){
         this.pickLookup[this.pickPostion].marcKey = this.contextData.marcKey
       }
+      let types = this.pickLookup[this.pickPostion].extra['rdftypes']
+      this.contextData.type = types.includes("Hub") ? "madsrdf:Topic" : "madsrdf:" +  types[0]
+      this.contextData.typeFull = this.contextData.type.replace('madsrdf:', 'http://www.loc.gov/mads/rdf/v1#')
+
     } else {
       this.contextData.literal = true
     }
@@ -1920,6 +1925,7 @@ methods: {
     this.getContext()
 
     if (this.contextData){
+      console.info("Making local copy 2.")
       this.localContextCache[this.contextData.uri] = JSON.parse(JSON.stringify(this.contextData))
     }
 
@@ -2428,6 +2434,8 @@ methods: {
         for (let x of this.components){
           if (this.localContextCache[x.uri]){
 
+            console.info("setting type.")
+
             if (this.activeComponent.type){
               // don't do anything
             } else {
@@ -2597,6 +2605,9 @@ methods: {
     // remove our werid hyphens before we send it back
     for (let c of this.components){
       c.label = c.label.replaceAll('‑','-')
+
+      console.info("c.uri: ", c.uri)
+      console.info("this.localContextCache: ", this.localContextCache)
 
       // we have the full mads type from the build process, check if the component is a id name authortiy
       // if so over write the user defined type with the full type from the authority file so that

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -178,7 +178,8 @@
                             <AuthTypeIcon :type="contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]"></AuthTypeIcon>
                         </span>
                         {{Array.isArray(contextData.title) ? contextData.title[0]["@value"] : contextData.title }}
-                        <AuthTypeIcon v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
+                        <!-- <AuthTypeIcon v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon> -->
+                         <sup style="font-size: .5em;" v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')">(may subd geog)</sup>
                     </h3>
 
                     <div class="modal-context-data-title" v-if="contextData.rdftypes">{{contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]}}</div>
@@ -186,131 +187,29 @@
 
                     <br><br>
 
-                    <div v-if="contextData.locale && contextData.locale.length>0">
-                      <div class="modal-context-data-title">Associated Locales:</div>
+                    <template v-for="key in panelDetailOrder">
+                    <div v-if="contextData[key] && contextData[key].length>0">
+                      <div class="modal-context-data-title modal-context-data-title-add-gap">{{ this.labelMap[key] }}:</div>
                       <ul>
-                        <li class="modal-context-data-li" v-if="Array.isArray(contextData.locale)" v-for="(v,idx) in contextData.locale" v-bind:key="'var' + idx">{{v}}</li>
-                        <li class="modal-context-data-li" v-else  v-bind:key="'var' + idx + 'single'">{{contextData.locale}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.notes && contextData.notes.length>0">
-                      <div class="modal-context-data-title">Notes:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.notes" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.nonlatinLabels && contextData.nonlatinLabels.length>0">
-                      <div class="modal-context-data-title">Non-Latin Auth Label(s):</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.nonlatinLabels" v-bind:key="'var' + idx">{{ v }}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.variantLabels && contextData.variantLabels.length>0">
-                      <div class="modal-context-data-title">Variants:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.variantLabels" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.birthdates && contextData.birthdates.length>0">
-                      <div class="modal-context-data-title">Birth Date:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.birthdates" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.birthplaces && contextData.birthplaces.length>0">
-                      <div class="modal-context-data-title">Birth Place:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.birthplaces" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.locales && contextData.locales.length>0">
-                      <div class="modal-context-data-title">Associated Locales:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.locales" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.activityfields && contextData.activityfields.length>0">
-                      <div class="modal-context-data-title">Fields of Activity:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.activityfields" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.occupations && contextData.occupations.length>0">
-                      <div class="modal-context-data-title">Occupations:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.occupations" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.languages && contextData.languages.length>0">
-                      <div class="modal-context-data-title">Associated Languages:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.languages" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.lcclasss && contextData.lcclasss.length>0">
-                      <div class="modal-context-data-title">LC Classification:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-if="Array.isArray(contextData.lcclasss)" v-for="v in contextData.lcclasss" v-bind:key="v">
-                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                        <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
+                          <template v-if="v.startsWith('http')">
+                            <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
+                          </template>
+                          <template v-else-if="key == 'lcclasss'">
+                            <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                          </template>
+                          <template v-else-if="key == 'broaders'">
+                            <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                          </template>
+                          <template v-else>
+                            {{v}}
+                          </template>
                         </li>
+                        <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ contextData[key] }}</li>
                       </ul>
                     </div>
+                  </template>
 
-                    <div v-if="contextData.broaders && contextData.broaders.length>0">
-                      <div class="modal-context-data-title">Has Broader Authority:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="v in contextData.broaders" v-bind:key="v">
-                          <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
-                        </li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.gacs && contextData.gacs.length>0">
-                      <div class="modal-context-data-title">GAC(s):</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.gacs" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.collections && contextData.collections.length>0">
-                      <div class="modal-context-data-title">MADS Collections:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="v in contextData.collections" v-bind:key="v">
-                          <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
-                        </li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.sources && contextData.sources.length>0">
-                      <div class="modal-context-data-title">Sources:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="v in contextData.sources" v-bind:key="v">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.subjects && contextData.subjects.length>0">
-                      <div class="modal-context-data-title">Subjects:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.subjects" v-bind:key="'var' + idx">{{v}}</li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.marcKey && contextData.marcKey.length>0">
-                      <div class="modal-context-data-title">MARC Key:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-bind:key="contextData.marcKey">{{ Array.isArray(contextData.marcKey) ? contextData.marcKey[0]["@value"] : contextData.marcKey }}</li>
-                      </ul>
-                    </div>
 
                     <div v-if="this.pickCurrent != null">
                       <div class="clear-selected">
@@ -935,7 +834,32 @@ data: function() {
       'madsrdf:Geographic': {label:'Geographic ($z)', value:'madsrdf:Geographic',selected:false},
       'madsrdf:Temporal': {label:'Chronological ($y)', value:'madsrdf:Temporal',selected:false},
     },
-    excludeDisplayList: ['literal', 'uri', 'title', 'marcKey', 'sources']
+
+    labelMap: {
+      "notes": "Notes",
+      "nonlatinLabels": "Non-Latin Authoritative Labels",
+      "variantLabels": "Variants",
+      "birthdates": "Date of Birth",
+      "birthplaces": "Place of Birth",
+      "locales": "Associated Locales",
+      "activityfields": "Fields of Activity",
+      "occupations": "Occupations",
+      "languages": "Associated Languages",
+      "lcclasss": "LC Classification",
+      "broaders": "Has Broader Authority",
+      "gacs": "GAC(s)",
+      "collections": "MADS Collections",
+      "sources": "Sources",
+      "subjects": "Subjects",
+      "marcKey": "MARC Key",
+    },
+    panelDetailOrder: [
+      "notes","nonlatinLabels","variantLabels","birthdates",
+      "birthplaces","locales","activityfields","occupations",
+      "languages","lcclasss","broaders","gacs","collections",
+      "sources", "subjects", "marcKey"
+    ],
+
 
 
   }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -169,50 +169,135 @@
                   </div>
                 </div>
 
-
+                <!-- Results Panel -->
                 <div :style="`${this.preferenceStore.styleModalBackgroundColor()}; ${this.preferenceStore.styleModalTextColor()};`"  :class="['subject-editor-container-right', {'subject-editor-container-right-lowres':lowResMode}]">
                   <div v-if="contextRequestInProgress" style="font-weight: bold;">Retrieving data...</div>
                   <div class="modal-context" :style="{ }" v-if="Object.keys(contextData).length>0">
                     <h3 v-if="contextData.title">
-                        <span class="modal-context-icon simptip-position-top" :data-tooltip="'Type: ' + contextData.type">
-                            <AuthTypeIcon v-if="contextData.type" :type="contextData.type"></AuthTypeIcon>
+                        <span class="modal-context-icon simptip-position-top" v-if="contextData.rdftypes" :data-tooltip="'Type: ' + contextData.rdftypes[0]">
+                            <AuthTypeIcon :type="contextData.rdftypes[0]"></AuthTypeIcon>
                         </span>
                         {{Array.isArray(contextData.title) ? contextData.title[0]["@value"] : contextData.title }}
+                        <AuthTypeIcon v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                     </h3>
-                    <div class="modal-context-data-title">{{contextData.type}}</div>
+
+                    <div class="modal-context-data-title" v-if="contextData.rdftypes">{{contextData.rdftypes[0]}}</div>
                     <a style="color:#2c3e50" :href="contextData.uri" target="_blank" v-if="contextData.literal != true">view on id.loc.gov</a>
 
-                    <div v-if="contextData.nonLatinTitle && contextData.nonLatinTitle.length>0">
-                      <div class="modal-context-data-title">Non-Latin Auth Label:</div>
+                    <br><br>
+
+                    <div v-if="contextData.locale && contextData.locale.length>0">
+                      <div class="modal-context-data-title">Associated Locales:</div>
                       <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.nonLatinTitle" v-bind:key="'var' + idx">{{v['@value']}}{{ v['@language'] }}</li>
+                        <li class="modal-context-data-li" v-if="Array.isArray(contextData.locale)" v-for="(v,idx) in contextData.locale" v-bind:key="'var' + idx">{{v}}</li>
+                        <li class="modal-context-data-li" v-else  v-bind:key="'var' + idx + 'single'">{{contextData.locale}}</li>
                       </ul>
                     </div>
 
-                    <div v-if="contextData.variant && contextData.variant.length>0">
+                    <div v-if="contextData.notes && contextData.notes.length>0">
+                      <div class="modal-context-data-title">Notes:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.notes" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.nonlatinLabels && contextData.nonlatinLabels.length>0">
+                      <div class="modal-context-data-title">Non-Latin Auth Label(s):</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.nonlatinLabels" v-bind:key="'var' + idx">{{ v }}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.variantLabels && contextData.variantLabels.length>0">
                       <div class="modal-context-data-title">Variants:</div>
                       <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.variant" v-bind:key="'var' + idx">{{v}}</li>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.variantLabels" v-bind:key="'var' + idx">{{v}}</li>
                       </ul>
                     </div>
 
-                    <!-- Literals won't have `nodeMap` -->
-                    <div v-if="contextData.literal != true">
-                      <div v-for="key in Object.keys(contextData.nodeMap)" :key="key">
-                        <div class="modal-context-data-title">{{key}}:</div>
-                          <ul>
-                            <li class="modal-context-data-li" v-for="v in contextData.nodeMap[key]" v-bind:key="v">{{v}}</li>
-                          </ul>
-                      </div>
-                    </div>
-                    <div v-else>
-                      <div class="modal-context-data-title">{{ contextData.label }} [Literal]</div>
+                    <div v-if="contextData.birthdates && contextData.birthdates.length>0">
+                      <div class="modal-context-data-title">Birth Date:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.birthdates" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
                     </div>
 
-                    <div v-if="contextData.source && contextData.source.length>0">
+                    <div v-if="contextData.birthplaces && contextData.birthplaces.length>0">
+                      <div class="modal-context-data-title">Birth Place:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.birthplaces" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.activityfields && contextData.activityfields.length>0">
+                      <div class="modal-context-data-title">Fields of Activity:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.activityfields" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.occupations && contextData.occupations.length>0">
+                      <div class="modal-context-data-title">Occupations:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.occupations" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.languages && contextData.languages.length>0">
+                      <div class="modal-context-data-title">Associated Languages:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.languages" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.lcclasss && contextData.lcclasss.length>0">
+                      <div class="modal-context-data-title">LC Classification:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-if="Array.isArray(contextData.lcclasss)" v-for="v in contextData.lcclasss" v-bind:key="v">
+                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                        </li>
+                        <li class="modal-context-data-li" v-else >
+                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+contextData.lcclasss" target="_blank">{{contextData.lcclasss}}</a>
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.broaders && contextData.broaders.length>0">
+                      <div class="modal-context-data-title">Has Broader Authority:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="v in contextData.broaders" v-bind:key="v">
+                          <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.locales && contextData.locales.length>0">
+                      <div class="modal-context-data-title">Associated Locales:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.locales" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.gacs && contextData.gacs.length>0">
+                      <div class="modal-context-data-title">GAC(s):</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.gacs" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.collections && contextData.collections.length>0">
+                      <div class="modal-context-data-title">MADS Collections:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="v in contextData.collections" v-bind:key="v">
+                          <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.sources && contextData.sources.length>0">
                       <div class="modal-context-data-title">Sources:</div>
                       <ul>
-                        <li class="modal-context-data-li" v-for="v in contextData.source" v-bind:key="v">{{v}}</li>
+                        <li class="modal-context-data-li" v-for="v in contextData.sources" v-bind:key="v">{{v}}</li>
                       </ul>
                     </div>
 
@@ -845,7 +930,8 @@ data: function() {
       'madsrdf:GenreForm': {label:'Genre ($v)', value:'madsrdf:GenreForm',selected:false},
       'madsrdf:Geographic': {label:'Geographic ($z)', value:'madsrdf:Geographic',selected:false},
       'madsrdf:Temporal': {label:'Chronological ($y)', value:'madsrdf:Temporal',selected:false},
-    }
+    },
+    excludeDisplayList: ['literal', 'uri', 'title', 'marcKey', 'sources']
 
 
   }
@@ -1417,6 +1503,9 @@ methods: {
     searchStringFull=searchStringFull.replaceAll('‑','-')
 
     that.searchResults = await utilsNetwork.subjectSearch(searchString,searchStringFull,that.searchMode)
+
+    console.info("that.searchResults: ", that.searchResults)
+
     // if they clicked around while it was doing this lookup bail out
     // if (that.activeSearchInterrupted){
 
@@ -1509,6 +1598,8 @@ methods: {
     for (let x in that.searchResults.exact){
       that.pickLookup[(that.searchResults.names.length - x)*-1-2] = that.searchResults.exact[x]
     }
+
+    console.info("that.pickLookup: ", that.pickLookup)
 
     for (let k in that.pickLookup){
       that.pickLookup[k].picked = false
@@ -1646,6 +1737,29 @@ methods: {
       return false
     }
 
+    console.info("this.pickLookup[this.pickPostion]: ", this.pickLookup[this.pickPostion])
+
+    this.contextData = this.pickLookup[this.pickPostion].extra
+    if (this.pickLookup[this.pickPostion].uri){
+      this.contextData.literal = false
+      this.contextData.title = this.pickLookup[this.pickPostion].label
+      this.contextData.uri = this.pickLookup[this.pickPostion].uri
+      if (Object.keys(this.contextData).includes("marcKey")){
+        this.pickLookup[this.pickPostion].marcKey = this.contextData.marcKey
+      }
+    } else {
+      this.contextData.literal = true
+    }
+    console.info("this.contextData: ", this.contextData)
+
+  },
+
+  _getContext: async function(){
+    if (this.pickLookup[this.pickPostion].literal){
+      this.contextData = this.pickLookup[this.pickPostion]
+      return false
+    }
+
     this.contextRequestInProgress = true
     this.contextData = await utilsNetwork.returnContext(this.pickLookup[this.pickPostion].uri)
 
@@ -1692,20 +1806,20 @@ methods: {
   buildAddtionalInfo: function(collections){
     if (collections){
       let out = []
-      if (collections.includes("LCSHAuthorizedHeadings") || collections.includes("NamesAuthorizedHeadings")){
+      if (collections.includes("http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings") || collections.includes("http://id.loc.gov/authorities/subjects/collection_NamesAuthorizedHeadings")){
         out.push("(Auth Hd)")
-      } else if (collections.includes("GenreFormSubdivisions")){
+      } else if (collections.includes("http://id.loc.gov/authorities/subjects/collection_GenreFormSubdivisions")){
         out.push("(GnFrm)")
-      } else if (collections.includes("GeographicSubdivisions")){
+      } else if (collections.includes("http://id.loc.gov/authorities/subjects/collection_GeographicSubdivisions")){
         out.push("(GeoSubDiv)")
-      } else if (collections.includes("LCSH_Childrens")){
+      } else if (collections.includes("http://id.loc.gov/authorities/subjects/collection_LCSH_Childrens")){
           out.push("(ChldSubj)")
-      } else if (collections.includes("Subdivisions")){
+      } else if (collections.includes("http://id.loc.gov/authorities/subjects/collection_Subdivisions")){
         out.push("(SubDiv)")
       }
 
       // favor SubDiv over GnFrm
-      if (out.includes("(GnFrm)") && collections.includes("Subdivisions")){
+      if (out.includes("(GnFrm)") && collections.includes("http://id.loc.gov/authorities/subjects/collection_Subdivisions")){
         out = ["(SubDiv)"]
       }
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1138,6 +1138,8 @@ methods: {
 
     //make sure the searchString matches the components
     this.subjectString = this.components.map((component) => component.label).join("--")
+
+    console.info("Finished this.components: ", this.components)
   },
 
   /**
@@ -1666,7 +1668,8 @@ methods: {
       this.contextData = this.pickLookup[this.pickPostion]
       return false
     }
-
+    // let temp = await utilsNetwork.returnContext(this.pickLookup[this.pickPostion].uri)
+    // console.info("temp: ", temp)
     this.contextData = this.pickLookup[this.pickPostion].extra
     if (this.pickLookup[this.pickPostion].uri){
       this.contextData.literal = false
@@ -1686,9 +1689,11 @@ methods: {
 
     this.contextRequestInProgress = false
 
+    console.info("got context: ", JSON.parse(JSON.stringify(this.contextData)))
+
   },
 
-  _getContextDeprecated: async function(){
+  _getContext: async function(){
     if (this.pickLookup[this.pickPostion].literal){
       this.contextData = this.pickLookup[this.pickPostion]
       return false
@@ -2615,6 +2620,7 @@ methods: {
       // something like a name becomes a madsrdf:PersonalName instead of madsrdf:Topic
       if (c.uri && c.uri.includes('id.loc.gov/authorities/names/') && this.localContextCache && this.localContextCache[c.uri]){
         let tempType = this.localContextCache[c.uri].typeFull.replace('http://www.loc.gov/mads/rdf/v1#','madsrdf:')
+        console.info("tempType: ", tempType)
         if (!Object.keys(this.activeTypes).includes(tempType)){
           c.type = tempType
         }
@@ -2779,6 +2785,8 @@ methods: {
       this.components = newComponents
     }
 
+    console.info("add: ", this.components)
+    console.info("this.components: ", this.components)
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -170,6 +170,7 @@
                 </div>
 
                 <!-- Results Panel -->
+                <!-- !!{{ contextData }} -->
                 <div :style="`${this.preferenceStore.styleModalBackgroundColor()}; ${this.preferenceStore.styleModalTextColor()};`"  :class="['subject-editor-container-right', {'subject-editor-container-right-lowres':lowResMode}]">
                   <div v-if="contextRequestInProgress" style="font-weight: bold;">Retrieving data...</div>
                   <div class="modal-context" :style="{ }" v-if="Object.keys(contextData).length>0">
@@ -179,7 +180,10 @@
                         </span>
                         {{Array.isArray(contextData.title) ? contextData.title[0]["@value"] : contextData.title }}
                         <!-- <AuthTypeIcon v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon> -->
-                         <sup style="font-size: .5em;" v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')">(may subd geog)</sup>
+                        <sup style="font-size: .5em;" v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')">(may subd geog)</sup>
+                    </h3>
+                    <h3 v-if="contextData.label">
+                      {{ contextData.label }} [Literal]
                     </h3>
 
                     <div class="modal-context-data-title" v-if="contextData.rdftypes">{{contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]}}</div>
@@ -1678,7 +1682,7 @@ methods: {
 
   },
 
-  _getContext: async function(){
+  _getContextDeprecated: async function(){
     if (this.pickLookup[this.pickPostion].literal){
       this.contextData = this.pickLookup[this.pickPostion]
       return false
@@ -1931,6 +1935,7 @@ methods: {
   },
 
   selectContext: async function(pickPostion, update=true){
+    console.info("selectContext")
     if (pickPostion != null){
       this.pickPostion=pickPostion
       this.pickCurrent=pickPostion
@@ -1987,6 +1992,8 @@ methods: {
       }
 
       this.pickLookup[this.pickPostion].picked=true
+
+      console.info("this.pickLookup[this.pickPostion]: ", this.pickLookup[this.pickPostion])
 
       try {
         let marcKey = this.pickLookup[this.pickPostion].marcKey
@@ -2296,6 +2303,7 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
+    console.info("subjectStringChanged: ", event)
     this.subjectString=this.subjectString.replace("—", "--")
     this.validateOkayToAdd()
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -760,9 +760,9 @@ li::before {
 
 <style>
   div.may-sub-container span span.material-icons-outlined {
-    font-size: .8em !important;
-    position: relative !important;
-    top: -5px !important;
+    font-size: .8em;
+    position: relative;
+    top: -3px;
   }
 </style>
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1678,6 +1678,7 @@ methods: {
       let types = this.pickLookup[this.pickPostion].extra['rdftypes']
       this.contextData.type = types.includes("Hub") ? "madsrdf:Topic" : "madsrdf:" +  types[0]
       this.contextData.typeFull = this.contextData.type.replace('madsrdf:', 'http://www.loc.gov/mads/rdf/v1#')
+      this.contextData.gacs = this.pickLookup[this.pickPostion].extra.gacs
 
     } else {
       this.contextData.literal = true

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1508,8 +1508,6 @@ methods: {
 
     that.searchResults = await utilsNetwork.subjectSearch(searchString,searchStringFull,that.searchMode)
 
-    console.info("that.searchResults: ", that.searchResults)
-
     // if they clicked around while it was doing this lookup bail out
     // if (that.activeSearchInterrupted){
 
@@ -1602,8 +1600,6 @@ methods: {
     for (let x in that.searchResults.exact){
       that.pickLookup[(that.searchResults.names.length - x)*-1-2] = that.searchResults.exact[x]
     }
-
-    console.info("that.pickLookup: ", that.pickLookup)
 
     for (let k in that.pickLookup){
       that.pickLookup[k].picked = false
@@ -1742,8 +1738,6 @@ methods: {
       return false
     }
 
-    console.info("this.pickLookup[this.pickPostion]: ", this.pickLookup[this.pickPostion])
-
     this.contextData = this.pickLookup[this.pickPostion].extra
     if (this.pickLookup[this.pickPostion].uri){
       this.contextData.literal = false
@@ -1755,7 +1749,6 @@ methods: {
     } else {
       this.contextData.literal = true
     }
-    console.info("this.contextData: ", this.contextData)
 
     this.contextRequestInProgress = false
 
@@ -2699,31 +2692,31 @@ methods: {
     for (let el in this.searchResults["subjectsComplex"]){
       let target = this.searchResults["subjectsComplex"][el]
       if (target.label.replaceAll("‑", "-") == componentCheck && target.depreciated == false){
+        // we need to check the types of each element to make sure they really are the same terms
+        // let targetContext = await utilsNetwork.returnContext(target.uri)
+        let targetContext = target.extra
 
-		  // we need to check the types of each element to make sure they really are the same terms
-		  let targetContext = await utilsNetwork.returnContext(target.uri)
+        let marcKey = ""
+        if (Array.isArray(targetContext.marcKey) && typeof targetContext.marcKey[0] == 'string'){
+          marcKey = targetContext.marcKey[0]
+        } else if (targetContext.marcKey){
+          marcKey = targetContext.marcKey //[0]["@value"]
+        }
 
-		  let marcKey = ""
-      if (Array.isArray(targetContext.marcKey) && typeof targetContext.marcKey[0] == 'string'){
-        marcKey = targetContext.marcKey[0]
-      } else if (targetContext.marcKey){
-        marcKey = targetContext.marcKey[0]["@value"]
-      }
-
-		  if (marcKey.slice(5) == componentTypes){
-        //the entire built subject can be replaced by 1 term
-        match = true
-        this.components.push({
-          "complex": target.complex,
-          "id": 0,
-          "label": target.label,
-          "literal": false,
-          "posEnd": target.label.length,
-          "posStart": 0,
-          "type": "madsrdf:Topic",
-          "uri": target.uri,
-          "marcKey": marcKey
-        })
+        if (marcKey.slice(5) == componentTypes){
+          //the entire built subject can be replaced by 1 term
+          match = true
+          this.components.push({
+            "complex": target.complex,
+            "id": 0,
+            "label": target.label,
+            "literal": false,
+            "posEnd": target.label.length,
+            "posStart": 0,
+            "type": "madsrdf:Topic",
+            "uri": target.uri,
+            "marcKey": marcKey
+          })
         }
       }
     }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -174,14 +174,14 @@
                   <div v-if="contextRequestInProgress" style="font-weight: bold;">Retrieving data...</div>
                   <div class="modal-context" :style="{ }" v-if="Object.keys(contextData).length>0">
                     <h3 v-if="contextData.title">
-                        <span class="modal-context-icon simptip-position-top" v-if="contextData.rdftypes" :data-tooltip="'Type: ' + contextData.rdftypes[0]">
-                            <AuthTypeIcon :type="contextData.rdftypes[0]"></AuthTypeIcon>
+                        <span class="modal-context-icon simptip-position-top" v-if="contextData.rdftypes" :data-tooltip="'Type: ' + contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]">
+                            <AuthTypeIcon :type="contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]"></AuthTypeIcon>
                         </span>
                         {{Array.isArray(contextData.title) ? contextData.title[0]["@value"] : contextData.title }}
                         <AuthTypeIcon v-if="contextData.collections && contextData.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                     </h3>
 
-                    <div class="modal-context-data-title" v-if="contextData.rdftypes">{{contextData.rdftypes[0]}}</div>
+                    <div class="modal-context-data-title" v-if="contextData.rdftypes">{{contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]}}</div>
                     <a style="color:#2c3e50" :href="contextData.uri" target="_blank" v-if="contextData.literal != true">view on id.loc.gov</a>
 
                     <br><br>
@@ -229,6 +229,13 @@
                       </ul>
                     </div>
 
+                    <div v-if="contextData.locales && contextData.locales.length>0">
+                      <div class="modal-context-data-title">Associated Locales:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.locales" v-bind:key="'var' + idx">{{v}}</li>
+                      </ul>
+                    </div>
+
                     <div v-if="contextData.activityfields && contextData.activityfields.length>0">
                       <div class="modal-context-data-title">Fields of Activity:</div>
                       <ul>
@@ -256,9 +263,6 @@
                         <li class="modal-context-data-li" v-if="Array.isArray(contextData.lcclasss)" v-for="v in contextData.lcclasss" v-bind:key="v">
                           <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
                         </li>
-                        <li class="modal-context-data-li" v-else >
-                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+contextData.lcclasss" target="_blank">{{contextData.lcclasss}}</a>
-                        </li>
                       </ul>
                     </div>
 
@@ -268,13 +272,6 @@
                         <li class="modal-context-data-li" v-for="v in contextData.broaders" v-bind:key="v">
                           <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
                         </li>
-                      </ul>
-                    </div>
-
-                    <div v-if="contextData.locales && contextData.locales.length>0">
-                      <div class="modal-context-data-title">Associated Locales:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.locales" v-bind:key="'var' + idx">{{v}}</li>
                       </ul>
                     </div>
 
@@ -298,6 +295,13 @@
                       <div class="modal-context-data-title">Sources:</div>
                       <ul>
                         <li class="modal-context-data-li" v-for="v in contextData.sources" v-bind:key="v">{{v}}</li>
+                      </ul>
+                    </div>
+
+                    <div v-if="contextData.subjects && contextData.subjects.length>0">
+                      <div class="modal-context-data-title">Subjects:</div>
+                      <ul>
+                        <li class="modal-context-data-li" v-for="(v,idx) in contextData.subjects" v-bind:key="'var' + idx">{{v}}</li>
                       </ul>
                     </div>
 
@@ -1628,7 +1632,8 @@ methods: {
     // that.contextData.dispatch("clearContext", { self: that})
     if (that.pickLookup[that.pickPostion] && !that.pickLookup[that.pickPostion].literal){
       that.contextRequestInProgress = true
-      that.contextData = await utilsNetwork.returnContext(that.pickLookup[that.pickPostion].uri)
+      // that.contextData = await utilsNetwork.returnContext(that.pickLookup[that.pickPostion].uri)
+      that.contextData = that.getContext()
 
       // keep a local copy of it for looking up subject type
       if (that.contextData){
@@ -1751,6 +1756,8 @@ methods: {
       this.contextData.literal = true
     }
     console.info("this.contextData: ", this.contextData)
+
+    this.contextRequestInProgress = false
 
   },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -115,6 +115,9 @@
                         </template>
                         <span v-if="subject.collections && subject.collections.includes('LCNAF')"> [LCNAF]</span>
                         <span v-if="subject.collections"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
+                        <div class="may-sub-container" style="display: inline;">
+                          <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
+                        </div>
                       </div>
                     </div>
 
@@ -125,6 +128,9 @@
                           <span v-else>{{name.suggestLabel}}</span>
                           <span> [LCNAF]</span>
                           <span v-if="name.collections"> {{ this.buildAddtionalInfo(name.collections) }}</span>
+                          <div class="may-sub-container" style="display: inline;">
+                            <AuthTypeIcon v-if="name.collections && name.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
+                          </div>
                         </div>
                     </div>
 
@@ -134,14 +140,24 @@
                       <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
                         <span v-if="subjectC.collections"> {{ this.buildAddtionalInfo(subjectC.collections) }}</span>
+                        <div class="may-sub-container" style="display: inline;">
+                          <AuthTypeIcon v-if="subjectC.collections && subjectC.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
+                        </div>
                       </div>
                     </div>
 
                     <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">Simple</span>
-                      <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
-                        {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
+                      <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >
+                      {{subject.suggestLabel}}
+                        <span  v-if="subject.literal">
+                          {{subject.label}}
+                        </span>
+                        <span  v-if="subject.literal">[Literal]</span>
                         <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
+                        <div class="may-sub-container" style="display: inline;">
+                          <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
+                        </div>
                       </div>
                     </div>
 
@@ -152,6 +168,9 @@
                       <div v-for="(subjectC,idx) in searchResults.subjectsChildrenComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
                         <span v-if="subjectC.collections"> {{ this.buildAddtionalInfo(subjectC.collections) }}</span>
+                        <div class="may-sub-container" style="display: inline;">
+                          <AuthTypeIcon v-if="subjectC.collections && subjectC.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
+                        </div>
                       </div>
                     </div>
 
@@ -160,6 +179,9 @@
                       <div v-for="(subject,idx) in searchResults.subjectsChildren" @click="selectContext(searchResults.subjectsChildrenComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsChildrenComplex.length + idx)" :data-id="searchResults.subjectsChildrenComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsChildrenComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsChildrenComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsChildrenComplex.length + idx] && pickLookup[searchResults.subjectsChildrenComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
                         <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
+                        <div class="may-sub-container" style="display: inline;">
+                          <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
+                        </div>
                       </div>
                     </div>
 
@@ -200,7 +222,8 @@
                             <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
                           </template>
                           <template v-else-if="key == 'lcclasss'">
-                            <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                            <!-- <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a> -->
+                            <a :href="'https://id.loc.gov/authorities/classification/'+v" target="_blank">{{v}}</a>
                           </template>
                           <template v-else-if="key == 'broaders'">
                             <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
@@ -733,6 +756,14 @@ li::before {
   color: #999999;
 }*/
 
+</style>
+
+<style>
+  div.may-sub-container span span.material-icons-outlined {
+    font-size: .8em !important;
+    position: relative !important;
+    top: -5px !important;
+  }
 </style>
 
 <script>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1169,8 +1169,6 @@ methods: {
 
     //make sure the searchString matches the components
     this.subjectString = this.components.map((component) => component.label).join("--")
-
-    console.info("Finished this.components: ", this.components)
   },
 
   /**
@@ -1594,7 +1592,6 @@ methods: {
 
       // keep a local copy of it for looking up subject type
       if (that.contextData){
-        console.info("Making local copy.")
         that.localContextCache[that.contextData.uri] = JSON.parse(JSON.stringify(that.contextData))
       }
     }
@@ -1700,7 +1697,6 @@ methods: {
       return false
     }
     // let temp = await utilsNetwork.returnContext(this.pickLookup[this.pickPostion].uri)
-    // console.info("temp: ", temp)
     this.contextData = this.pickLookup[this.pickPostion].extra
     if (this.pickLookup[this.pickPostion].uri){
       this.contextData.literal = false
@@ -1719,9 +1715,6 @@ methods: {
     }
 
     this.contextRequestInProgress = false
-
-    console.info("got context: ", JSON.parse(JSON.stringify(this.contextData)))
-
   },
 
   _getContext: async function(){
@@ -1962,7 +1955,6 @@ methods: {
     this.getContext()
 
     if (this.contextData){
-      console.info("Making local copy 2.")
       this.localContextCache[this.contextData.uri] = JSON.parse(JSON.stringify(this.contextData))
     }
 
@@ -1978,7 +1970,6 @@ methods: {
   },
 
   selectContext: async function(pickPostion, update=true){
-    console.info("selectContext")
     if (pickPostion != null){
       this.pickPostion=pickPostion
       this.pickCurrent=pickPostion
@@ -2035,8 +2026,6 @@ methods: {
       }
 
       this.pickLookup[this.pickPostion].picked=true
-
-      console.info("this.pickLookup[this.pickPostion]: ", this.pickLookup[this.pickPostion])
 
       try {
         let marcKey = this.pickLookup[this.pickPostion].marcKey
@@ -2346,7 +2335,6 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
-    console.info("subjectStringChanged: ", event)
     this.subjectString=this.subjectString.replace("—", "--")
     this.validateOkayToAdd()
 
@@ -2470,16 +2458,12 @@ methods: {
       window.setTimeout(()=>{
         for (let x of this.components){
           if (this.localContextCache[x.uri]){
-
-            console.info("setting type.")
-
             if (this.activeComponent.type){
               // don't do anything
             } else {
               if (this.localContextCache[x.uri].nodeMap && this.localContextCache[x.uri].nodeMap['MADS Collection'] && this.localContextCache[x.uri].nodeMap['MADS Collection'].includes('GeographicSubdivisions')){
                 x.type = 'madsrdf:Geographic'
               }
-
 
               if (this.localContextCache[x.uri].type === 'GenreForm'){
                 x.type = 'madsrdf:GenreForm'
@@ -2643,15 +2627,11 @@ methods: {
     for (let c of this.components){
       c.label = c.label.replaceAll('‑','-')
 
-      console.info("c.uri: ", c.uri)
-      console.info("this.localContextCache: ", this.localContextCache)
-
       // we have the full mads type from the build process, check if the component is a id name authortiy
       // if so over write the user defined type with the full type from the authority file so that
       // something like a name becomes a madsrdf:PersonalName instead of madsrdf:Topic
       if (c.uri && c.uri.includes('id.loc.gov/authorities/names/') && this.localContextCache && this.localContextCache[c.uri]){
         let tempType = this.localContextCache[c.uri].typeFull.replace('http://www.loc.gov/mads/rdf/v1#','madsrdf:')
-        console.info("tempType: ", tempType)
         if (!Object.keys(this.activeTypes).includes(tempType)){
           c.type = tempType
         }
@@ -2816,8 +2796,6 @@ methods: {
       this.components = newComponents
     }
 
-    console.info("add: ", this.components)
-    console.info("this.components: ", this.components)
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -583,10 +583,10 @@ const utilsExport = {
 
 					if (ptObj.userValue[ptObj.propertyURI].length>1){
 						// some top level simpleLookup values like bf:content could have multiple values in it but we are really only setup to handle one
-						// so keep track of them for later						
-						userValueSiblings = JSON.parse(JSON.stringify(ptObj.userValue[ptObj.propertyURI])).slice(1) 
+						// so keep track of them for later
+						userValueSiblings = JSON.parse(JSON.stringify(ptObj.userValue[ptObj.propertyURI])).slice(1)
 						// console.log("Got the siblings:", userValueSiblings)
-						
+
 
 					}
 
@@ -988,11 +988,11 @@ const utilsExport = {
 							}
 						}
 						pLvl1.appendChild(bnodeLvl1)
-						rootEl.appendChild(pLvl1)				
+						rootEl.appendChild(pLvl1)
 						componentXmlLookup[`${rt}-${pt}`] = formatXML(pLvl1.outerHTML)
 
 						// this is kind of a hack here, since the system wasn't designed orgianlly to have multiple top level lookup to live in the same bnode
-						// for example bf:content there should be a single bf:content->bf:Content node for each value but in the interface it is nice to allow multiple 
+						// for example bf:content there should be a single bf:content->bf:Content node for each value but in the interface it is nice to allow multiple
 						// inputs in the same component. So allow them to do that but we will build those shallow sibling bnodes right here after we created the first one
 						if (userValueSiblings.length>0){
 							for (let uv of userValueSiblings){
@@ -1009,10 +1009,10 @@ const utilsExport = {
 								}else{
 									console.warn("There was no label for this sibling top level bnode, so there is porbably another way the label is being passed or something else is wrong.",bnodeLvl1Sibling)
 								}
-								
+
 								// add to the structure
 								pLvl1Sibling.appendChild(bnodeLvl1Sibling)
-								rootEl.appendChild(pLvl1Sibling)	
+								rootEl.appendChild(pLvl1Sibling)
 							}
 						}
 
@@ -1662,6 +1662,8 @@ const utilsExport = {
         // let newXML = this.splitComplexSubjects(strBf2MarcXmlElBib)
         // strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(newXML)
 
+		console.info("xml: ", strBf2MarcXmlElBib)
+
 		return {
 			xmlDom: rdf,
 			xmlStringFormatted: strXmlFormatted,
@@ -1790,7 +1792,7 @@ const utilsExport = {
 	creatHubStubURI: async function(hubCreatorObj,title){
 
 		let aap = utilsProfile.returnAap(hubCreatorObj.label,title)
-		
+
 		let aapHash = await md5(aap)
 		aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
 		let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
@@ -1811,7 +1813,7 @@ const utilsExport = {
 	createHubStubXML: async function(hubCreatorObj,title,langObj,catalogerId){
 
 
-		
+
 
 
 		// we are creating the xml in two formats, create the root node for both
@@ -1832,12 +1834,12 @@ const utilsExport = {
 		if (!title) return false
 
 		if (!hubCreatorObj){ hubCreatorObj = {'label':''}}
-		if (!hubCreatorObj.label){ hubCreatorObj.label = ''} 
+		if (!hubCreatorObj.label){ hubCreatorObj.label = ''}
 
-		
+
 
 		// let aap = utilsProfile.returnAap(hubCreatorObj.label,title)
-		
+
 		// let aapHash = await md5(aap)
 		// aapHash = `${aapHash.slice(0, 8)}-${aapHash.slice(8, 12)}-${aapHash.slice(12, 16)}-${aapHash.slice(16, 20)}-${aapHash.slice(20, 32)}`
 		// let hubUri = `http://id.loc.gov/resources/hubs/${aapHash}`
@@ -2015,7 +2017,7 @@ const utilsExport = {
 		leader.innerHTML = "     nz  a22     ni 4500"
 		rootEl.appendChild(leader)
 
-		
+
 
 		let field001 = document.createElementNS(marcNamespace,"marcxml:controlfield");
 		field001.setAttribute( 'tag', '001')
@@ -2029,9 +2031,9 @@ const utilsExport = {
 
 		function pad2(n) { return n < 10 ? '0' + n : n }
 		let date = new Date();
-		let dateValue = date.getFullYear().toString() + pad2(date.getMonth() + 1) + pad2( date.getDate()) + pad2( date.getHours() ) + pad2( date.getMinutes() ) + pad2( date.getSeconds() )	
+		let dateValue = date.getFullYear().toString() + pad2(date.getMonth() + 1) + pad2( date.getDate()) + pad2( date.getHours() ) + pad2( date.getMinutes() ) + pad2( date.getSeconds() )
 		dateValue = dateValue + ".0"
-		
+
 
 		let field005 = document.createElementNS(marcNamespace,"marcxml:controlfield");
 		field005.setAttribute( 'tag', '005')
@@ -2076,12 +2078,12 @@ const utilsExport = {
 		let field040e = document.createElementNS(marcNamespace,"marcxml:subfield");
 		field040e.setAttribute( 'code', 'e')
 		field040e.innerHTML = 'rda'
-		field040.appendChild(field040e)		
+		field040.appendChild(field040e)
 
 		let field040c = document.createElementNS(marcNamespace,"marcxml:subfield");
 		field040c.setAttribute( 'code', 'c')
 		field040c.innerHTML = 'DLC'
-		field040.appendChild(field040c)	
+		field040.appendChild(field040c)
 
 
 		rootEl.appendChild(field040)
@@ -2096,7 +2098,7 @@ const utilsExport = {
 				let subfield = document.createElementNS(marcNamespace,"marcxml:subfield");
 				subfield.setAttribute( 'code', key)
 				subfield.innerHTML = oneXXParts[key]
-				fieldName.appendChild(subfield)	
+				fieldName.appendChild(subfield)
 			}
 		}
 		// 110//$aMiller, Sam$d1933
@@ -2114,7 +2116,7 @@ const utilsExport = {
 					let subfield = document.createElementNS(marcNamespace,"marcxml:subfield");
 					subfield.setAttribute( 'code', key)
 					subfield.innerHTML = fourXXParts[key]
-					fieldName4xx.appendChild(subfield)	
+					fieldName4xx.appendChild(subfield)
 				}
 			}
 
@@ -2123,7 +2125,7 @@ const utilsExport = {
 
 
 
-		
+
 
 
 
@@ -2145,7 +2147,7 @@ const utilsExport = {
 		rootEl.appendChild(field670)
 
 
-		
+
 
 
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1661,6 +1661,7 @@ const utilsExport = {
 
         // let newXML = this.splitComplexSubjects(strBf2MarcXmlElBib)
         // strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(newXML)
+		console.info("xml: ", strXmlBasic)
 		return {
 			xmlDom: rdf,
 			xmlStringFormatted: strXmlFormatted,
@@ -2082,7 +2083,7 @@ const utilsExport = {
 		field040c.innerHTML = 'DLC'
 		field040.appendChild(field040c)
 
-		
+
 		rootEl.appendChild(field040)
 
 
@@ -2090,8 +2091,8 @@ const utilsExport = {
 		let field985 = document.createElementNS(marcNamespace,"marcxml:datafield");
 		field985.setAttribute( 'tag', '985')
 		field985.setAttribute( 'ind1', ' ')
-		field985.setAttribute( 'ind2', ' ')		
-		
+		field985.setAttribute( 'ind2', ' ')
+
 		let field985e = document.createElementNS(marcNamespace,"marcxml:subfield");
 		field985e.setAttribute( 'code', 'e')
 		field985e.innerHTML = 'MARVA-NAR'
@@ -2100,9 +2101,9 @@ const utilsExport = {
 		let field985d = document.createElementNS(marcNamespace,"marcxml:subfield");
 		field985d.setAttribute( 'code', 'd')
 		field985d.innerHTML = `${date.getFullYear().toString()}-${pad2(date.getMonth() + 1)}-${pad2( date.getDate())}`
-	
+
 		field985.appendChild(field985d)
-		
+
 		rootEl.appendChild(field985)
 
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1661,9 +1661,6 @@ const utilsExport = {
 
         // let newXML = this.splitComplexSubjects(strBf2MarcXmlElBib)
         // strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(newXML)
-
-		console.info("xml: ", strBf2MarcXmlElBib)
-
 		return {
 			xmlDom: rdf,
 			xmlStringFormatted: strXmlFormatted,

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2336,11 +2336,11 @@ const utilsNetwork = {
       let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
       let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
 
-      let worksUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-      let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
+      let worksUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
+      let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
 
-      let hubsUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-      let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
+      let hubsUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
+      let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
 
       let childrenSubject = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&-memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
       let childrenSubjectComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&rdftype=ComplexType'
@@ -2360,6 +2360,9 @@ const utilsNetwork = {
       }
 
       console.info("subjectUrlComplex: ", subjectUrlComplex)
+
+      console.info("hubsUrlKeyword: ", hubsUrlKeyword)
+      console.info("hubsUrlAnchored: ", hubsUrlAnchored)
 
       searchVal = decodeURIComponent(searchVal)
       complexVal = decodeURIComponent(complexVal)
@@ -2647,6 +2650,8 @@ const utilsNetwork = {
         'subjectsChildrenComplex': resultsChildrenSubjectsComplex,
         'exact': exact
       }
+
+      console.info("results: ", results)
 
       this.subjectSearchActive = false
       return results

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -459,26 +459,18 @@ const utilsNetwork = {
                 // console.log("URL",url)
                 // console.log("r",r)
                 for (let hit of r.hits){
-                  let context = null
-                  // we only need the context for the subject search to have collection information in the output
-                  if(searchPayload.subjectSearch == true){
-                    context = await this.returnContext(hit.uri)
-                  }
-
                   let hitAdd = {
-                    collections: context ? context.nodeMap["MADS Collection"] : [],
+                    collections: hit.more.collections ? hit.more.collections : [],
                     label: hit.aLabel,
                     vlabel: hit.vLabel,
                     suggestLabel: hit.suggestLabel,
                     uri: hit.uri,
                     literal:false,
                     depreciated: false,
-                    extra: '',
+                    extra: hit.more,
                     total: r.count,
                     undifferentiated: false
                   }
-
-
 
                   if (hitAdd.label=='' && hitAdd.suggestLabel.includes('DEPRECATED')){
                     hitAdd.label  = hitAdd.suggestLabel.split('(DEPRECATED')[0] + ' DEPRECATED'
@@ -2367,6 +2359,8 @@ const utilsNetwork = {
         subjectUrlHierarchicalGeographic = subjectUrlHierarchicalGeographic.replace('&count=4','&count=12').replace("<OFFSET>", "1")
       }
 
+      console.info("subjectUrlComplex: ", subjectUrlComplex)
+
       searchVal = decodeURIComponent(searchVal)
       complexVal = decodeURIComponent(complexVal)
 
@@ -2779,10 +2773,10 @@ const utilsNetwork = {
   },
 
 
-  
+
 
   /**
-  * Publish the NAR 
+  * Publish the NAR
   * @async
   * @param {string} xml - The xml string
   * @return {obj} - {status:false, msg: ""}
@@ -2815,7 +2809,7 @@ const utilsNetwork = {
 
       // alert("Did not post, please report this error--" + JSON.stringify(content.publish,null,2))
 
-      
+
       return {status:false, postLocation: (content.postLocation) ? content.postLocation : null, msg: JSON.stringify(content.publish,null,2), msgObj: content.publish}
     }
   },

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -556,9 +556,6 @@ const utilsNetwork = {
     * @return {array} - An array of {@link contextResult} results
     */
     returnContext: async function(uri){
-      console.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-      console.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-      console.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
       let returnUrls = useConfigStore().returnUrls
       let results
       let d
@@ -2362,11 +2359,6 @@ const utilsNetwork = {
         subjectUrlHierarchicalGeographic = subjectUrlHierarchicalGeographic.replace('&count=4','&count=12').replace("<OFFSET>", "1")
       }
 
-      console.info("subjectUrlComplex: ", subjectUrlComplex)
-
-      console.info("hubsUrlKeyword: ", hubsUrlKeyword)
-      console.info("hubsUrlAnchored: ", hubsUrlAnchored)
-
       searchVal = decodeURIComponent(searchVal)
       complexVal = decodeURIComponent(complexVal)
 
@@ -2653,8 +2645,6 @@ const utilsNetwork = {
         'subjectsChildrenComplex': resultsChildrenSubjectsComplex,
         'exact': exact
       }
-
-      console.info("results: ", results)
 
       this.subjectSearchActive = false
       return results

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -556,6 +556,9 @@ const utilsNetwork = {
     * @return {array} - An array of {@link contextResult} results
     */
     returnContext: async function(uri){
+      console.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+      console.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+      console.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
       let returnUrls = useConfigStore().returnUrls
       let results
       let d

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -513,10 +513,10 @@ export const useConfigStore = defineStore('config', {
 
     "https://preprod-8230.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-      "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
+      "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'", "all":true},
       "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 
-      "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+      "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'"},
 
       "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 
@@ -581,10 +581,10 @@ export const useConfigStore = defineStore('config', {
 
     "https://preprod-8080.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-      "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
+      "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype=keyword", "all":true},
       "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 
-      "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+      "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype=keyword"},
 
       "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -348,11 +348,11 @@ export const useConfigStore = defineStore('config', {
             }
         ]
      },
-    "http://id.loc.gov/authorities/demographicTerms" : {"name":"demographicTerms", "type":"complex", "modes":[
-      {
-      'LCDGT All':{"url":"https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      }
-    ]},
+    // "http://id.loc.gov/authorities/demographicTerms" : {"name":"demographicTerms", "type":"complex", "modes":[
+    //   {
+    //   'LCDGT All':{"url":"https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
+    //   }
+    // ]},
     "http://id.loc.gov/authorities/genreForms" : {
       "name":"genreForms",
       "type":"complex",
@@ -487,16 +487,16 @@ export const useConfigStore = defineStore('config', {
       ]
     },
 
-    "http://id.loc.gov/authorities/demographicTerms": {
-      "name":"demographicTerms",
-      "type":"complex",
-      "processor" : 'lcAuthorities',
-      "modes":[
-        {
-          'LCDGT All':{"url":"https://preprod-8288.id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>", "all":true},
-        }
-      ]
-    },
+    // "http://id.loc.gov/authorities/demographicTerms": {
+    //   "name":"demographicTerms",
+    //   "type":"complex",
+    //   "processor" : 'lcAuthorities',
+    //   "modes":[
+    //     {
+    //       'LCDGT All':{"url":"https://preprod-8288.id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>", "all":true},
+    //     }
+    //   ]
+    // },
 
 
     "http://id.loc.gov/entities/providers" : {"name":"providers", "type":"complex", "modes":[]},

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -32,7 +32,7 @@ export const useConfigStore = defineStore('config', {
 
         id: 'https://id.loc.gov/',
         env : 'production',
-        dev: true,
+        dev: false,
         displayLCOnlyFeatures: true,
       },
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2361,6 +2361,7 @@ export const useProfileStore = defineStore('profile', {
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null, marcKey=null ){
       console.info("setValueComplex")
       console.info("nodeMap: ", nodeMap)
+      console.info("type: ", type)
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -2374,13 +2375,19 @@ export const useProfileStore = defineStore('profile', {
       if (!type && URI && !lastProperty.includes("intendedAudience")){
         // I regretfully inform you we will need to look this up
         let context = await utilsNetwork.returnContext(URI)
+        console.info("context: ", context)
         type = context.typeFull
         console.info("type: ", type)
       }
 
-      if (type && !type.startsWith("http")){
-        type = "http://www.loc.gov/mads/rdf/v1#" + type
+      if (['Work', 'Hub'].includes(type)){
+        type = "http://id.loc.gov/ontologies/bibframe/" + type
       }
+      if (type && !type.startsWith("http")){
+        type = "http://www.loc.gov/mads/rdf/v1#" + type // Works and Hubs should be `BF:` not madsrdf.
+      }
+
+      console.info("type: ", type)
 
       // literals don't have a type or a URI & intendedAudience has extra considerations
       // namely that the rdf:Type in BF is bf:Authority
@@ -2556,6 +2563,7 @@ export const useProfileStore = defineStore('profile', {
     * @return {void} -
     */
     setValueSubject: async function(componentGuid,subjectComponents,propertyPath){
+      console.info("\n\n\nsetValueSubject")
         // we're just going to overwrite the whole userValue with the constructed headings
 
 
@@ -2606,6 +2614,7 @@ export const useProfileStore = defineStore('profile', {
                 }
 
                 let thisLevelType = utilsRDF.suggestTypeProfile(p.propertyURI,pt)
+                console.info("thisLevelType: ", thisLevelType)
                 if (thisLevelType === false){
                   // did not find it in the profile, look to the network
                   thisLevelType = await utilsRDF.suggestTypeNetwork(p.propertyURI)
@@ -2662,6 +2671,7 @@ export const useProfileStore = defineStore('profile', {
                   delete currentUserValuePos["http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme"]
                 }
 
+                console.info("subjectComponents[0]: ", subjectComponents[0])
                 if (subjectComponents[0].type){
                   currentUserValuePos['@type'] = subjectComponents[0].type.replace('madsrdf:','http://www.loc.gov/mads/rdf/v1#')
                 }else{
@@ -2846,7 +2856,8 @@ export const useProfileStore = defineStore('profile', {
 
             }
 
-
+            console.info("pt: ", JSON.parse(JSON.stringify(pt)))
+            console.info("userValue: ", JSON.parse(JSON.stringify(userValue)))
             // double check the @type of the resource we want to be as specific as possible
             if (currentUserValuePos['@type'] == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
               // this is very generic, try not to use that

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2374,8 +2374,13 @@ export const useProfileStore = defineStore('profile', {
         // I regretfully inform you we will need to look this up
         let context = await utilsNetwork.returnContext(URI)
         type = context.typeFull
-
+        console.info("type: ", type)
       }
+
+      if (type && !type.startsWith("http")){
+        type = "http://www.loc.gov/mads/rdf/v1#" + type
+      }
+
       // literals don't have a type or a URI & intendedAudience has extra considerations
       // namely that the rdf:Type in BF is bf:Authority
       if ((!type && !URI) || lastProperty.includes("intendedAudience")){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2359,7 +2359,7 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null, marcKey=null ){
-
+      console.info("setValueComplex")
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -2470,6 +2470,8 @@ export const useProfileStore = defineStore('profile', {
           if (!Array.isArray(marcKey)){
             marcKey = [marcKey]
           }
+
+          console.info("marcKey: ", marcKey)
 
           for (let aMarcKeyNode of marcKey){
             if (!blankNode['http://id.loc.gov/ontologies/bflc/marcKey']){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2360,6 +2360,7 @@ export const useProfileStore = defineStore('profile', {
     */
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null, marcKey=null ){
       console.info("setValueComplex")
+      console.info("nodeMap: ", nodeMap)
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -2454,14 +2455,15 @@ export const useProfileStore = defineStore('profile', {
           }
 
           //Add gacs code to user data
-          if (nodeMap["GAC(s)"]){
+          console.info("nodeMap: ", nodeMap)
+          if (nodeMap["gacs"]){
             blankNode["http://www.loc.gov/mads/rdf/v1#code"] = []
-            for (let code in nodeMap["GAC(s)"]){
+            for (let code in nodeMap["gacs"]){
                 blankNode["http://www.loc.gov/mads/rdf/v1#code"].push(
                   {
                     '@guid': short.generate(),
                     "@gacs": "http://id.loc.gov/datatypes/codes/gac",
-                    'http://www.loc.gov/mads/rdf/v1#code': nodeMap["GAC(s)"][code]
+                    'http://www.loc.gov/mads/rdf/v1#code': nodeMap["gacs"][code]
                   }
                 )
             }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2359,10 +2359,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null, marcKey=null ){
-      console.info("setValueComplex")
-      console.info("nodeMap: ", nodeMap)
-      console.info("type: ", type)
-      console.info("marcKey: ", marcKey)
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -2376,9 +2372,7 @@ export const useProfileStore = defineStore('profile', {
       if (!type && URI && !lastProperty.includes("intendedAudience")){
         // I regretfully inform you we will need to look this up
         let context = await utilsNetwork.returnContext(URI)
-        console.info("context: ", context)
         type = context.typeFull
-        console.info("type: ", type)
         if (!marcKey){
           marcKey = context.marcKey
         }
@@ -2390,8 +2384,6 @@ export const useProfileStore = defineStore('profile', {
       if (type && !type.startsWith("http")){
         type = "http://www.loc.gov/mads/rdf/v1#" + type // Works and Hubs should be `BF:` not madsrdf.
       }
-
-      console.info("type: ", type)
 
       // literals don't have a type or a URI & intendedAudience has extra considerations
       // namely that the rdf:Type in BF is bf:Authority
@@ -2466,7 +2458,6 @@ export const useProfileStore = defineStore('profile', {
           }
 
           //Add gacs code to user data
-          console.info("nodeMap: ", nodeMap)
           if (nodeMap["gacs"]){
             blankNode["http://www.loc.gov/mads/rdf/v1#code"] = []
             for (let code in nodeMap["gacs"]){
@@ -2483,8 +2474,6 @@ export const useProfileStore = defineStore('profile', {
           if (!Array.isArray(marcKey)){
             marcKey = [marcKey]
           }
-
-          console.info("marcKey: ", marcKey)
 
           for (let aMarcKeyNode of marcKey){
             if (!blankNode['http://id.loc.gov/ontologies/bflc/marcKey']){
@@ -2567,10 +2556,7 @@ export const useProfileStore = defineStore('profile', {
     * @return {void} -
     */
     setValueSubject: async function(componentGuid,subjectComponents,propertyPath){
-      console.info("\n\n\nsetValueSubject")
         // we're just going to overwrite the whole userValue with the constructed headings
-
-
         let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
         // console.log('-----')
@@ -2618,7 +2604,6 @@ export const useProfileStore = defineStore('profile', {
                 }
 
                 let thisLevelType = utilsRDF.suggestTypeProfile(p.propertyURI,pt)
-                console.info("thisLevelType: ", thisLevelType)
                 if (thisLevelType === false){
                   // did not find it in the profile, look to the network
                   thisLevelType = await utilsRDF.suggestTypeNetwork(p.propertyURI)
@@ -2675,7 +2660,6 @@ export const useProfileStore = defineStore('profile', {
                   delete currentUserValuePos["http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme"]
                 }
 
-                console.info("subjectComponents[0]: ", subjectComponents[0])
                 if (subjectComponents[0].type){
                   currentUserValuePos['@type'] = subjectComponents[0].type.replace('madsrdf:','http://www.loc.gov/mads/rdf/v1#')
                 }else{
@@ -2860,8 +2844,6 @@ export const useProfileStore = defineStore('profile', {
 
             }
 
-            console.info("pt: ", JSON.parse(JSON.stringify(pt)))
-            console.info("userValue: ", JSON.parse(JSON.stringify(userValue)))
             // double check the @type of the resource we want to be as specific as possible
             if (currentUserValuePos['@type'] == 'http://www.w3.org/2000/01/rdf-schema#Resource'){
               // this is very generic, try not to use that
@@ -4869,7 +4851,6 @@ export const useProfileStore = defineStore('profile', {
 
         data = incomingValue.split(";;;")
       }
-      console.info("\n-------------------------\n")
       for (let item of data){
         const dataJson = JSON.parse(item)
         this.parseActiveInsert(JSON.parse(JSON.stringify(dataJson)))

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2362,6 +2362,7 @@ export const useProfileStore = defineStore('profile', {
       console.info("setValueComplex")
       console.info("nodeMap: ", nodeMap)
       console.info("type: ", type)
+      console.info("marcKey: ", marcKey)
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -2378,6 +2379,9 @@ export const useProfileStore = defineStore('profile', {
         console.info("context: ", context)
         type = context.typeFull
         console.info("type: ", type)
+        if (!marcKey){
+          marcKey = context.marcKey
+        }
       }
 
       if (['Work', 'Hub'].includes(type)){
@@ -4821,6 +4825,7 @@ export const useProfileStore = defineStore('profile', {
                     if (!current.deleted && current.propertyURI.trim() == targetURI.trim() && current.propertyLabel.trim() == targetLabel.trim()){
                         let currentPos = order.indexOf(current.id)
                         let newPos = order.indexOf(newComponent.id)
+
                         // if (Object.keys(current.userValue).length == 1){
                         if (this.isEmptyComponent(current)){
                             current.userValue = newComponent.userValue
@@ -4830,7 +4835,7 @@ export const useProfileStore = defineStore('profile', {
                             let structure = this.returnStructureByComponentGuid(guid)
 
                             let newPt
-                            if (sourceRt && sourceRt != targetRt){
+                            if ((sourceRt && sourceRt != targetRt) || (!sourceRt && !incomingTargetRt)){
                               newPt = await this.duplicateComponentGetId(guid, structure, rt, "last")
                             } else {
                               if (newPos < 0){
@@ -4851,25 +4856,24 @@ export const useProfileStore = defineStore('profile', {
     },
 
     pasteSelected: async function(){
-        let data
-        const clipboardContents = await navigator.clipboard.read();
+      let data
+      const clipboardContents = await navigator.clipboard.read();
 
-        for (let item of clipboardContents){
-
-              if (!item.types.includes("text/plain")) {
-                throw new Error("Clipboard does not contain text data.");
-              }
-
-              let blob = await item.getType("text/plain")
-              const incomingValue = await blob.text()
-
-              data = incomingValue.split(";;;")
-            }
-
-        for (let item of data){
-          const dataJson = JSON.parse(item)
-          this.parseActiveInsert(JSON.parse(JSON.stringify(dataJson)))
+      for (let item of clipboardContents){
+        if (!item.types.includes("text/plain")) {
+          throw new Error("Clipboard does not contain text data.");
         }
+
+        let blob = await item.getType("text/plain")
+        const incomingValue = await blob.text()
+
+        data = incomingValue.split(";;;")
+      }
+      console.info("\n-------------------------\n")
+      for (let item of data){
+        const dataJson = JSON.parse(item)
+        this.parseActiveInsert(JSON.parse(JSON.stringify(dataJson)))
+      }
     },
 
 

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -83,6 +83,7 @@
                   <template v-else>
 
                     <li v-for="(r,idx) in searchByLccnResults" :key="r.idURL">
+                      !!{{ r }}
                         <div style="display:flex">
 
                             <div style="flex:2;">{{++idx}}. <span style="font-weight:bold">{{r.label}}</span></div>
@@ -282,9 +283,6 @@
       ...mapState(useConfigStore, ['testData']),
       ...mapState(useProfileStore, ['startingPoints','profiles']),
       ...mapWritableState(useProfileStore, ['activeProfile', 'emptyComponents','activeProfilePosted','activeProfilePostedTimestamp']),
-
-
-      
 
 
       // // gives read access to this.count and this.double
@@ -674,7 +672,7 @@
   }
 </style>
 
-<style scoped>  
+<style scoped>
 
 
 #test-data-table{
@@ -696,7 +694,7 @@
 
   background-color: v-bind("preferenceStore.returnValue('--c-edit-modals-background-color')")  !important;
   color: v-bind("preferenceStore.returnValue('--c-edit-modals-text-color')")  !important;
-  
+
   background-color: v-bind("preferenceStore.returnValue('--c-edit-modals-background-color-accent')")  !important;
 
 }

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -83,7 +83,6 @@
                   <template v-else>
 
                     <li v-for="(r,idx) in searchByLccnResults" :key="r.idURL">
-                      !!{{ r }}
                         <div style="display:flex">
 
                             <div style="flex:2;">{{++idx}}. <span style="font-weight:bold">{{r.label}}</span></div>


### PR DESCRIPTION
Update to `complex lookup`s to use the data in the `more` property that `suggest2` returns. This cuts back on the number of requests that Marva makes to ID. It should be <10 for any lookup. Before there could be dozens and even hundreds if the cataloger has there preferences set to return lots of subjects.

There's some updates to how the detail display. But it should be the same for the catalogers except that it should be faster.