### PR TITLE
add infi scroll and other shelflisting improvements

### DIFF
--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -2,7 +2,10 @@
   // import { usePreferenceStore } from '@/stores/preference'
   import { useProfileStore } from '@/stores/profile'
   import { useConfigStore } from '@/stores/config'
+  import { usePreferenceStore } from '@/stores/preference'
 
+
+  
   import { mapStores, mapState, mapWritableState } from 'pinia'
   import { VueFinalModal } from 'vue-final-modal'
   import VueDragResize from 'vue3-drag-resize'
@@ -25,15 +28,17 @@
         height: 0,
         top: 100,
         left: 0,
+        
 
         initalHeight: 550,
-        initalLeft: 100,
-
+        initalLeft: 50,
+        initalWidth:950,
+        initalTop:10,
         searching: false,
 
         classNumber: null,
         cutterNumber:null,
-        displaySubjects: false,
+        displaySubjects: true,
         contributor:null,
         title:null,
         subj:null,
@@ -42,6 +47,14 @@
 
         hitCount: 10,
         results: [],
+
+        loadingMore: false,
+        loadingMoreDescending: false,
+
+
+        searchDebounce: null,
+
+        oldInterface: false,
 
         idbase: useConfigStore().returnUrls.id
 
@@ -55,7 +68,10 @@
       // ...mapStores(usePreferenceStore),
       ...mapStores(useConfigStore),
       ...mapStores(useProfileStore),
+      ...mapStores(usePreferenceStore),
 
+
+      
 
 
       // ...mapWritableState(usePreferenceStore, ['literalLangGuid']),
@@ -89,7 +105,13 @@
           this.top = newRect.top
           this.left = newRect.left
 
+          // this.initalHeight = newRect.height
+          // this.initalLeft = newRect.left
+
           this.$refs.shelfListingContent.style.height = newRect.height + 'px'
+          this.$refs.shelfListingDisplay.style.height = newRect.height - 44 + 'px'
+
+          
 
         },
 
@@ -106,6 +128,87 @@
           }
         },
 
