### PR TITLE
reorder on the fly when literal non-latin preference is changed

### DIFF
--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -639,8 +639,8 @@ export const usePreferenceStore = defineStore('preference', {
         range: [true,false]
     },
     '--b-edit-main-literal-non-latin-first' : {
-      desc: 'With paired literals values (transliteration) always show the non-Latin value first (otherwise the Latin value will be first). (Requires Refresh)',
-      descShort: 'Paired literals, show non-Latin First. (Requires Refresh)',
+      desc: 'With paired literals values (transliteration) always show the non-Latin value first (otherwise the Latin value will be first)',
+      descShort: 'Paired literals, show non-Latin First.',
       value: false,
       type: 'boolean',
       unit: null,
@@ -1485,6 +1485,15 @@ export const usePreferenceStore = defineStore('preference', {
 
       this.styleDefault[propertyName].value = value
       this.savePreferences()
+
+      // we can do any actions on specific preference changes here
+      console.log(propertyName, this.styleDefault[propertyName].value)
+      if (propertyName == '--b-edit-main-literal-non-latin-first'){
+        useProfileStore().reorderAllNonLatinLiterals()
+        
+      }
+
+
       return true
     },
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5928,7 +5928,7 @@ export const useProfileStore = defineStore('profile', {
         if (bIsLatin && !aIsLatin) return 1;
         return 0;
       });
-    }        
+    },        
 
 
     /**
@@ -5993,6 +5993,63 @@ export const useProfileStore = defineStore('profile', {
         }
       }
 
+
+    },
+    /**
+     * Reorders all non-Latin and Latin literals within the active profile based on user preferences.
+     * 
+     * This function:
+     * 1. Traverses through all resource templates (rt) and property templates (pt) in the active profile
+     * 2. Examines both nested literals inside bnodes and top-level literals
+     * 3. When it finds multiple literals where at least one has a @language tag:
+     *    - For nested literals: Sorts the array using sortObjectsByLatinMatch()
+     *    - For top-level literals in groupTopLeveLiterals: Sorts using sortObjectsByLatinMatch()
+     * 4. The sort order is determined by the '--b-edit-main-literal-non-latin-first' preference:
+     *    - If true: Non-Latin literals appear first (reversed sort)
+     *    - If false: Latin literals appear first (normal sort)
+     * 
+     * @return {void} Modifies the active profile's literal ordering directly
+     */
+    reorderAllNonLatinLiterals(){
+      // we are going to go looking for literals inside bnodes that have two literals with one at least of them with a @language tag
+      for (let pkey in this.activeProfile.rt){     
+        for (let key in this.activeProfile.rt[pkey].pt){
+          let pt = this.activeProfile.rt[pkey].pt[key]
+          if (pt.userValue){
+            let propsFirstLevel = Object.keys(pt.userValue).filter(v => { return !v.startsWith('@') })
+            for (let p1 of propsFirstLevel){
+              for (let bnode of pt.userValue[p1]){
+                let propsSecondLevel = Object.keys(bnode).filter(v => { return !v.startsWith('@') })
+                for (let p2 of propsSecondLevel){
+                  if (Array.isArray(bnode[p2]) && bnode[p2].length>1){
+                    if (bnode[p2].filter((v)=>{ return (v['@language'])}).length>0){                    
+                      // sort the array of literals so the latin one is first
+                      console.log("bnode",bnode)
+                      if (usePreferenceStore().returnValue('--b-edit-main-literal-non-latin-first')){
+                        bnode[p2] = useProfileStore().sortObjectsByLatinMatch(bnode[p2],p2).reverse()                    
+                      }else{
+                        bnode[p2] = useProfileStore().sortObjectsByLatinMatch(bnode[p2],p2)                    
+                      }                      
+                    }
+                  }
+                }              
+              }
+            }
+            // also the top level literals
+            if (useConfigStore().groupTopLeveLiterals.indexOf(pt.propertyURI) > -1){
+              if (pt.userValue[pt.propertyURI]){
+                if (usePreferenceStore().returnValue('--b-edit-main-literal-non-latin-first')){
+                  pt.userValue[pt.propertyURI] = useProfileStore().sortObjectsByLatinMatch(pt.userValue[pt.propertyURI],pt.propertyURI).reverse()                    
+                }else{
+                  pt.userValue[pt.propertyURI] = useProfileStore().sortObjectsByLatinMatch(pt.userValue[pt.propertyURI],pt.propertyURI)                    
+                } 
+
+              }
+
+            }
+          }      
+        }      
+      }
 
     },
   


### PR DESCRIPTION
Adds: When the --b-edit-main-literal-non-latin-first preference is changed it now reorders the literals in real time.