### PR TITLE
[BFP-327] Custom Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2025-04-02
+### Added
+- Ability to set and save the order components appear in Marva [BFP-327]
+
+
 ## [1.1.1] - 2025-04-01
 ### Fixed
 - Hub subjects not being `bf:Hub`

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -29,7 +29,7 @@
                 </div>
           </template>
             <template v-if="((preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === false) || (preferenceStore.returnValue('--b-edit-main-splitpane-edit-switch-between-resource-button') === true && profileName == activeResourceName ) )">
-              <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
+                <div v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder"
                     :key="profileCompoent">
                   <template v-if="(!preferenceStore.returnValue('--c-general-ad-hoc') || (createLayoutMode && !layoutActive)) || (layoutActive || (preferenceStore.returnValue('--c-general-ad-hoc') && profileStore.emptyComponents[profileName] && !profileStore.emptyComponents[profileName].includes(profileCompoent) ))">
                   <template v-if="!activeProfile.rt[profileName].pt[profileCompoent].deleted && !hideAdminField(activeProfile.rt[profileName].pt[profileCompoent], profileName)">
@@ -71,6 +71,7 @@
                 <button class="instanceDeleteButton" v-if="showDeleteInstanceButton(profileName)" @click="showDeleteInstanceModal(profileName)">Delete Item</button>
             </div>
         </template>
+
 
         <template v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" :key="profileCompoent">
           <template v-if="(createLayoutMode && layoutActive) || layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && includeInLayout(activeProfile.rt[profileName].pt[profileCompoent].id, layoutActiveFilter['properties'][profileName])) ">
