### PR TITLE
Adjustments for Hub Subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2025-04-01
+### Fixed
+- Hub subjects not being `bf:Hub`
+- Hub subjects not appearing in Marva
 
 
 ## [1.1.0] - 2025-03-31
@@ -14,11 +18,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Adds more detail display for Entities when searching (Hubs, names, etc.)
 - Added Variant title option to Hub creation modal with Scriptshifter support [BFP-347]
-- Simple lookups have the code "Author (aut)" removed from the label when selected 
+- Simple lookups have the code "Author (aut)" removed from the label when selected
 - Simple lookups have been limited to Eng lang
 
 ### Fixed
-- Improved building of Hubs 
+- Improved building of Hubs
 - Improved subject heading building
 - Improved suggest2/ API integration
 - Fix not being able to add literals to complex lookups

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -431,6 +431,7 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
+      console.info("setComplexValue")
       if (contextValue.literal){
         this.profileStore.setValueComplex(
             this.guid,
@@ -647,6 +648,7 @@ export default {
 
 
     subjectAdded: function(components){
+      console.info("subjectAdded: ", components)
       this.profileStore.setValueSubject(this.guid,components,this.propertyPath)
       this.hideSubjectModal()
 

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -284,7 +284,6 @@ export default {
 
 
     complexLookupValues(){
-
       try{
           let values = this.profileStore.returnComplexLookupValueFromProfile(this.guid,this.propertyPath)
           return values
@@ -431,7 +430,6 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-      console.info("setComplexValue")
       if (contextValue.literal){
         this.profileStore.setValueComplex(
             this.guid,
@@ -648,7 +646,6 @@ export default {
 
 
     subjectAdded: function(components){
-      console.info("subjectAdded: ", components)
       this.profileStore.setValueSubject(this.guid,components,this.propertyPath)
       this.hideSubjectModal()
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -129,6 +129,9 @@ export default {
                 if (val['@type'] && this.rtLookup[tmpid].resourceURI === val['@type']){
                   useId = tmpid
                   foundBetter = true
+                  if (tmpid == 'lc:RT:bf2:Topic:SubjectWork' && key == 'http://www.loc.gov/mads/rdf/v1#componentList'){ // a hub with subdivisions should be `lc:RT:bf2:Components`
+                    useId = 'lc:RT:bf2:Components'
+                  }
                 }
               }
             }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -971,7 +971,6 @@ methods: {
    * @param {obj} incomingSubjects - the existing subject data
    */
   buildLookupComponents: function(incomingSubjects){
-    console.info("buildLookupComponents: ", incomingSubjects)
     this.typeLookup = {}
 
     if (!incomingSubjects || typeof incomingSubjects == "undefined"){
@@ -1074,7 +1073,6 @@ methods: {
    * but there won't be components.
    */
   buildComponents: function(searchString){
-    console.info("buildComponents: ", searchString, "--", this.componetLookup)
     // searchString = searchString.replace("—", "--") // when copying a heading from class web
 
     let subjectStringSplit = searchString.split('--')
@@ -1165,9 +1163,6 @@ methods: {
       if (this.typeLookup[id+offset]){
         type = this.typeLookup[id+offset]
       }
-
-      console.info("this.typeLookup: ", this.typeLookup)
-      console.info("type: ", type)
 
       if (uri && uri.includes("/hubs/")){
         type = "bf:Hub"
@@ -2009,8 +2004,6 @@ methods: {
       //Science—Experiments
     }
 
-    console.info("selectContext: ", this.pickLookup[this.pickPostion])
-
     if (this.pickLookup[this.pickPostion].complex){
       // if it is a complex authorized heading then just replace the whole things with it
       this.subjectString = this.pickLookup[this.pickPostion].label
@@ -2657,7 +2650,6 @@ methods: {
   },
 
   add: async function(){
-    console.info("Components: ", JSON.parse(JSON.stringify(this.components)))
     //remove any existing thesaurus label, so it has the most current
     //this.profileStore.removeValueSimple(componentGuid, fieldGuid)
 
@@ -2836,9 +2828,6 @@ methods: {
     if (newComponents.length > 0){
       this.components = newComponents
     }
-    //TODO: hubs, should be type <bf:Hub>, hubs are not populating the subject component correctly
-    // record:  2025422115, https://editor.id.loc.gov/bfe2/quartz/edit/e1519219
-    console.info("Final Components: ", JSON.parse(JSON.stringify(this.components)))
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -971,6 +971,7 @@ methods: {
    * @param {obj} incomingSubjects - the existing subject data
    */
   buildLookupComponents: function(incomingSubjects){
+    console.info("buildLookupComponents: ", incomingSubjects)
     this.typeLookup = {}
 
     if (!incomingSubjects || typeof incomingSubjects == "undefined"){
@@ -1073,6 +1074,7 @@ methods: {
    * but there won't be components.
    */
   buildComponents: function(searchString){
+    console.info("buildComponents: ", searchString, "--", this.componetLookup)
     // searchString = searchString.replace("—", "--") // when copying a heading from class web
 
     let subjectStringSplit = searchString.split('--')
@@ -1162,6 +1164,13 @@ methods: {
 
       if (this.typeLookup[id+offset]){
         type = this.typeLookup[id+offset]
+      }
+
+      console.info("this.typeLookup: ", this.typeLookup)
+      console.info("type: ", type)
+
+      if (uri && uri.includes("/hubs/")){
+        type = "bf:Hub"
       }
 
       this.components.push({
@@ -2000,6 +2009,8 @@ methods: {
       //Science—Experiments
     }
 
+    console.info("selectContext: ", this.pickLookup[this.pickPostion])
+
     if (this.pickLookup[this.pickPostion].complex){
       // if it is a complex authorized heading then just replace the whole things with it
       this.subjectString = this.pickLookup[this.pickPostion].label
@@ -2646,6 +2657,7 @@ methods: {
   },
 
   add: async function(){
+    console.info("Components: ", JSON.parse(JSON.stringify(this.components)))
     //remove any existing thesaurus label, so it has the most current
     //this.profileStore.removeValueSimple(componentGuid, fieldGuid)
 
@@ -2824,7 +2836,9 @@ methods: {
     if (newComponents.length > 0){
       this.components = newComponents
     }
-
+    //TODO: hubs, should be type <bf:Hub>, hubs are not populating the subject component correctly
+    // record:  2025422115, https://editor.id.loc.gov/bfe2/quartz/edit/e1519219
+    console.info("Final Components: ", JSON.parse(JSON.stringify(this.components)))
     this.$emit('subjectAdded', this.components)
   },
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1367,7 +1367,7 @@ const utilsExport = {
 			for (let item of items){
 				let uri = null
 				if (item.attributes['rdf:resource']){
-					uri = item.attributes['rdf:resource'].value
+					uri = item.attributes['rdf:resource'].valfue
 				}else if(item.attributes['rdf:about']){
 					uri = item.attributes['rdf:about'].value
 				}
@@ -1672,8 +1672,8 @@ const utilsExport = {
 	let bf2MarcInstances = rdfBasic.getElementsByTagName("bf:Instance")
 	for (let x = 0; x < bf2MarcInstances.length; x++){
 		if (bf2MarcInstances[x].parentNode && bf2MarcInstances[x].parentNode.tagName && bf2MarcInstances[x].parentNode.tagName.toLowerCase() == 'rdf'){
-			bf2MarcXmlElRdf.appendChild(bf2MarcInstances[x].cloneNode(true))	
-		}	
+			bf2MarcXmlElRdf.appendChild(bf2MarcInstances[x].cloneNode(true))
+		}
 	}
 	let bf2MarcItems = rdfBasic.getElementsByTagName("bf:Item")
 	for (let x = 0; x < bf2MarcItems.length; x++){
@@ -2237,7 +2237,7 @@ const utilsExport = {
 			field670b.innerHTML = mainTitleNote
 			field670.appendChild(field670b)
 		}
-		
+
 
 		let field670u = document.createElementNS(marcNamespace,"marcxml:subfield");
 		field670u.setAttribute( 'code', 'u')

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 1,
-    versionPatch: 0,
+    versionPatch: 1,
 
 
     regionUrls: {
@@ -332,7 +332,7 @@ export const useConfigStore = defineStore('config', {
     {lccn:'2026888777',label:"Secondary Instance Test", idUrl:'https://id.loc.gov/resources/instances/2026888777.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
 
-    
+
 
   ],
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2271,7 +2271,7 @@ export const useProfileStore = defineStore('profile', {
 
         let values = []
 
-        for (let v of valueLocation){              
+        for (let v of valueLocation){
               let URI = null
               let label = null
 
@@ -2665,6 +2665,10 @@ export const useProfileStore = defineStore('profile', {
     * @return {void} -
     */
     setValueSubject: async function(componentGuid,subjectComponents,propertyPath){
+      console.info("setValueSubject")
+      console.info("componentGuid: ", componentGuid)
+      console.info("subjectComponents: ", subjectComponents)
+      console.info("propertyPath: ", propertyPath)
         // we're just going to overwrite the whole userValue with the constructed headings
         let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2665,10 +2665,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void} -
     */
     setValueSubject: async function(componentGuid,subjectComponents,propertyPath){
-      console.info("setValueSubject")
-      console.info("componentGuid: ", componentGuid)
-      console.info("subjectComponents: ", subjectComponents)
-      console.info("propertyPath: ", propertyPath)
         // we're just going to overwrite the whole userValue with the constructed headings
         let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
 
@@ -5363,7 +5359,6 @@ export const useProfileStore = defineStore('profile', {
       // if no empty ddc, create one
       if (!hasEmptyDDC){
         newDDC = await this.duplicateComponentGetId(this.returnStructureByComponentGuid(guid)['@guid'], structure, "lc:RT:bf2:Monograph:Work", lastClassifiction)
-        console.info("newDDC: ", newDDC)
         ddcComponent = activeProfile.rt["lc:RT:bf2:Monograph:Work"].pt[newDDC[0]]
       }
 


### PR DESCRIPTION
Some adjustments for Hub subjects. They were getting the wrong type which caused issues with the Marc preview and sometimes they could be missing from Marva though they would appear in the XML and Marc previews.

Fixes: 
* Complex hub subjects not appearing in Marva
* Hub subject type should always be `bf:Hub`