+        async search(){
+
+
+
+          window.clearTimeout(this.searchDebounce)
+          this.searchDebounce = window.setTimeout(async () =>{
+            this.searching=true
+            this.results = []            
+            if (!this.classNumber){this.classNumber=''}
+            if (!this.cutterNumber){this.cutterNumber=''}
+
+            let contributor = this.contributor ? "&sp-name="+this.contributor : ""
+            let title = this.title ? "&sp-title="+this.title  : ""
+            let subj = this.subj ? "&sp-subject="+this.subj  : ""
+            let date = this.date ? "&sp-date="+this.date : ""
+            let countParam = "&count=201"
+           
+            
+            let initalResult =  await utilsNetwork.searchShelfList(
+              this.classNumber.trim() + '' + this.cutterNumber.trim(),
+              contributor + title + subj + date + countParam
+            )
+            let initalFirstClass = initalResult[0].term
+            let initalLastClass = initalResult[initalResult.length-1].term
+
+            let initalIds = initalResult.map((v) => {return v.bibid})
+
+            
+            // PS3603.R
+            // browse-order=ascending&browse=class&count=200&mime=json
+            const initalFirstClassPromise = utilsNetwork.searchShelfList(initalFirstClass, "&count=201&browse-order=descending&browse=class&mime=json")
+            const initalLastClassPromise = utilsNetwork.searchShelfList(initalLastClass, "&count=201&browse-order=ascending&browse=class&mime=json")
+
+            
+            let firstExpand = await Promise.all([initalFirstClassPromise, initalLastClassPromise]);
+            
+            // const initalFirstClassPos = firstExpand[0].map(e => e.selected).indexOf('selected');
+            // const initalLastClassPos = firstExpand[1].map(e => e.selected).indexOf('selected');
+
+            for (let toAdd of firstExpand[0].reverse()){
+              if (!toAdd.selected && initalIds.indexOf(toAdd.bibid) == -1){
+                initalResult.unshift(toAdd)
+              }
+            }
+            for (let toAdd of firstExpand[1]){
+              if (!toAdd.selected && initalIds.indexOf(toAdd.bibid) == -1){
+                initalResult.push(toAdd)
+              }
+            }
+            
+
+
+            
+            
+            this.results=initalResult
+            this.searching=false
+            // this.dragResize()
+            this.$refs.shelfListingDisplay.style.height = this.initalHeight - 44 + 'px'
+
+
+            this.$nextTick(async () => {
+              this.$refs.selected[0].scrollIntoView({ 
+                behavior: 'auto',
+                block: 'center',
+                inline: 'center'
+               });
+
+
+               // load up some more results while they start looking
+               await this.searchLoadMore()
+              //  await this.searchLoadMore()
+
+            });
+
+          },750)
+
+
+
+        },
+
+
         async save(){
 
 
@@ -119,7 +222,7 @@
             // the open button lives in the item portion of the number so we don't have the class portion, but they will always be siblings so just modify the path
             // so it matches to where the class property path is
             let classPropertyPath = JSON.parse(JSON.stringify(this.activeShelfListData.componentPropertyPath))
-            console.log(classPropertyPath)
+            
             classPropertyPath = classPropertyPath.map((v) => {
               v.propertyURI = v.propertyURI.replace("itemPortion",'classificationPortion')
               return v
@@ -145,10 +248,9 @@
         },
 
 
-        async search(){
+        async searchOld(){
           if (!this.classNumber){this.classNumber=''}
           if (!this.cutterNumber){this.cutterNumber=''}
-
 
           const contributor = this.contributor ? "&sp-name="+this.contributor : ""
           const title = this.title ? "&sp-title="+this.title  : ""
@@ -196,6 +298,90 @@
 
         },
 
+        async searchLoadMore(){
+
+          if (this.loadingMore){ return false}
+          if (!this.results){return false}
+          if (!this.results[this.results.length-1]){ return false}
+          this.loadingMore = true
+          
+          let lastTerm = this.results[this.results.length-1].term
+          let ids = this.results.map((v) => {return v.bibid})
+
+          const initalLastClassPromise = await utilsNetwork.searchShelfList(lastTerm, "&count=201&browse-order=ascending&browse=class&mime=json")
+          for (let toAdd of initalLastClassPromise){
+              if (!toAdd.selected && ids.indexOf(toAdd.bibid) == -1){
+                this.results.push(toAdd)
+              }
+            }
+
+          this.loadingMore = false
+
+        },  
+        async searchLoadMoreDescending(){
+
+        if (this.loadingMore){ return false}
+        if (!this.results){return false}
+        if (!this.results[0]){ return false}
+        this.loadingMore = true
+
+        let firstTerm = this.results[0].term
+        let ids = this.results.map((v) => {return v.bibid})
+
+        const initalFirstClassPromise = await utilsNetwork.searchShelfList(firstTerm, "&count=201&browse-order=descending&browse=class&mime=json")
+
+
+        for (let toAdd of initalFirstClassPromise.reverse()){
+            if (!toAdd.selected && ids.indexOf(toAdd.bibid) == -1){
+              this.results.unshift(toAdd)
+            }
+          }
+
+
+        this.loadingMore = false
+
+        },  
+
+        async watchScroll(event){
+
+          let element = event.target
+
+          let percentScrolled = (element.scrollTop + element.offsetHeight) / element.scrollHeight
+          
+
+          if (percentScrolled>=0.8){
+            this.searchLoadMore()
+
+          }else if (element.scrollTop <= 1){
+
+            if (this.loadingMoreDescending){return false}
+
+            let firstBibid = JSON.parse(JSON.stringify(this.results[0].bibid))
+
+            this.loadingMoreDescending=true
+            await this.searchLoadMoreDescending()
+
+            let el = document.querySelector(`[data-bibid="${firstBibid}"]`)
+
+            el.scrollIntoView({ 
+              behavior: 'smooth',
+              block: 'center',
+              inline: 'center'
+            });
+            el.style.transitionDuration = '5s';
+            el.style.backgroundColor = 'cornflowerblue';
+            window.setTimeout(()=>{
+              el.style.removeProperty('background-color')
+            },5000)
+            
+            
+
+            this.loadingMoreDescending=false
+            // element.scrollTop = 100
+          }
+
+        }
+
 
 
 
@@ -203,10 +389,16 @@
 
     async created(){
 
-
+      // this.width=50
+      this.initalWidth=window.innerWidth/1.25
     },
 
-    async mounted() {
+    async mounted() {      
+      // If they launched the shefllist from the tools menu then it does not have the 
+      // context of launching from the component, so fake it via the profile
+      if (Object.keys(this.activeShelfListData)==0){
+        this.profileStore.buildActiveShelfListDataFromProfile()
+      }
       this.classNumber = this.activeShelfListData.class
       this.cutterNumber = this.activeShelfListData.cutter
       this.contributor = this.activeShelfListData.contributor
@@ -229,53 +421,52 @@
 
     <VueFinalModal
       display-directive="show"
-      :hide-overlay="true"
+      :hide-overlay="false"
       :overlay-transition="'vfm-fade'"
 
 
     >
         <VueDragResize
           :is-active="true"
-          :w="950"
+          :w="initalWidth"
           :h="initalHeight"
           :x="initalLeft"
+          :y="initalTop"
           class="shelf-listing-modal"
           @resizing="dragResize"
           @dragging="dragResize"
           :sticks="['br']"
           :stickSize="22"
         >
-          <div id="shelf-listing-content" ref="shelfListingContent" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
+          <div id="shelf-listing-content" ref="shelfListingContent" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)" :style="`${this.preferenceStore.styleModalBackgroundColor()} ${this.preferenceStore.styleModalTextColor()}`">
+
+              <div class="shelflist-menu">
+                <input v-model="classNumber" class="number-input" placeholder="Class" @input="search()" type="text" />
+                <input v-model="cutterNumber" class="number-input" @input="search()" placeholder="Cutter" type="text" />
+                <button class="number-input" @click="save" :disabled="(!activeShelfListData.componentGuid)">Save</button>
+
+                <div class="menu-buttons">
+                  <button class="close-button"   @pointerup="showShelfListingModal=false">X</button>
+                </div>
 
 
-            <div class="menu-buttons">
-              <button class="close-button"   @pointerup="showShelfListingModal=false">X</button>
-            </div>
 
-            <div class="shelf-listing-work-area">
-              <input v-model="classNumber" class="number-input" placeholder="Class" @keyup="hitCount=10; search()" type="text" />
-              <input v-model="cutterNumber" class="number-input" @keyup="hitCount=10; search()" placeholder="Cutter" type="text" />
-              <button class="number-input" @click="save" :disabled="(!activeShelfListData.componentGuid)">Save</button>
-
-              <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-              <input type="checkbox" id="showSubjects" v-model="displaySubjects" v-on:change="search" />
-              <label for="showSubjects">&nbsp;Show Subjects</label>
-
-              <div class="serach-results-container">
-                <h2 v-if="searching == true"><span class="material-icons icon">search</span>Searching...</h2>
-
+              </div>
+              <div id="listing-display" ref="shelfListingDisplay" @scroll="watchScroll">
+                
+                <div class="loader" v-if="searching"></div>
                 <h3 v-if="searching==false && results.length==0">No Results</h3>
 
                 <table v-if="searching==false">
-                  <thead v-if="results.length>0">
+                  <thead v-if="results.length>0" :style="`${this.preferenceStore.styleModalTextColor()} ${this.preferenceStore.styleModalBackgroundColor()}`">
                     <tr>
-                      <td>Number</td>
-                      <td>Main Author, Creator, etc.</td>
-                      <td>Uniform Title</td>
-                      <td>Title</td>
-                      <td v-if="displaySubjects">Subject</td>
-                      <td>Date</td>
-                      <td> </td>
+                      <th :style="`${this.preferenceStore.styleModalBackgroundColor()}`">Number</th>
+                      <th :style="`${this.preferenceStore.styleModalBackgroundColor()}`">Main Author, Creator, etc.</th>
+                      <th :style="`${this.preferenceStore.styleModalBackgroundColor()}`">Uniform Title</th>
+                      <th :style="`${this.preferenceStore.styleModalBackgroundColor()}`">Title</th>
+                      <th v-if="displaySubjects" :style="`${this.preferenceStore.styleModalBackgroundColor()}`">Subject</th>
+                      <th :style="`${this.preferenceStore.styleModalBackgroundColor()}`">Date</th>
+                      <th :style="`${this.preferenceStore.styleModalBackgroundColor()}`"> </th>
 
                     </tr>
                   </thead>
@@ -283,7 +474,7 @@
 
                     <template v-for="r in results">
                       <template  v-if="r.selected == undefined">
-                        <tr :class="[{nuba: r.notused == 'nuba'}]">
+                        <tr :class="[{nuba: r.notused == 'nuba'}]" :data-bibid="r.bibid">
                           <td>{{ r.term }}</td>
                           <td>{{ r.creator }}</td>
                           <td>{{ r.uniformtitle }}</td>
@@ -295,7 +486,7 @@
                       </template>
 
                       <template  v-if="r.selected != undefined && r.selected.trim() == 'selected'">
-                        <tr style="background-color: yellow;">
+                        <tr style="background-color: yellow;" ref="selected" :data-bibid="r.bibid">
                           <td>{{ r.term }}</td>
                           <td>{{ r.creator }}</td>
                           <td>{{ r.uniformtitle }}</td>
@@ -308,10 +499,13 @@
                     </template>
                   </tbody>
                 </table>
-                <button v-if="searching==false && results.length > 0" class="number-input" ref="moreButton" @click="hitCount += 20; search()">Next 20</button>
+
+
+
+
               </div>
 
-            </div>
+
 
           </div>
 
@@ -329,6 +523,30 @@
 </style>
 
 <style scoped>
+
+  table{
+    width: 100%;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    background-color: white;
+    z-index: 100;
+    border-bottom: solid 1px whitesmoke;
+    
+  }
+
+  #listing-display{
+    overflow-y: scroll !important;
+  }
+  .shelflist-menu{
+    padding: 0.5em;
+    width: 100%;
+    height: 43px;
+    position: relative;
+
+  }
 
   .serach-results-container{
     margin-top: 1em;
@@ -374,15 +592,17 @@
   }
   tr:hover{
     background-color: aliceblue;
+    color:black
   }
   td{
     border-bottom: solid 1px whitesmoke;
+    /* font-family: Avenir, Helvetica, Arial, sans-serif; */
 
   }
   #shelf-listing-content{
-    padding: 1em;
+    padding: 0.2em;
     background-color: white;
-    overflow-y: scroll !important;
+    
   }
 
   .checkbox-option{
@@ -412,13 +632,16 @@
 
   .menu-buttons{
 
-    position: relative;
-    z-index: 100;
+    position: absolute;
+    z-index: 200;
+    right: 10px;
+    top: 12px;
+
   }
   .close-button{
     position: absolute;
-    right: 5px;
-    top: 5px;
+    right: 0px;
+    top: 0px;
     background-color: white;
     border-radius: 5px;
     border: solid 1px black;
@@ -429,6 +652,42 @@
       background-color: lightgray;
   }
 
+  .loader {
+  width: 100px;
+  height: 100px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+  margin-top: 10%;
+}
+.loader::after,
+.loader::before {
+  content: '';  
+  box-sizing: border-box;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background: #99a4f0;
+  position: absolute;
+  left: 0;
+  top: 0;
+  animation: animloader 2s linear infinite;
+}
+.loader::after {
+  animation-delay: 0s;
+}
 
-
+@keyframes animloader {
+  0% {
+    transform: scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+    
+  
 </style>

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5847,10 +5847,73 @@ export const useProfileStore = defineStore('profile', {
 
 
 
-    }
+    },
+
+    /**
+     * Extracts Library of Congress Classification (LCC) data from the active profile and updates the activeShelfListData state
+     * 
+     * This function:
+     * 1. Searches through all resource templates (rt) and property templates (pt) in the active profile
+     * 2. Looks for classification properties of type ClassificationLcc
+     * 3. Extracts the classification portion (class number) and item portion (cutter number)
+     * 4. Updates the activeShelfListData state with:
+     *    - class: The LCC class number
+     *    - classGuid: GUID for the class number component
+     *    - cutter: The cutter number
+     *    - cutterGuid: GUID for the cutter number component
+     *    - componentGuid: GUID of the parent classification component
+     *    - componentPropertyPath: Path to locate the item portion property
+     *
+     * Used by the shelf listing functionality to locate and modify LCC numbers.
+     * 
+     * 
+     * @return {void} Updates the activeShelfListData state directly
+     */
+    buildActiveShelfListDataFromProfile(){
+
+      // look through the active profile for the LCC data
+      for (let rt in this.activeProfile.rt){
+        for (let pt in this.activeProfile.rt[rt].pt){
+          pt = this.activeProfile.rt[rt].pt[pt]
+          if (pt.propertyURI == "http://id.loc.gov/ontologies/bibframe/classification"){
+            if (pt.userValue &&
+                pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'] && 
+                pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0] &&
+                pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]['@type'] &&
+                pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]['@type'] == "http://id.loc.gov/ontologies/bibframe/ClassificationLcc"){
+
+                  let classObj = pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]
+
+                  if (
+                    classObj['http://id.loc.gov/ontologies/bibframe/classificationPortion'] &&
+                    classObj['http://id.loc.gov/ontologies/bibframe/classificationPortion'][0] &&
+                    classObj['http://id.loc.gov/ontologies/bibframe/classificationPortion'][0]['http://id.loc.gov/ontologies/bibframe/classificationPortion']
+                  ){
+                    this.activeShelfListData.class = classObj['http://id.loc.gov/ontologies/bibframe/classificationPortion'][0]['http://id.loc.gov/ontologies/bibframe/classificationPortion']
+                    this.activeShelfListData.classGuid = classObj['http://id.loc.gov/ontologies/bibframe/classificationPortion'][0]['@guid']
+                  }
+                  if (
+                    classObj['http://id.loc.gov/ontologies/bibframe/itemPortion'] &&
+                    classObj['http://id.loc.gov/ontologies/bibframe/itemPortion'][0] &&
+                    classObj['http://id.loc.gov/ontologies/bibframe/itemPortion'][0]['http://id.loc.gov/ontologies/bibframe/itemPortion']
+                  ){
+                    this.activeShelfListData.cutter = classObj['http://id.loc.gov/ontologies/bibframe/itemPortion'][0]['http://id.loc.gov/ontologies/bibframe/itemPortion']
+                    this.activeShelfListData.cutterGuid = classObj['http://id.loc.gov/ontologies/bibframe/itemPortion'][0]['@guid']
+                  }
+                  
+                  this.activeShelfListData.componentGuid = pt['@guid']
+                  this.activeShelfListData.componentPropertyPath = [
+                    {level: 0, propertyURI: 'http://id.loc.gov/ontologies/bibframe/classification'},
+                    {level: 1, propertyURI: 'http://id.loc.gov/ontologies/bibframe/itemPortion'}
+                  ]
+                }              
+          }
+        }
+      }
 
 
-
+    },
+  
 
 
   },


### PR DESCRIPTION


Changes: Shelflisting behavior is now based on scroll, you are able to keep scrolling ascending or descending and the modal will fire off new API requests and parse the results into the existing list of resources. Subject headings display is on by default. You can "Save" the class/cutter into the record if you launched the Shelflist tool from the Tools menu and not the shelfist helper tools area in the editor.