### PR TITLE
Update returnComplexLookupValueFromProfile for Hubs as Subject to ren…

### DIFF
--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -91,7 +91,8 @@
           <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false">
             <div class="lookup-fake-input-entities" v-if="marcDeliminatedLCSHMode == false">
 
-
+              
+              
               <div v-for="(avl,idx) in complexLookupValues" :class="['selected-value-container']">
 
                 <div class="selected-value-container-auth">

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 24,
+    versionPatch: 25,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2233,18 +2233,39 @@ export const useProfileStore = defineStore('profile', {
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.loc.gov/mads/rdf/v1#Geographic')  })
 
 
-      // console.log("propertyPath=",propertyPath)
 
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
       let valueLocation = utilsProfile.returnValueFromPropertyPath(pt,propertyPath)
       let deepestLevelURI = propertyPath[propertyPath.length-1].propertyURI
+      // console.log(pt.propertyURI)
+      // console.log("propertyPath=",propertyPath)
+
+      // working with Hubs as subjects breaks a few things.
+      // rewrite the property Path if we are working with them
+      if (pt.propertyURI == 'http://id.loc.gov/ontologies/bibframe/subject'){
+
+        if (pt.userValue && 
+            pt.userValue['http://id.loc.gov/ontologies/bibframe/subject'] && 
+            pt.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0] && 
+            pt.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@type'] &&
+            (pt.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@type'] == "http://id.loc.gov/ontologies/bibframe/Hub" || pt.userValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@type'] == "http://id.loc.gov/ontologies/bibframe/Work")
+        )
+          
+        
+        //  it is a subject remove label properties
+        propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=="http://www.loc.gov/mads/rdf/v1#authoritativeLabel")  })
+        valueLocation = utilsProfile.returnValueFromPropertyPath(pt,propertyPath)
+
+        // console.log("NEW propertyPath=",propertyPath)
+
+      }     
 
       if (valueLocation){
 
         let values = []
 
         for (let v of valueLocation){
-
+              console.log("v",v)
               let URI = null
               let label = null
 


### PR DESCRIPTION
returnComplexLookupValueFromProfile was not locating the subject property path correctly when Hubs were used due to how the profile nests authlabel under subject. 