### PR TITLE
[BFP-342] MARC Subject Entry `$b`

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1391,7 +1391,10 @@ const utilsNetwork = {
         result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (not string)'
       }
 
-      lcsh=lcsh.replace(/\$c/g,'').replace(/\$d/g,'').replace(/\|c/g,'').replace(/\|d/g,'').replace(/‡c/g,'').replace(/‡d/g,'').replace(/\s{2,}/g, ' ')
+      lcsh=lcsh.replace(/\$b/g,' ').replace(/\|b/g,' ').replace(/‡b/g,' ')
+               .replace(/\$c/g,'').replace(/\|c/g,'').replace(/‡c/g,'')
+               .replace(/\$d/g,'').replace(/\|d/g,'').replace(/‡d/g,'')
+               .replace(/\s{2,}/g, ' ')
 
       // if it doesn't have a $a or ‡a in the start of the string add it
       // often times copying from a system they dont include the $a

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1391,10 +1391,12 @@ const utilsNetwork = {
         result.msg = 'REGEX Error: That value doesn\'t look like a valid MARC encoded LCSH string (not string)'
       }
 
-      lcsh=lcsh.replace(/\$b/g,' ').replace(/\|b/g,' ').replace(/‡b/g,' ')
-               .replace(/\$c/g,'').replace(/\|c/g,'').replace(/‡c/g,'')
-               .replace(/\$d/g,'').replace(/\|d/g,'').replace(/‡d/g,'')
-               .replace(/\s{2,}/g, ' ')
+      lcsh=lcsh.replace(/[\|\$\‡]{1}[bcd]{1}/g, ' ').replace(/\s{2,}/g, ' ')
+
+      // .replace(/\$b/g,' ').replace(/\|b/g,' ').replace(/‡b/g,' ')
+      //          .replace(/\$c/g,'').replace(/\|c/g,'').replace(/‡c/g,'')
+      //          .replace(/\$d/g,'').replace(/\|d/g,'').replace(/‡d/g,'')
+      //          .replace(/\s{2,}/g, ' ')
 
       // if it doesn't have a $a or ‡a in the start of the string add it
       // often times copying from a system they dont include the $a


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-342

Toss `$b` in Marc Subject input. This was already being done with `$c` and `$d`. It wasn't finding matches when it should. Without `$b` it does find the match.

![image](https://github.com/user-attachments/assets/c284fdf1-638b-4d54-9b4a-4907eb42b752)
