### PR TITLE
Bfp 368 multiple top level literals grouping

### DIFF
--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1771,7 +1771,13 @@ const utilsParse = {
         if (groupTopLeveLiteralsToMerge[toGroupUri].mergeUnder){
           let ptToReOrder = profile.rt[pkey].pt[groupTopLeveLiteralsToMerge[toGroupUri].mergeUnder]
           if (ptToReOrder && ptToReOrder.userValue && ptToReOrder.userValue[toGroupUri]){
-            ptToReOrder.userValue[toGroupUri] = useProfileStore().sortObjectsByLatinMatch(ptToReOrder.userValue[toGroupUri],toGroupUri )
+            
+            if (usePreferenceStore().returnValue('--b-edit-main-literal-non-latin-first')){
+              ptToReOrder.userValue[toGroupUri] = useProfileStore().sortObjectsByLatinMatch(ptToReOrder.userValue[toGroupUri],toGroupUri ).reverse()
+            }else{
+              ptToReOrder.userValue[toGroupUri] = useProfileStore().sortObjectsByLatinMatch(ptToReOrder.userValue[toGroupUri],toGroupUri )
+            }
+            
           }
         }
       }
@@ -1780,30 +1786,28 @@ const utilsParse = {
       for (let key in profile.rt[pkey].pt){
         let pt = profile.rt[pkey].pt[key]
         if (pt.userValue){
-          console.log(pt.userValue)
           let propsFirstLevel = Object.keys(pt.userValue).filter(v => { return !v.startsWith('@') })
-          console.log(propsFirstLevel)          
           for (let p1 of propsFirstLevel){
             for (let bnode of pt.userValue[p1]){
               let propsSecondLevel = Object.keys(bnode).filter(v => { return !v.startsWith('@') })
-              console.log(propsSecondLevel)
               for (let p2 of propsSecondLevel){
-                if (Array.isArray(bnode[p2])){
-                  if (bnode[p2].filter((v)=>{ return (v['@language'])}).length>0){
+                if (Array.isArray(bnode[p2]) && bnode[p2].length>1){
+                  if (bnode[p2].filter((v)=>{ return (v['@language'])}).length>0){                    
+                    // sort the array of literals so the latin one is first
+                    if (usePreferenceStore().returnValue('--b-edit-main-literal-non-latin-first')){
+                      bnode[p2] = useProfileStore().sortObjectsByLatinMatch(bnode[p2],p2).reverse()                    
+                    }else{
+                      bnode[p2] = useProfileStore().sortObjectsByLatinMatch(bnode[p2],p2)                    
+                    }
+
                     
-                    console.log(p2,"Has lang tag")
-                    break
                   }
                 }
               }              
             }
-
           }
-        }
-        
+        }      
       }
-
-
 
       let adminMedtataPrimary = null
       let adminMedtataSecondary = []

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1776,6 +1776,35 @@ const utilsParse = {
         }
       }
 
+      // we are going to go looking for literals inside bnodes that have two literals with one at least of them with a @language tag
+      for (let key in profile.rt[pkey].pt){
+        let pt = profile.rt[pkey].pt[key]
+        if (pt.userValue){
+          console.log(pt.userValue)
+          let propsFirstLevel = Object.keys(pt.userValue).filter(v => { return !v.startsWith('@') })
+          console.log(propsFirstLevel)          
+          for (let p1 of propsFirstLevel){
+            for (let bnode of pt.userValue[p1]){
+              let propsSecondLevel = Object.keys(bnode).filter(v => { return !v.startsWith('@') })
+              console.log(propsSecondLevel)
+              for (let p2 of propsSecondLevel){
+                if (Array.isArray(bnode[p2])){
+                  if (bnode[p2].filter((v)=>{ return (v['@language'])}).length>0){
+                    
+                    console.log(p2,"Has lang tag")
+                    break
+                  }
+                }
+              }              
+            }
+
+          }
+        }
+        
+      }
+
+
+
       let adminMedtataPrimary = null
       let adminMedtataSecondary = []
       for (let key in profile.rt[pkey].pt){

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -6,7 +6,6 @@ import short from 'short-uuid'
 
 import utilsRDF from './utils_rdf';
 
-
 const hashCode = s => s.split('').reduce((a,b) => (((a << 5) - a) + b.charCodeAt(0))|0, 0)
 
 
@@ -1734,6 +1733,48 @@ const utilsParse = {
         profile.rt[pkey].unusedXml = false
       }
 
+      // keep track of the value we need to add
+      let groupTopLeveLiteralsToMerge = {}
+      // loop through and check if there are any top level literals we want to group
+      for (let key in profile.rt[pkey].pt){
+        let pt = profile.rt[pkey].pt[key]
+        // the list of props we allow to group are in the config
+        if (useConfigStore().groupTopLeveLiterals.indexOf(pt.propertyURI) > -1){
+          if (pt.userValue && pt.userValue[pt.propertyURI] && pt.userValue[pt.propertyURI][0]){
+            if (!groupTopLeveLiteralsToMerge[pt.propertyURI]){
+              groupTopLeveLiteralsToMerge[pt.propertyURI] = {mergeUnder: pt.id, toRemove: [], values: []}
+            }else{
+              groupTopLeveLiteralsToMerge[pt.propertyURI].toRemove.push(pt.id)
+            }
+            groupTopLeveLiteralsToMerge[pt.propertyURI].values.push(pt.userValue[pt.propertyURI][0])
+          }                    
+        }
+      }
+      // loop through the list of properties we found to see if we have multiple to merge
+      for (let toGroupUri in groupTopLeveLiteralsToMerge){
+        for (let key in profile.rt[pkey].pt){
+          if (profile.rt[pkey].pt[key].propertyURI == toGroupUri){
+            let pt = profile.rt[pkey].pt[key]
+            if (pt.id == groupTopLeveLiteralsToMerge[toGroupUri].mergeUnder){
+              pt.userValue[toGroupUri] = groupTopLeveLiteralsToMerge[toGroupUri].values
+            }            
+          }
+        }
+        for (let toRemove of groupTopLeveLiteralsToMerge[toGroupUri].toRemove){
+          if (profile.rt[pkey].ptOrder.indexOf(toRemove) > -1){
+            delete profile.rt[pkey].pt[toRemove]
+            profile.rt[pkey].ptOrder = profile.rt[pkey].ptOrder.filter((x) => { return x !== toRemove })
+          }
+        }
+      }
+      for (let toGroupUri in groupTopLeveLiteralsToMerge){
+        if (groupTopLeveLiteralsToMerge[toGroupUri].mergeUnder){
+          let ptToReOrder = profile.rt[pkey].pt[groupTopLeveLiteralsToMerge[toGroupUri].mergeUnder]
+          if (ptToReOrder && ptToReOrder.userValue && ptToReOrder.userValue[toGroupUri]){
+            ptToReOrder.userValue[toGroupUri] = useProfileStore().sortObjectsByLatinMatch(ptToReOrder.userValue[toGroupUri],toGroupUri )
+          }
+        }
+      }
 
       let adminMedtataPrimary = null
       let adminMedtataSecondary = []
@@ -1768,7 +1809,6 @@ const utilsParse = {
           // that will be our primary adminMetadata that they edit. Except, we want the `primary` Admin field to stay primary
           // even after it gets a status. Most of the admin fields will be hidden, but the Primary field in the instance will
           // remain and should continue to be editable.
-
           if (userValue){
 
             if (profile.rt[pkey].pt[key].parentId.includes(":Instance") && (!userValue['http://id.loc.gov/ontologies/bibframe/status'] || Object.keys(userValue).length > 7)){

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -6,8 +6,8 @@ export const useConfigStore = defineStore('config', {
   state: () => ({
 
     versionMajor: 1,
-    versionMinor: 1,
-    versionPatch: 0,
+    versionMinor: 2,
+    versionPatch: 1,
 
 
     regionUrls: {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -189,6 +189,11 @@ export const useConfigStore = defineStore('config', {
     'http://id.loc.gov/ontologies/bflc/projectedProvisionDate',
   ],
 
+  // these are predicates that will merged into one PT
+  groupTopLeveLiterals: [
+    'http://id.loc.gov/ontologies/bibframe/editionStatement',
+    'http://id.loc.gov/ontologies/bibframe/responsibilityStatement',
+  ],
 
   // these are properties that aren't allowed to be both when merging data with template
   templatesDataFlowCantBeBoth: [

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -638,7 +638,15 @@ export const usePreferenceStore = defineStore('preference', {
         group: 'Literal Field',
         range: [true,false]
     },
-
+    '--b-edit-main-literal-non-latin-first' : {
+      desc: 'With paired literals values (transliteration) always show the non-Latin value first (otherwise the Latin value will be first). (Requires Refresh)',
+      descShort: 'Paired literals, show non-Latin First. (Requires Refresh)',
+      value: false,
+      type: 'boolean',
+      unit: null,
+      group: 'Literal Field',
+      range: [true,false]
+    },
 
 
 
@@ -1541,7 +1549,7 @@ export const usePreferenceStore = defineStore('preference', {
       this.diacriticUse = this.returnValue('--c-diacritics-enabled-macros')
       this.diacriticUse = [...new Set(this.diacriticUse)];
 
-      console.log(this.diacriticUse)
+      // console.log(this.diacriticUse)
       for (let d in this.diacriticPacks.macroExpress){
 
         let macros = this.diacriticPacks.macroExpress[d]
@@ -1552,7 +1560,7 @@ export const usePreferenceStore = defineStore('preference', {
           }
         }
       }
-      console.log(this.diacriticUseValues)
+      // console.log(this.diacriticUseValues)
     },
 
     // turn copy mode on/off

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5849,7 +5849,30 @@ export const useProfileStore = defineStore('profile', {
 
 
 
-    }
+    },
+
+    /**
+     * Sorts an array of objects based on whether a specified key's value matches the latinRegex pattern.
+     * It sorts the array with the latin objects first, followed by the non-Latin objects.
+     * 
+     * @param {Object[]} arr - Array of objects to sort
+     * @param {string} key - Object key whose value should be tested against latinRegex
+     * @return {Object[]} - Sorted array with non-Latin objects first
+     */
+    sortObjectsByLatinMatch(arr, key) {
+      return arr.sort((a, b) => {
+        // Handle cases where key doesn't exist
+        const aValue = a[key] || '';
+        const bValue = b[key] || '';
+        
+        const aIsLatin = latinRegex.test(aValue);
+        const bIsLatin = latinRegex.test(bValue);
+        
+        if (!bIsLatin && aIsLatin) return -1; 
+        if (bIsLatin && !aIsLatin) return 1;
+        return 0;
+      });
+    }        
 
 
 


### PR DESCRIPTION

Changed: The default display order of paired literals is Latin first 
Changed: Top level literals like edition statement group together in one component
Adds: New preference to change the display order of non-latin literals
