### PR TITLE
Bfp 358 non latin agent fixes

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -259,15 +259,26 @@
             }
           })
 
-        // wrapping this in setTimeout might not be needed anymore
+          // wrapping this in setTimeout might not be needed anymore
         if (searchPayload.type == 'complex'){
           this.searchTimeout = window.setTimeout(async ()=>{
             this.activeComplexSearchInProgress = true
             this.activeComplexSearch = []
             this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
+
+            // 2025-03 // there is currently an issue with ID suggest2/ that if you search with SOME diacritics it will fail
+            // so there is now a flag that enables it searching it. So if they get NO results at all then try again with the flag
+            // There will always be 1 result which is the literal
+            
+            if (this.activeComplexSearch.length == 1 && this.activeComplexSearch[0].literal){
+              // modify the payload to include the flag in the url
+              searchPayload.url[0] = searchPayload.url[0] + '&keepdiacritics=true'
+              this.activeComplexSearch = await utilsNetwork.searchComplex(searchPayload)
+            }
+
             this.activeComplexSearchInProgress = false
             this.initalSearchState =false
-          }, 400)
+          }, 100)
         } else {
           let filter = function(obj, target){
             let result = []

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1202,6 +1202,7 @@
     width: 100%;
     margin: 3px;
     font-size: 1.5em;
+    font-family: Avenir, Helvetica, Arial, sans-serif;
   }
 
   .toggle-btn-grp div:focus{

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 0,
     versionMinor: 18,
-    versionPatch: 29,
+    versionPatch: 33,
 
     regionUrls: {
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2456,6 +2456,7 @@ export const useProfileStore = defineStore('profile', {
           }
 
           for (let aLabelNode of label){
+            console.log("aLabelNode",aLabelNode)
             if (!blankNode['http://www.w3.org/2000/01/rdf-schema#label']){
               blankNode['http://www.w3.org/2000/01/rdf-schema#label'] = []
             }
@@ -2480,7 +2481,7 @@ export const useProfileStore = defineStore('profile', {
               console.error("Cannot understand response from context extaction for label:",label)
             }
           }
-
+          console.log("nodeMap",nodeMap)
           //Add gacs code to user data
           if (nodeMap["gacs"]){
             blankNode["http://www.loc.gov/mads/rdf/v1#code"] = []
@@ -2500,6 +2501,9 @@ export const useProfileStore = defineStore('profile', {
           }
 
           for (let aMarcKeyNode of marcKey){
+
+            console.log("aMarcKeyNode",aMarcKeyNode)
+
             if (!blankNode['http://id.loc.gov/ontologies/bflc/marcKey']){
               blankNode['http://id.loc.gov/ontologies/bflc/marcKey'] = []
             }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2456,7 +2456,7 @@ export const useProfileStore = defineStore('profile', {
           }
 
           for (let aLabelNode of label){
-            console.log("aLabelNode",aLabelNode)
+
             if (!blankNode['http://www.w3.org/2000/01/rdf-schema#label']){
               blankNode['http://www.w3.org/2000/01/rdf-schema#label'] = []
             }
@@ -2481,7 +2481,41 @@ export const useProfileStore = defineStore('profile', {
               console.error("Cannot understand response from context extaction for label:",label)
             }
           }
-          console.log("nodeMap",nodeMap)
+
+          // add in the venacular labels
+          if (nodeMap && nodeMap.vernacularLabels){
+            for (let l of nodeMap.vernacularLabels){
+              // make sure there really is a non-latin label
+              if (l.indexOf("@") == -1){
+                continue
+              }
+              // the api returns it as "label@language"
+              let lLabel = l.split("@")[0]
+              let lLanguage = l.split("@")[1]
+              // make sure there is a label field for it
+              if (!blankNode['http://www.w3.org/2000/01/rdf-schema#label']){
+                blankNode['http://www.w3.org/2000/01/rdf-schema#label'] = []
+              }
+
+              blankNode['http://www.w3.org/2000/01/rdf-schema#label'].push(
+                {
+                  '@guid': short.generate(),
+                  'http://www.w3.org/2000/01/rdf-schema#label' : lLabel,
+                  '@language': lLanguage
+                }
+              )
+            }
+          }
+
+
+
+
+          // if (URI.indexOf('n2010057779') > -1){
+          //   nodeMap.vernacularMarcKeys = ["4001 $a玄 武岩,$d1969-@zxx-Hani","4001 $a현 무암,$d1969-@zxx-Hang"]
+          // }
+
+          // console.log("nodeMap",nodeMap)
+
           //Add gacs code to user data
           if (nodeMap["gacs"]){
             blankNode["http://www.loc.gov/mads/rdf/v1#code"] = []
@@ -2502,7 +2536,7 @@ export const useProfileStore = defineStore('profile', {
 
           for (let aMarcKeyNode of marcKey){
 
-            console.log("aMarcKeyNode",aMarcKeyNode)
+            // console.log("aMarcKeyNode",aMarcKeyNode)
 
             if (!blankNode['http://id.loc.gov/ontologies/bflc/marcKey']){
               blankNode['http://id.loc.gov/ontologies/bflc/marcKey'] = []
@@ -2539,6 +2573,35 @@ export const useProfileStore = defineStore('profile', {
               console.error("Cannot understand response from context extaction for marcKey:",marcKey)
             }
           }
+
+
+          // add in the venacular marckeys
+          if (nodeMap && nodeMap.vernacularMarcKeys){
+            for (let l of nodeMap.vernacularMarcKeys){
+              // make sure there really is a non-latin label
+              if (l.indexOf("@") == -1){
+                continue
+              }
+              // the api returns it as "label@language"
+              let lLabel = l.split("@")[0]
+              let lLanguage = l.split("@")[1]
+              // make sure there is a label field for it
+              if (!blankNode['http://id.loc.gov/ontologies/bflc/marcKey']){
+                blankNode['http://id.loc.gov/ontologies/bflc/marcKey'] = []
+              }
+
+              blankNode['http://id.loc.gov/ontologies/bflc/marcKey'].push(
+                {
+                  '@guid': short.generate(),
+                  'http://id.loc.gov/ontologies/bflc/marcKey' : lLabel,
+                  '@language': lLanguage
+                }
+              )
+            }
+          }
+
+
+
 
 
           // if (nodeMap["marcKey"]){


### PR DESCRIPTION
`vernacularLabels` and `vernacularMarcKeys` have been added to the suggest2/ "more" responses so that 880s can be corrected generated when before that info came from the madsrdf_raw requests.

Set the font-family in the complex lookup modal so that it can display uncommon diacritics

On no hits from a search it will try again immediately with keepdiacritics=true added to the suggest2/ url due to suggest2/ diacritic search limitations.

