### PR TITLE
Some More Updates to Match Suggest2

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -431,7 +431,6 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-      console.info("setComplexValue: ", contextValue)
       if (Object.keys(contextValue.extra).length == 0){
         // Intended audience mixes simple and complex lookups, so do check
         this.profileStore.setValueSimple(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title[0])

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -431,6 +431,7 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
+      console.info("setComplexValue: ", contextValue)
       if (Object.keys(contextValue.extra).length == 0){
         // Intended audience mixes simple and complex lookups, so do check
         this.profileStore.setValueSimple(this.guid, null, this.propertyPath, contextValue.uri, contextValue.title[0])
@@ -450,7 +451,7 @@ export default {
           this.propertyPath,
           contextValue.uri,
           contextValue.title,
-          null, //contextValue.type.includes("Hub") ? "Hub" : contextValue.extra.rdftypes[0],
+          (contextValue.type && (contextValue.type.includes("Hub") || contextValue.type.includes("Work")) ) ? contextValue.type : contextValue.extra.rdftypes[0],
           contextValue.extra,
           contextValue.extra.marcKey
         )

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -77,9 +77,7 @@
                 <div class="lookup-fake-input-entities" style="display:inline-block;">
                   <div v-for="(avl,idx) in simpleLookupValues" class="selected-value-container">
                       <span v-if="!avl.needsDereference" style="padding-right: 0.3em; font-weight: bold">{{avl.label}}<span class="uncontrolled" v-if="avl.isLiteral">(uncontrolled)</span><span v-if="!avl.isLiteral" title="Controlled Term" class="selected-value-icon" style=""></span></span>
-
                       <span v-else style="padding-right: 0.3em; font-weight: bold"><LabelDereference :URI="avl.URI"/><span v-if="!avl.isLiteral" title="Controlled Term" class="selected-value-icon"></span></span>
-
                       <span @click="removeValue(idx)" style="border-left: solid 1px black; padding: 0 0.5em; font-size: 1em; cursor: pointer;">x</span>
                   </div>
                 </div>

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -288,16 +288,13 @@ export default {
     ...mapWritableState(useProfileStore, ['activeField','activeProfile']),
 
     simpleLookupValues(){
-      console.info("simpleLookupValues")
       // profileStore.setActiveField()
       let values = this.profileStore.returnSimpleLookupValueFromProfile(this.guid, this.propertyPath)
       if (this.readOnly && values.length==0){
         this.showField=false
       }
 
-      console.info("values: ", values)
       return values
-
     },
 
     // if there is already a value we just need one of them so we can find its parent to put new ones into

--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -288,12 +288,14 @@ export default {
     ...mapWritableState(useProfileStore, ['activeField','activeProfile']),
 
     simpleLookupValues(){
+      console.info("simpleLookupValues")
       // profileStore.setActiveField()
       let values = this.profileStore.returnSimpleLookupValueFromProfile(this.guid, this.propertyPath)
       if (this.readOnly && values.length==0){
         this.showField=false
       }
 
+      console.info("values: ", values)
       return values
 
     },
@@ -868,9 +870,6 @@ export default {
               break
             }
 
-
-
-
             // this.activeLookupValue.push({'http://www.w3.org/2000/01/rdf-schema#label':metadata[key].label[idx],URI:metadata[key].uri})
             this.activeFilter = ''
             this.activeValue = ''
@@ -882,7 +881,6 @@ export default {
             break
           }
         }
-
 
         // if there is a value still that means the value did not match a item in the list
         // so add the value as a uncontrolled value

--- a/src/components/panels/edit/fields/helpers/LabelDereference.vue
+++ b/src/components/panels/edit/fields/helpers/LabelDereference.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-
+import { useConfigStore } from '@/stores/config'
 
 export default {
   name: "EditLabelDereference",
@@ -77,6 +77,10 @@ export default {
                 this.displayLabel = cache
 
               }else{
+                let returnUrls = useConfigStore().returnUrls
+                if (returnUrls.env == "production"){
+                  URL = URL.replace("//id.", "//preprod-8080.id.")
+                }
 
                 let self = this
                 fetch(URL, {method: 'HEAD' }).then(

--- a/src/components/panels/edit/fields/helpers/LabelDereference.vue
+++ b/src/components/panels/edit/fields/helpers/LabelDereference.vue
@@ -19,16 +19,11 @@ export default {
 
   data:function() {
     return {
-
       displayLabel: ''
-
     }
   },
 
-  created: function(){
-
-
-  },
+  created: function(){},
 
   computed: {
 
@@ -45,7 +40,6 @@ export default {
   methods:{
 
     fetchLabel: function(){
-      console.info("fetchLabel")
       if (this.URI){
         if (this.URI.startsWith('http://') || this.URI.startsWith('https://') ){
 
@@ -67,7 +61,6 @@ export default {
               }
 
               let URL = this.URI + '.madsrdf_raw.json' //'.nt'
-              console.info("    url: ", URL)
               URL = URL.replace('http://','https://')
 
               let cache = sessionStorage.getItem(URL);

--- a/src/components/panels/edit/fields/helpers/LabelDereference.vue
+++ b/src/components/panels/edit/fields/helpers/LabelDereference.vue
@@ -35,7 +35,7 @@ export default {
     displayLabelValue(){
       this.fetchLabel()
       return this.displayLabel
-    }, 
+    },
 
 
   },
@@ -45,7 +45,7 @@ export default {
   methods:{
 
     fetchLabel: function(){
-
+      console.info("fetchLabel")
       if (this.URI){
         if (this.URI.startsWith('http://') || this.URI.startsWith('https://') ){
 
@@ -53,24 +53,25 @@ export default {
 
             // if its a instance/work/hub getthe x-pref label from the head request
             if (
-                this.URI.includes('/resources/instances/') || 
-                this.URI.includes('/resources/works/') || 
+                this.URI.includes('/resources/instances/') ||
+                this.URI.includes('/resources/works/') ||
                 this.URI.includes('/resources/hubs/') ||
                 this.URI.includes('/ontologies/bibframe/') ||
 
-                
-                this.URI.includes('/vocabulary/') 
+
+                this.URI.includes('/vocabulary/')
               ){
 
               if (this.URI.endsWith('/')){
                 this.URI = this.URI.slice(0, -1)
               }
 
-              let URL = this.URI + '.nt'
+              let URL = this.URI + '.madsrdf_raw.json' //'.nt'
+              console.info("    url: ", URL)
               URL = URL.replace('http://','https://')
 
               let cache = sessionStorage.getItem(URL);
-              
+
               if (cache){
 
                 this.displayLabel = cache
@@ -82,7 +83,7 @@ export default {
                   function(response)
                     {
 
-                      // an id upgrade enables a ecoded pref-label to be exposed 
+                      // an id upgrade enables a ecoded pref-label to be exposed
                       // since the old x-preflabel is not encoded and header vars are not unicode supporting
                       // so use it if avialable
                       let preflabel = response.headers.get("x-preflabel");
@@ -92,15 +93,11 @@ export default {
 
                       if (preflabel){
                         self.displayLabel = preflabel
-
-
                         sessionStorage.setItem(URL, preflabel);
-
-
                       }
                     }
                   ).catch(function() {
-                        
+
                         // there was something with the request, ignore
 
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -70,7 +70,7 @@
           "collections": "MADS Collections",
           "sources": "Sources",
           "marcKey": "MARC Key",
-          "relateds": "Releated Names"
+          "relateds": "See Also"
         },
         panelDetailOrder: [
           "notes","nonlatinLabels","variantLabels", "relateds","birthdates","birthplaces","locales",
@@ -1027,7 +1027,7 @@
                             <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
                             <!-- <a :href="'https://id.loc.gov/authorities/classification/'+v" target="_blank">{{v}}</a> -->
                           </template>
-                          <template v-else-if="key == 'broaders'">
+                          <template v-else-if="key == 'broaders' || key == 'relateds'">
                             <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
                           </template>
                           <template v-else>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -70,7 +70,7 @@
           "collections": "MADS Collections",
           "sources": "Sources",
           "marcKey": "MARC Key",
-          "relateds": "See Also"
+          "relateds": "Related"
         },
         panelDetailOrder: [
           "notes","nonlatinLabels","variantLabels", "relateds","birthdates","birthplaces","locales",

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -70,8 +70,13 @@
           "collections": "MADS Collections",
           "sources": "Sources",
           "marcKey": "MARC Key",
+          "relateds": "Releated Names"
         },
-        panelDetailOrder: ["notes","nonlatinLabels","variantLabels","birthdates","birthplaces","locales","activityfields","occupations","languages","lcclasss","broaders","gacs","collections","sources", "marcKey"],
+        panelDetailOrder: [
+          "notes","nonlatinLabels","variantLabels", "relateds","birthdates","birthplaces","locales",
+          "activityfields","occupations","languages","lcclasss","broaders","gacs","collections",
+          "sources", "marcKey"
+        ],
       }
     },
     computed: {

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -926,6 +926,12 @@ methods: {
 
   //parse complex headings so we can have complete and broken up headings
   parseComplexSubject: async function(uri){
+    console.info("parseComplexSubject: ", uri)
+    let returnUrls = useConfigStore().returnUrls
+    if (returnUrls.env == 'production'){
+      uri = uri.replace('http://id.', 'https://preprod-8080.id.')
+      uri = uri.replace('https://id.', 'https://preprod-8080.id.')
+    }
     let data = await utilsNetwork.fetchSimpleLookup(uri + ".json", true)
     let components = false
     let subfields = false

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -886,7 +886,7 @@ data: function() {
       "sources": "Sources",
       "subjects": "Subjects",
       "marcKey": "MARC Key",
-      "relateds": "Related Names"
+      "relateds": "Related"
     },
     panelDetailOrder: [
       "notes","nonlatinLabels","variantLabels", "relateds","birthdates",

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -89,7 +89,7 @@
                   <button @click="searchModeSwitch('LCSHNAF')" :data-tooltip="'Shortcut: CTRL+ALT+1'" :class="['simptip-position-bottom',{'active':(searchMode==='LCSHNAF')}]">LCSH/NAF</button>
                   <button @click="searchModeSwitch('CHILD')" :data-tooltip="'Shortcut: CTRL+ALT+2'" :class="['simptip-position-bottom',{'active':(searchMode==='CHILD')}]">Children's Subjects</button>
                   <button @click="searchModeSwitch('GEO')" :data-tooltip="'Shortcut: CTRL+ALT+3'" :class="['simptip-position-bottom',{'active':(searchMode==='GEO')}]">Indirect Geo</button>
-                  <button @click="searchModeSwitch('WORKS')" :data-tooltip="'Shortcut: CTRL+ALT+4'" :class="['simptip-position-bottom',{'active':(searchMode==='WORKS')}]">Works</button>
+                  <!-- <button @click="searchModeSwitch('WORKS')" :data-tooltip="'Shortcut: CTRL+ALT+4'" :class="['simptip-position-bottom',{'active':(searchMode==='WORKS')}]">Works</button> -->
                   <button @click="searchModeSwitch('HUBS')" :data-tooltip="'Shortcut: CTRL+ALT+5'" :class="['simptip-position-bottom',{'active':(searchMode==='HUBS')}]">Hubs</button>
 
                 </div>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -886,9 +886,10 @@ data: function() {
       "sources": "Sources",
       "subjects": "Subjects",
       "marcKey": "MARC Key",
+      "relateds": "Related Names"
     },
     panelDetailOrder: [
-      "notes","nonlatinLabels","variantLabels","birthdates",
+      "notes","nonlatinLabels","variantLabels", "relateds","birthdates",
       "birthplaces","locales","activityfields","occupations",
       "languages","lcclasss","broaders","gacs","collections",
       "sources", "subjects", "marcKey"

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -926,7 +926,6 @@ methods: {
 
   //parse complex headings so we can have complete and broken up headings
   parseComplexSubject: async function(uri){
-    console.info("parseComplexSubject: ", uri)
     let returnUrls = useConfigStore().returnUrls
     if (returnUrls.env == 'production'){
       uri = uri.replace('http://id.', 'https://preprod-8080.id.')

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1731,7 +1731,7 @@ methods: {
     this.contextRequestInProgress = false
   },
 
-  _getContext: async function(){
+  _getContextDeprecated: async function(){
     if (this.pickLookup[this.pickPostion].literal){
       this.contextData = this.pickLookup[this.pickPostion]
       return false

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -584,11 +584,6 @@ const utilsNetwork = {
     * @return {object} - the data response
     */
     fetchContextData: async function(uri){
-      console.info("!!!!!!!!!!!!!!!!!!!!!!!")
-      console.info("!!!!!!!!!!!!!!!!!!!!!!!")
-      console.info("FETCHING")
-      console.info("!!!!!!!!!!!!!!!!!!!!!!!")
-      console.info("!!!!!!!!!!!!!!!!!!!!!!!")
           let returnUrls = useConfigStore().returnUrls
 
           if ((uri.startsWith('http://id.loc.gov') || uri.startsWith('https://id.loc.gov')) && uri.match(/(authorities|vocabularies)/)) {
@@ -751,7 +746,6 @@ const utilsNetwork = {
     * @return {array} - An array of {@link contextResult} results
     */
     extractContextDataWorksHubs: async function(data){
-      console.info("extractContextDataWorksHubs")
       let returnUrls = useConfigStore().returnUrls
 
 
@@ -832,11 +826,7 @@ const utilsNetwork = {
                     url = url.replace('https://preprod-8288.id.loc.gov','https://id.loc.gov')
                   }
 
-
-
-
                   let response = await fetch(url.replace('http://','https://')+'.nt');
-                  console.info("response: ", response)
                   let text  = await response.text()
 
                   let instanceText = ""
@@ -921,7 +911,6 @@ const utilsNetwork = {
     * @return {array} - An array of {@link contextResult} results
     */
     extractContextData: function(data){
-      console.info("extractContextData")
       data.uri = data.uri.replace("https://preprod-8080.", "http://id.loc.gov/")
 
           var results = {
@@ -2162,8 +2151,6 @@ const utilsNetwork = {
       }else if (result.hit && result.resultType == 'COMPLEX') {
         // if they are adding a complex value still need to lookup the marc key
         // let marcKeyResult = await this.returnMARCKey(result.hit.uri + '.madsrdf_raw.jsonld')
-        console.info("result.hit: ", result.hit)
-        console.info("marcKeyResult: ", marcKeyResult)
 
         result.hit.marcKey = result.hit.extra.marcKey
       }
@@ -2181,7 +2168,6 @@ const utilsNetwork = {
     * @return {string} - The URI of the likely MADSRDF rdf type
     */
     returnRDFType: async function(uri){
-      console.info("returnRDFType")
       uri=uri.trim()
       let uriToLookFor = uri
 
@@ -2252,7 +2238,6 @@ const utilsNetwork = {
     * @return {string} - The URI of the likely MADSRDF rdf type
     */
     returnMARCKey: async function(uri){
-      console.info("returnMARCKey")
       uri=uri.trim()
 
       // marc keys don't exist on the RWO so if they are asking for a RWO switch it to a auth

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1570,8 +1570,8 @@ const utilsNetwork = {
         let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
         let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
 
-        let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
-        let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
+        // let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
+        let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
 
         let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")
         let subjectUrlHierarchicalGeographicLCSH = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+ '&rdftype=HierarchicalGeographic'
@@ -1671,12 +1671,12 @@ const utilsNetwork = {
           signal: this.controllers.controllerGeographicLCNAF.signal
         }
 
-        let searchPayloadWorksAnchored = {
-          processor: 'lcAuthorities',
-          url: [worksUrlAnchored],
-          searchValue: searchVal,
-          signal: this.controllers.controllerWorksAnchored.signal
-        }
+        // let searchPayloadWorksAnchored = {
+        //   processor: 'lcAuthorities',
+        //   url: [worksUrlAnchored],
+        //   searchValue: searchVal,
+        //   signal: this.controllers.controllerWorksAnchored.signal
+        // }
         let searchPayloadHubsAnchored = {
           processor: 'lcAuthorities',
           url: [hubsUrlAnchored],
@@ -1706,7 +1706,7 @@ const utilsNetwork = {
         let resultsSubjectsComplex=[]
         let resultsHierarchicalGeographic=[]
         let resultsHierarchicalGeographicLCSH=[]
-        let resultsWorksAnchored=[]
+        // let resultsWorksAnchored=[]
         let resultsHubsAnchored=[]
         let resultsPayloadSubjectsSimpleSubdivision=[]
         let resultsPayloadSubjectsTemporal=[]
@@ -1725,7 +1725,7 @@ const utilsNetwork = {
         // if it is a primary heading then we need to search LCNAF, HUBS, WORKS, and simple subjects, and do the whole thing with complex subjects
         if (heading.primary){
           // resultsNames = await this.searchComplex(searchPayloadNames)
-          [resultsNames, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic,resultsHierarchicalGeographicLCSH, resultsWorksAnchored, resultsHubsAnchored, resultsChildren, resultsChildrenSubDiv, resultsExactName, resultsExactSubject] = await Promise.all([
+          [resultsNames, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic,resultsHierarchicalGeographicLCSH, resultsHubsAnchored, resultsChildren, resultsChildrenSubDiv, resultsExactName, resultsExactSubject] = await Promise.all([
               this.searchComplex(searchPayloadNames),
               this.searchComplex(searchPayloadNamesSubdivision),
               this.searchComplex(searchPayloadSubjectsSimple),
@@ -1733,7 +1733,7 @@ const utilsNetwork = {
               this.searchComplex(searchPayloadSubjectsComplex),
               this.searchComplex(searchPayloadHierarchicalGeographic),
               this.searchComplex(searchPayloadHierarchicalGeographicLCSH),
-              this.searchComplex(searchPayloadWorksAnchored),
+              // this.searchComplex(searchPayloadWorksAnchored),
               this.searchComplex(searchPayloadHubsAnchored),
               this.searchComplex(searchPayloadChildren),
               this.searchComplex(searchPayloadChildrenSub),
@@ -1751,7 +1751,7 @@ const utilsNetwork = {
           resultsSubjectsComplex = resultsSubjectsComplex.filter((r)=>{ return (!r.literal) })
           resultsHierarchicalGeographic = resultsHierarchicalGeographic.filter((r)=>{ return (!r.literal) })
           resultsHierarchicalGeographicLCSH = resultsHierarchicalGeographicLCSH.filter((r)=>{ return (!r.literal) })
-          resultsWorksAnchored = resultsWorksAnchored.filter((r)=>{ return (!r.literal) })
+          // resultsWorksAnchored = resultsWorksAnchored.filter((r)=>{ return (!r.literal) })
           resultsHubsAnchored = resultsHubsAnchored.filter((r)=>{ return (!r.literal) })
           resultsPayloadSubjectsSimpleSubdivision = resultsPayloadSubjectsSimpleSubdivision.filter((r)=>{ return (!r.literal) })
           resultsChildren = resultsChildren.filter((r)=>{ return (!r.literal) })
@@ -1875,20 +1875,20 @@ const utilsNetwork = {
           }
 
           // see if we matched a Work name as primary compontant
-          if (resultsWorksAnchored.length>0){
-            for (let r of resultsWorksAnchored){
-              // lower case, remove end space, make double whitespace into one and remove any punctuation
-              if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
-                result.resultType = 'PRECOORD-WORK'
-                if (!result.hit){ result.hit = [] }
-                r.heading = heading
-                result.hit.push(r)
-                foundHeading = true
-                break
-              }
-            }
-            if (foundHeading){ continue }
-          }
+          // if (resultsWorksAnchored.length>0){
+          //   for (let r of resultsWorksAnchored){
+          //     // lower case, remove end space, make double whitespace into one and remove any punctuation
+          //     if (heading.label.toLowerCase().trim().replace(/\s+/g,' ').replace(/[\p{P}$+<=>^`|~]/gu, '') == r.label.toLowerCase().trim().replace(/[\p{P}$+<=>^`|~]/gu, '')){
+          //       result.resultType = 'PRECOORD-WORK'
+          //       if (!result.hit){ result.hit = [] }
+          //       r.heading = heading
+          //       result.hit.push(r)
+          //       foundHeading = true
+          //       break
+          //     }
+          //   }
+          //   if (foundHeading){ continue }
+          // }
 
           // see if we matched a Hub name as primary compontant
           if (resultsHubsAnchored.length>0){
@@ -2342,11 +2342,11 @@ const utilsNetwork = {
       let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
       let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
 
-      let worksUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
-      let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
+      // let worksUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
+      // let worksUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
 
-      let hubsUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
-      let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
+      let hubsUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
+      let hubsUrlAnchored = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/hubs'].modes[0]['Hubs - Left Anchored'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
 
       let childrenSubject = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&-memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
       let childrenSubjectComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsCyac).replace("<OFFSET>", "1")+'&rdftype=ComplexType'
@@ -2463,21 +2463,20 @@ const utilsNetwork = {
         signal: this.controllers.controllerHierarchicalGeographic.signal,
       }
 
-      let searchPayloadWorksAnchored = {
-        processor: 'lcAuthorities',
-        url: [worksUrlAnchored],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerWorksAnchored.signal,
-      }
-
-      let searchPayloadWorksKeyword = {
-        processor: 'lcAuthorities',
-        url: [worksUrlKeyword],
-        searchValue: searchVal,
-        subjectSearch: true,
-        signal: this.controllers.controllerWorksKeyword.signal,
-      }
+      // let searchPayloadWorksAnchored = {
+      //   processor: 'lcAuthorities',
+      //   url: [worksUrlAnchored],
+      //   searchValue: searchVal,
+      //   subjectSearch: true,
+      //   signal: this.controllers.controllerWorksAnchored.signal,
+      // }
+      // let searchPayloadWorksKeyword = {
+      //   processor: 'lcAuthorities',
+      //   url: [worksUrlKeyword],
+      //   searchValue: searchVal,
+      //   subjectSearch: true,
+      //   signal: this.controllers.controllerWorksKeyword.signal,
+      // }
 
       let searchPayloadHubsAnchored = {
         processor: 'lcAuthorities',
@@ -2543,12 +2542,12 @@ const utilsNetwork = {
             this.searchComplex(searchPayloadHierarchicalGeographic)
         ]);
 
-      }else if (mode == "WORKS"){
+      // }else if (mode == "WORKS"){
 
-        [resultsWorksAnchored,resultsWorksKeyword ] = await Promise.all([
-            this.searchComplex(searchPayloadWorksAnchored),
-            this.searchComplex(searchPayloadWorksKeyword)
-        ]);
+      //   [resultsWorksAnchored,resultsWorksKeyword ] = await Promise.all([
+      //       this.searchComplex(searchPayloadWorksAnchored),
+      //       this.searchComplex(searchPayloadWorksKeyword)
+      //   ]);
 
       }else if (mode == "HUBS"){
 
@@ -2601,11 +2600,11 @@ const utilsNetwork = {
       // }]
 
 
-      if (mode == "WORKS"){
-        // over write the subjects if we are doing a work search
-        resultsSubjectsSimple = resultsWorksAnchored
-        resultsSubjectsComplex = resultsWorksKeyword
-      }
+      // if (mode == "WORKS"){
+      //   // over write the subjects if we are doing a work search
+      //   resultsSubjectsSimple = resultsWorksAnchored
+      //   resultsSubjectsComplex = resultsWorksKeyword
+      // }
       if (mode == "HUBS"){
         // over write the subjects if we are doing a work search
         resultsSubjectsSimple = resultsHubsAnchored

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -751,6 +751,7 @@ const utilsNetwork = {
     * @return {array} - An array of {@link contextResult} results
     */
     extractContextDataWorksHubs: async function(data){
+      console.info("extractContextDataWorksHubs")
       let returnUrls = useConfigStore().returnUrls
 
 
@@ -835,6 +836,7 @@ const utilsNetwork = {
 
 
                   let response = await fetch(url.replace('http://','https://')+'.nt');
+                  console.info("response: ", response)
                   let text  = await response.text()
 
                   let instanceText = ""

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -50,14 +50,12 @@ const utilsNetwork = {
     * @return {object} - returns the results processing
     */
     loadSimpleLookup: async function(uris){
-      console.info("loadSimpleLookup")
         // TODO make this better for multuple lookup list (might not be needed)
         if (!Array.isArray(uris)){
           uris=[uris]
         }
         for (let uri of uris){
           let url = uri
-          console.info("url: ", url)
           // TODO more checks here
           if (!uri.includes('.json') && !uri.includes("suggest2")){
               url = url + '.json'
@@ -284,7 +282,6 @@ const utilsNetwork = {
     * @return {object|string} - returns the JSON object parsed into JS Object or the text body of the response depending if it is json or not
     */
     fetchSimpleLookup: async function(url, json, signal=null) {
-      console.info("fetchSimpleLookup: ", url)
       url = url || config.profileUrl
       if (url.includes("id.loc.gov")){
         url = url.replace('http://','https://')
@@ -292,12 +289,6 @@ const utilsNetwork = {
 
       // if we use the memberOf there might be a id URL in the params, make sure its not https
       url = url.replace('memberOf=https://id.loc.gov/','memberOf=http://id.loc.gov/')
-
-      let returnUrls = useConfigStore().returnUrls
-      if (returnUrls.env == 'production'){
-        url = url.replace("https://id.loc.gov", "https://preprod-8080.id.loc.gov")
-        console.info("url: ", url)
-      }
 
       let options = {signal: signal}
       if (json){
@@ -578,7 +569,6 @@ const utilsNetwork = {
         return false
       }
 
-      console.info("uri: ", uri)
       if (d && uri.includes('resources/works/') || uri.includes('resources/hubs/')){
         results = await this.extractContextDataWorksHubs(d)
       }else if (d){
@@ -1011,8 +1001,6 @@ const utilsNetwork = {
                     results.title = g['http://id.loc.gov/ontologies/bflc/aap'][0]['@value']
                   }
 
-                  console.info("types: ", g['@type'])
-
                   if (g['@type'] && g['@type'][0]){
                     results.type = this.rdfType(g['@type'][0])
                     results.typeFull = g['@type'][0]
@@ -1220,7 +1208,6 @@ const utilsNetwork = {
 
 
               if (n['@id'] && n['@id'] == data.uri && n['@type']){
-                console.info("types: ", n['@type'])
                   n['@type'].forEach((t)=>{
                       if (results.type===null){
                           results.type = this.rdfType(t)
@@ -1283,7 +1270,6 @@ const utilsNetwork = {
             }
           })
 
-          console.info("results: ", results)
           return results;
         },
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 20,
+    versionPatch: 21,
 
     regionUrls: {
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -579,52 +579,42 @@ export const useConfigStore = defineStore('config', {
 
 
 
-    "https://preprod-8080.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-      "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype=keyword", "all":true},
-      "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+    // "https://preprod-8080.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
+    //   {
+    //   "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype=keyword", "all":true},
+    //   "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+    //   "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype=keyword"},
+    //   "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+    //   }
+    // ]},
 
-      "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype=keyword"},
-
-      "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-
-      }
-    ]},
-
-    "https://preprod-8080.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
-      {
-      "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
-      "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-
-      "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
-
-      "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-
-      }
-    ]},
+    // "https://preprod-8080.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
+    //   {
+    //   "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
+    //   "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+    //   "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+    //   "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+    //   }
+    // ]},
 
     "https://preprod-8080.id.loc.gov/resources/hubs" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-
-
-
       "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
-
       "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-
+      }
+    ]},
+    "https://preprod-8080.id.loc.gov/resources/hubs/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
+      {
+      "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
+      "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
       }
     ]},
 
 
     "https://id.loc.gov/resources/hubs" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-
-
-
       "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
-
       "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-
       }
     ]},
 
@@ -633,13 +623,8 @@ export const useConfigStore = defineStore('config', {
 
     "https://preprod-8080.id.loc.gov/resources/hubs" : {"name":"Hubs", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-
-
-
       "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>","all":true},
-
       "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-
       }
     ]},
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2205,9 +2205,7 @@ export const useProfileStore = defineStore('profile', {
 
         }
 
-        console.info("values: ", values)
         return values
-
       }
 
       // if valueLocation is false then it did not find anytihng meaning its empty, return empty array
@@ -2361,6 +2359,15 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null, marcKey=null ){
+      console.info("setValueComplex")
+      console.info("    componentGuid: ", componentGuid)
+      console.info("    fieldGuid: ", fieldGuid)
+      console.info("    propertyPath: ", propertyPath)
+      console.info("    URI: ", URI)
+      console.info("    label: ", label)
+      console.info("    type: ", type)
+      console.info("    nodeMap: ", nodeMap)
+      console.info("    marcKey: ", marcKey)
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
@@ -2380,12 +2387,12 @@ export const useProfileStore = defineStore('profile', {
       //   }
       // }
 
-      // if (['Work', 'Hub'].includes(type)){
-      //   type = "http://id.loc.gov/ontologies/bibframe/" + type
-      // }
-      // if (type && !type.startsWith("http")){
-      //   type = "http://www.loc.gov/mads/rdf/v1#" + type // Works and Hubs should be `BF:` not madsrdf.
-      // }
+      if (['Work', 'Hub'].includes(type)){
+        type = "http://id.loc.gov/ontologies/bibframe/" + type
+      }
+      if (type && !type.startsWith("http")){
+        type = "http://www.loc.gov/mads/rdf/v1#" + type
+      }
 
       // literals don't have a type or a URI & intendedAudience has extra considerations
       // namely that the rdf:Type in BF is bf:Authority

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2359,15 +2359,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueComplex: async function(componentGuid, fieldGuid, propertyPath, URI, label, type, nodeMap=null, marcKey=null ){
-      console.info("setValueComplex")
-      console.info("    componentGuid: ", componentGuid)
-      console.info("    fieldGuid: ", fieldGuid)
-      console.info("    propertyPath: ", propertyPath)
-      console.info("    URI: ", URI)
-      console.info("    label: ", label)
-      console.info("    type: ", type)
-      console.info("    nodeMap: ", nodeMap)
-      console.info("    marcKey: ", marcKey)
       // TODO: reconcile this to how the profiles are built, or dont..
       // remove the sameAs from this property path, which will be the last one, we don't need it
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2205,6 +2205,7 @@ export const useProfileStore = defineStore('profile', {
 
         }
 
+        console.info("values: ", values)
         return values
 
       }
@@ -2370,21 +2371,21 @@ export const useProfileStore = defineStore('profile', {
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
 
-      if (!type && URI && !lastProperty.includes("intendedAudience")){
-        // I regretfully inform you we will need to look this up
-        let context = await utilsNetwork.returnContext(URI)
-        type = context.typeFull
-        if (!marcKey){
-          marcKey = context.marcKey
-        }
-      }
+      // if (!type && URI && !lastProperty.includes("intendedAudience")){
+      //   // I regretfully inform you we will need to look this up
+      //   let context = await utilsNetwork.returnContext(URI)
+      //   type = context.typeFull
+      //   if (!marcKey){
+      //     marcKey = context.marcKey
+      //   }
+      // }
 
-      if (['Work', 'Hub'].includes(type)){
-        type = "http://id.loc.gov/ontologies/bibframe/" + type
-      }
-      if (type && !type.startsWith("http")){
-        type = "http://www.loc.gov/mads/rdf/v1#" + type // Works and Hubs should be `BF:` not madsrdf.
-      }
+      // if (['Work', 'Hub'].includes(type)){
+      //   type = "http://id.loc.gov/ontologies/bibframe/" + type
+      // }
+      // if (type && !type.startsWith("http")){
+      //   type = "http://www.loc.gov/mads/rdf/v1#" + type // Works and Hubs should be `BF:` not madsrdf.
+      // }
 
       // literals don't have a type or a URI & intendedAudience has extra considerations
       // namely that the rdf:Type in BF is bf:Authority


### PR DESCRIPTION
Related: #270

This has some more changes to match updates in the suggest2 service.

* Remove the ability to search `Works` in subjects, only `Hubs`
* More calls to `8080` in Production
* Cut out a final request for `context` -- no longer needed because the Hubs should have their `marcKeys`
* Replace dereferencing call to `...nt` to `...madsrdf_raw.json` -- this call only cares about the header information, and doing an `nt` call creates MADS > NTriples > Header
* Add display for `relateds` to context information

I tried to use `8080` with the simple lookups, but the language lookup would timeout.