### PR TITLE
Split CYAC Subdivisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Hub subjects not being `bf:Hub`
 - Hub subjects not appearing in Marva
+- CYAC headings not splitting up
 
 
 ## [1.1.0] - 2025-03-31

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2682,9 +2682,10 @@ methods: {
       componentTypes = false
     }
 
+    let complexSubjects = this.searchResults["subjectsComplex"].concat(this.searchResults["subjectsChildrenComplex"])
 
-    for (let el in this.searchResults["subjectsComplex"]){
-      let target = this.searchResults["subjectsComplex"][el]
+    for (let el in complexSubjects){
+      let target = complexSubjects[el]
       if (target.label.replaceAll("‑", "-") == componentCheck && target.depreciated == false){
         // we need to check the types of each element to make sure they really are the same terms
         // let targetContext = await utilsNetwork.returnContext(target.uri)
@@ -2729,7 +2730,7 @@ methods: {
         for (let component in frozenComponents){
           // if (this.components[component].complex && !['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(this.components[component].type)){
           const target = frozenComponents[component]
-          if (frozenComponents.length > 1 && !(['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(target.type) || (target.uri && target.uri.includes("childrensSubjects/sj"))) && target.complex){
+          if (frozenComponents.length > 1 && !(['madsrdf:Geographic', 'madsrdf:HierarchicalGeographic'].includes(target.type) ) && target.complex){
             let uri = target.uri
             let data = false //await this.parseComplexSubject(uri)  //This can take a while, and is only need for the URI, but lots of things don't have URIs
             if (uri){
@@ -2800,6 +2801,12 @@ methods: {
               }
               let marcKey = tag + "  " + sub + labels[idx]
 
+              let uriId = id
+
+              if (target.uri.includes("childrensSubjects/sj") && target.id > 0){
+                uriId = uriId - frozenComponents.filter((c) => !c.complex).length
+              }
+
               newComponents.splice(id, 0, ({
               "complex": false,
               "id": id,
@@ -2808,7 +2815,7 @@ methods: {
               "posEnd": labels[idx].length,
               "posStart": 0,
               "type": subfield,
-              "uri": data && data["components"] && data["components"][0]["@list"][id]["@id"].startsWith("http") ? data["components"][0]["@list"][id]["@id"] : "",
+              "uri": data && data["components"] && data["components"][0]["@list"][uriId]["@id"].startsWith("http") ? data["components"][0]["@list"][uriId]["@id"] : "",
               "marcKey": marcKey,
               "fromComplex": true,
               "complexMarcKey": target.marcKey

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -26,6 +26,7 @@ const utilsNetwork = {
       "controllerNamesSubdivision": new AbortController(),
       "controllerSubjectsSimple": new AbortController(),
       "controllerPayloadSubjectsSimpleSubdivision": new AbortController(),
+      "controllerSubjectsComplexPart": new AbortController(),
       "controllerSubjectsComplex": new AbortController(),
       "controllerHierarchicalGeographic": new AbortController(),
       "controllerWorksAnchored": new AbortController(),
@@ -2520,6 +2521,7 @@ const utilsNetwork = {
       let resultsSubjectsSimple=[]
       let resultsPayloadSubjectsSimpleSubdivision=[]
       let resultsSubjectsComplex=[]
+      let resultsSubjectsComplexPart=[]
       let resultsHierarchicalGeographic=[]
       let resultsWorksAnchored=[]
       let resultsWorksKeyword=[]

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4813,7 +4813,6 @@ export const useProfileStore = defineStore('profile', {
             firstHasURI=true
           }
 
-
           if (allHasURI){return ['done_all','Linked']}
           if (firstHasURI){return ['warning','Partially Linked']}
 


### PR DESCRIPTION
Fix: CYAC headings not splitting up

This resulted in 6XX fields in the Marc preview with `--` in them. 

![image](https://github.com/user-attachments/assets/dcae72bd-65ea-4217-a40d-28cf0fb81415)