@@ -225,8 +226,6 @@
     },
 
     methods: {
-
-
         showErrors(guid){
 
           console.log(guid)
@@ -401,6 +400,7 @@
     mounted: function(){
         //populate when loading from a search
         this.populateTitle()
+        this.profileStore.useCustomComponentOrder()
     },
 
     updated: function(){

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -269,7 +269,7 @@
             // 2025-03 // there is currently an issue with ID suggest2/ that if you search with SOME diacritics it will fail
             // so there is now a flag that enables it searching it. So if they get NO results at all then try again with the flag
             // There will always be 1 result which is the literal
-            
+
             if (this.activeComplexSearch.length == 1 && this.activeComplexSearch[0].literal){
               // modify the payload to include the flag in the url
               searchPayload.url[0] = searchPayload.url[0] + '&keepdiacritics=true'
@@ -932,7 +932,6 @@
                 <div class="toggle-btn-grp cssonly">
                   <div v-for="opt in modalSelectOptions"><input type="radio" :value="opt.label" class="search-mode-radio" v-model="modeSelect" name="searchMode"/><label onclick="" class="toggle-btn">{{opt.label}}</label></div>
 				  </div>
-
                   <div v-if="(activeComplexSearch && activeComplexSearch[0] && ((activeComplexSearch[0].total % 25 ) > 0 || activeComplexSearch.length > 0))" class="complex-lookup-paging">
                     <span :style="`${this.preferenceStore.styleModalTextColor()}`">
                       <a href="#" title="first page" class="first" :class="{off: this.currentPage == 1}" @click="firstPage()">

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -160,9 +160,15 @@
       generateLabel: function(data){
         let label = !data.literal ? data.suggestLabel : data.label + ((data.literal) ? ' [Literal]' : '')
 
-        if (label.includes("(USE ")){
-          label = data.label + " (USE FOR " + data.suggestLabel.replace(/\(USE.*\)/mg, "") + ")"
-        }
+        // if (label.includes("(USE ")){
+        //   label = data.label + " (USE FOR " + data.suggestLabel.replace(/\(USE.*\)/mg, "") + ")"
+        // }
+        // console.info("search: ", this.searchValueLocal)
+
+        // let re = new RegExp(String.raw`(${this.searchValueLocal})`, "i")
+        // label = label.replace(re, "??")
+
+        // console.info("label: ", label)
 
         return label
       },
@@ -989,7 +995,8 @@
                       Searching...
                     </option>
                     <template v-if="!isSimpleLookup()">
-                      <option v-for="(r,idx) in activeComplexSearch.sort((a,b) => (a.label > b.label ? 1 : (a.label < b.label) ? -1 : 0))" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
+                      <!-- .sort((a,b) => (a.label > b.label ? 1 : (a.label < b.label) ? -1 : 0)) -->
+                      <option v-for="(r,idx) in activeComplexSearch" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
                         <div class="option-text">
                           {{ generateLabel(r) }}
                         </div>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -157,6 +157,15 @@
     },
 
     methods: {
+      generateLabel: function(data){
+        let label = !data.literal ? data.suggestLabel : data.label + ((data.literal) ? ' [Literal]' : '')
+
+        if (label.includes("(USE ")){
+          label = data.label + " (USE FOR " + data.suggestLabel.replace(/\(USE.*\)/mg, "") + ")"
+        }
+
+        return label
+      },
       truncate: function(string){
         let stg = string
         if (string.length > 80){
@@ -980,9 +989,9 @@
                       Searching...
                     </option>
                     <template v-if="!isSimpleLookup()">
-                      <option v-for="(r,idx) in activeComplexSearch" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
+                      <option v-for="(r,idx) in activeComplexSearch.sort((a,b) => (a.label > b.label ? 1 : (a.label < b.label) ? -1 : 0))" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
                         <div class="option-text">
-                          {{ (!r.literal ? r.suggestLabel : r.label) + ((r.literal) ? ' [Literal]' : '') }}
+                          {{ generateLabel(r) }}
                         </div>
                       </option>
                     </template>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -46,7 +46,15 @@ import { isReadonly } from 'vue';
 
 
     methods: {
-
+      saveOrder: function(){
+        this.profileStore.saveCustomComponentOrder()
+      },
+      useOrder: function(){
+        this.profileStore.useCustomComponentOrder()
+      },
+      useDefault: function(){
+        this.profileStore.useDefaultComponentOrder()
+      },
       // Whether or not a component that isn't explicitly in that layout should be included
       // this is important for adding components when a layout is open
       includeInLayout: function(checkId, targets){
@@ -344,6 +352,12 @@ import { isReadonly } from 'vue';
   <template  v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-accordion') == true">
     <AccordionList  :open-multiple-items="false">
 
+      <span style="margin-left: 15px;">
+        <span class="material-icons order-icon simptip-position-right" data-tooltip="SAVE ORDER" @click="saveOrder">reorder</span>
+        <span class="material-icons order-icon simptip-position-right" data-tooltip="USE ORDER" @click="useOrder">sync</span>
+        <span class="material-icons order-icon simptip-position-right" data-tooltip="LOAD DEFAULT" @click="useDefault">history</span>
+      </span>
+
       <template v-for="profileName in activeProfile.rtOrder" :key="profileName">
       <!-- <div v-for="profileName in activeProfile.rtOrder" class="sidebar" :key="profileName"> -->
 
@@ -374,7 +388,6 @@ import { isReadonly } from 'vue';
                     </div>
 
                   </template>
-
 
                   <ul class="sidebar-property-ul" role="list">
                           <draggable
@@ -408,7 +421,7 @@ import { isReadonly } from 'vue';
                                   </template>
                                 </li>
                               </template>
-                             </template>
+                            </template>
                           </draggable>
 
 
@@ -884,5 +897,17 @@ li.not-populated-hide:before{
   list-style: none;
 }
 
+.order-icon {
+  color: white;
+  cursor: pointer;
+  margin-right: 25%;
+}
+
+.order-icon:hover {
+  border-radius: 25%;
+  background-color: white;
+  color: black;
+  cursor: pointer;
+}
 
 </style>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -353,7 +353,7 @@ import { isReadonly } from 'vue';
     <AccordionList  :open-multiple-items="false">
 
       <span style="margin-left: 15px;">
-        <span class="material-icons order-icon simptip-position-right" data-tooltip="SAVE ORDER" @click="saveOrder">reorder</span>
+        <span class="material-icons order-icon simptip-position-right" data-tooltip="SAVE ORDER" @click="saveOrder">list_alt</span>
         <span class="material-icons order-icon simptip-position-right" data-tooltip="USE ORDER" @click="useOrder">sync</span>
         <span class="material-icons order-icon simptip-position-right" data-tooltip="LOAD DEFAULT" @click="useDefault">history</span>
       </span>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -898,15 +898,15 @@ li.not-populated-hide:before{
 }
 
 .order-icon {
-  color: white;
+  color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-font-color')") !important;
   cursor: pointer;
   margin-right: 25%;
 }
 
 .order-icon:hover {
   border-radius: 25%;
-  background-color: white;
-  color: black;
+  color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-background-color')") !important;
+  background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-font-color')") !important;
   cursor: pointer;
 }
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -468,6 +468,8 @@ const utilsNetwork = {
               url = url.replace('q=?','q=')
             }
 
+            console.info("url: ", url)
+
             let r = await this.fetchSimpleLookup(url, false, searchPayload.signal)
 
             //Config only allows 25 results, this will add something to the results

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -33,7 +33,7 @@ export const useConfigStore = defineStore('config', {
 
         id: 'https://id.loc.gov/',
         env : 'production',
-        dev: true,
+        dev: false,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
       },

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -6,8 +6,8 @@ export const useConfigStore = defineStore('config', {
   state: () => ({
 
     versionMajor: 1,
-    versionMinor: 1,
-    versionPatch: 1,
+    versionMinor: 2,
+    versionPatch: 0,
 
 
     regionUrls: {

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1260,6 +1260,13 @@ export const usePreferenceStore = defineStore('preference', {
         group: 'layouts',
       },
 
+      '--l-custom-order' : {
+        desc: '',
+        descShort: '',
+        value: {},
+        type: 'object',
+        group: 'preferenes',
+      },
 
 
     }
@@ -1558,6 +1565,15 @@ export const usePreferenceStore = defineStore('preference', {
     // turn copy mode on/off
     toggleCopyMode: function(){
         this.copyMode = !this.copyMode
+    },
+
+    saveOrder: function(newOrder){
+      this.setValue('--l-custom-order', newOrder)
+    },
+
+    loadOrder: function(){
+      let currentOrder = this.returnValue('--l-custom-order')
+      return currentOrder
     },
 
     deleteLayout: function(target){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -438,14 +438,39 @@ export const useProfileStore = defineStore('profile', {
 
   },
   actions: {
-
-
     resetLocalComponentCache(){
       cachePt = {}
       cacheGuid = {}
       dataChangedTimeout = null
     },
 
+    /** Load the default component order */
+    useDefaultComponentOrder(){
+      let profileName = this.activeProfile.id
+      let profile = this.profiles[profileName]
+      for (let rt in this.activeProfile.rt){
+        this.activeProfile.rt[rt].ptOrder = profile.rt[rt].ptOrder
+      }
+    },
+
+    /** Save the cataloger's current component order */
+    saveCustomComponentOrder(){
+      let order = {}
+
+      for (let rt in this.activeProfile.rt){
+        let ptOrder = this.activeProfile.rt[rt].ptOrder
+        order[rt] = ptOrder
+      }
+      usePreferenceStore().saveOrder(order)
+      this.useCustomComponentOrder()
+    },
+    /** Load the saved custom component order */
+    useCustomComponentOrder(){
+      let order = usePreferenceStore().loadOrder()
+        for (let profileName in order){
+          this.activeProfile.rt[profileName].ptOrder = order[profileName]
+        }
+    },
 
     /**
     * The main first process that takes the raw profiles and processes them for use

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -290,12 +290,9 @@
       startingPointsFiltered(){
         let points = []
         for (let k in this.startingPoints){
-
           if (this.startingPoints[k].work && this.startingPoints[k].instance){
             points.push(this.startingPoints[k])
           }
-
-
         }
 
         points.push( { "name": "HUB", "work": null, "instance": "lc:RT:bf2:HubBasic:Hub", "item": null },)


### PR DESCRIPTION
Add: Ability to save the order of the components.

This is managed in the `properties` panel with three options at the top:
1) Save Order
2) Load Order
3) Load Default Order

![image](https://github.com/user-attachments/assets/017edfe8-edaf-41b8-9d02-1304674be933)
