### PR TITLE
Fix Custom Ordering

### DIFF
--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -404,12 +404,11 @@
     },
 
     updated: function(){
-        let bibId = this.getBibId()
-		// Add the ID to the title when loading from "Your Records"
-
-        if (!document.title.includes(bibId)){
-            this.populateTitle()
-        }
+      let bibId = this.getBibId()
+    // Add the ID to the title when loading from "Your Records"
+      if (!document.title.includes(bibId)){
+          this.populateTitle()
+      }
     }
 
   }

--- a/src/components/panels/edit/EditPanel.vue
+++ b/src/components/panels/edit/EditPanel.vue
@@ -75,7 +75,7 @@
 
         <template v-for="(profileCompoent,idx) in activeProfile.rt[profileName].ptOrder" :key="profileCompoent">
           <template v-if="(createLayoutMode && layoutActive) || layoutActive == false || (layoutActive == true && layoutActiveFilter.properties[profileName] && includeInLayout(activeProfile.rt[profileName].pt[profileCompoent].id, layoutActiveFilter['properties'][profileName])) ">
-            <template v-if="!hideProps.includes(activeProfile.rt[profileName].pt[profileCompoent].propertyURI)">
+            <template v-if="activeProfile.rt[profileName].pt[profileCompoent] && !hideProps.includes(activeProfile.rt[profileName].pt[profileCompoent].propertyURI)">
 
               <template v-if="(preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === true && activeProfile.rt[profileName].pt[profileCompoent].canBeHidden === false) || preferenceStore.returnValue('--b-edit-main-splitpane-edit-adhoc-mode') === false">
 
@@ -400,7 +400,7 @@
     mounted: function(){
         //populate when loading from a search
         this.populateTitle()
-        this.profileStore.useCustomComponentOrder()
+        // this.profileStore.useCustomComponentOrder()
     },
 
     updated: function(){

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -46,6 +46,14 @@ import { isReadonly } from 'vue';
 
 
     methods: {
+      isPrimaryComponent: function(order, target){
+        if (order.includes(target)){
+          return true
+        }
+
+
+        return false
+      },
       saveOrder: function(){
         this.profileStore.saveCustomComponentOrder()
       },
@@ -400,7 +408,7 @@ import { isReadonly } from 'vue';
                             <template #item="{element}">
                               <template v-if="!hideAdminField(activeProfile.rt[profileName].pt[element], profileName) && !activeProfile.rt[profileName].pt[element].deleted && !hideProps.includes(activeProfile.rt[profileName].pt[element].propertyURI) && ( (layoutActive && layoutActiveFilter['properties'][profileName] && includeInLayout(activeProfile.rt[profileName].pt[element].id, layoutActiveFilter['properties'][profileName])) || !layoutActive || (createLayoutMode && layoutActive))">
                                 <li @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-li sidebar-property-li-empty', {'user-populated': (hasData(activeProfile.rt[profileName].pt[element]) == 'user')} , {'system-populated': (hasData(activeProfile.rt[profileName].pt[element])) == 'system'}  , {'not-populated-hide': (preferenceStore.returnValue('--c-general-ad-hoc') && emptyComponents[profileName] && emptyComponents[profileName].includes(element) && !layoutActive )}]">
-                                  <a href="#" @click.stop="jumpToElement(profileName, element)" class="sidebar-property-ul-alink">
+                                  <a href="#" @click.stop="jumpToElement(profileName, element)" :class="['sidebar-property-ul-alink', {'primary-component': isPrimaryComponent(profileStore.profiles[activeProfile.id].rt[profileName].ptOrder, activeProfile.rt[profileName].pt[element].id)},]">
                                       <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-number-labels')">{{activeProfile.rt[profileName].ptOrder.indexOf(element)}}</template>
                                       <span v-if="replacePropertyWithValue(activeProfile.rt[profileName].pt[element].propertyURI)">
                                         {{ returnHeadingLabel(activeProfile.rt[profileName].pt[element]) }}
@@ -908,6 +916,11 @@ li.not-populated-hide:before{
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-background-color')") !important;
   background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-font-color')") !important;
   cursor: pointer;
+}
+
+.primary-component {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
 }
 
 </style>

--- a/src/components/panels/sidebar_property/Properties.vue
+++ b/src/components/panels/sidebar_property/Properties.vue
@@ -360,10 +360,10 @@ import { isReadonly } from 'vue';
   <template  v-if="preferenceStore.returnValue('--b-edit-main-splitpane-properties-accordion') == true">
     <AccordionList  :open-multiple-items="false">
 
-      <span style="margin-left: 15px;">
-        <span class="material-icons order-icon simptip-position-right" data-tooltip="SAVE ORDER" @click="saveOrder">list_alt</span>
-        <span class="material-icons order-icon simptip-position-right" data-tooltip="USE ORDER" @click="useOrder">sync</span>
-        <span class="material-icons order-icon simptip-position-right" data-tooltip="LOAD DEFAULT" @click="useDefault">history</span>
+      <span class="order-actions-span">
+        <div class="icon-container"><span class="material-icons order-icon simptip-position-right" data-tooltip="SAVE ORDER" @click="saveOrder">list_alt</span></div>
+        <div class="icon-container"><span class="material-icons order-icon simptip-position-right" data-tooltip="USE ORDER" @click="useOrder">sync</span></div>
+        <div class="icon-container"><span class="material-icons order-icon simptip-position-right" data-tooltip="LOAD DEFAULT" @click="useDefault">history</span></div>
       </span>
 
       <template v-for="profileName in activeProfile.rtOrder" :key="profileName">
@@ -905,6 +905,21 @@ li.not-populated-hide:before{
   list-style: none;
 }
 
+.primary-component {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.order-actions-span {
+  width: 100%;
+  display: table;
+}
+
+.icon-container{
+  display: table-cell;
+  text-align: center;
+}
+
 .order-icon {
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-font-color')") !important;
   cursor: pointer;
@@ -916,11 +931,6 @@ li.not-populated-hide:before{
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-background-color')") !important;
   background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-properties-font-color')") !important;
   cursor: pointer;
-}
-
-.primary-component {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
 }
 
 </style>

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -468,8 +468,6 @@ const utilsNetwork = {
               url = url.replace('q=?','q=')
             }
 
-            console.info("url: ", url)
-
             let r = await this.fetchSimpleLookup(url, false, searchPayload.signal)
 
             //Config only allows 25 results, this will add something to the results

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -27,8 +27,8 @@ export const useConfigStore = defineStore('config', {
         profiles : 'http://localhost:9401/util/profiles/profile/prod',
         starting: 'http://localhost:9401/util/profiles/starting/prod',
 
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
         id: 'https://id.loc.gov/',

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -27,8 +27,8 @@ export const useConfigStore = defineStore('config', {
         profiles : 'http://localhost:9401/util/profiles/profile/prod',
         starting: 'http://localhost:9401/util/profiles/starting/prod',
 
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
         id: 'https://id.loc.gov/',

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -513,8 +513,13 @@ export const useProfileStore = defineStore('profile', {
 
         // remove the extra pieces
         customOrder = customOrder.filter(el => !additionalToCustomOrder.includes(el))
-        customOrder = customOrder.concat(missingFromCustomOrder)
-        // this doesn't maintain the order if there's a change in the profile, but what's that order supposed to be if they changing it?
+        // customOrder = customOrder.concat(missingFromCustomOrder)
+
+        // add the missing peices in the same index from the default
+        for (let el of missingFromCustomOrder){
+          let idx = profileOrder.indexOf(el)
+          customOrder.splice(idx, 0, el)
+        }
 
         for (let el of customOrder){
           // These should all be base level names, no `_ + new Date()`

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -490,6 +490,7 @@ export const useProfileStore = defineStore('profile', {
       }
 
       usePreferenceStore().saveOrder(order)
+      this.useCustomComponentOrder()
     },
 
     /** Load the saved custom component order */
@@ -503,11 +504,24 @@ export const useProfileStore = defineStore('profile', {
         let currentOrder = this.activeProfile.rt[profileName].ptOrder
         let customOrder = order[profileName]
         let tempOrder = []
+
+        // if there's a change to the profile, adjust the order accordingly
+        let profileOrder = profile.rt[profileName].ptOrder
+
+        let additionalToCustomOrder = customOrder.filter(el => !profileOrder.includes(el))
+        let missingFromCustomOrder = profileOrder.filter(el => !customOrder.includes(el))
+
+        // remove the extra pieces
+        customOrder = customOrder.filter(el => !additionalToCustomOrder.includes(el))
+        customOrder = customOrder.concat(missingFromCustomOrder)
+        // this doesn't maintain the order if there's a change in the profile, but what's that order supposed to be if they changing it?
+
         for (let el of customOrder){
           // These should all be base level names, no `_ + new Date()`
           let matchingComponents = currentOrder.filter(i => i.includes(el)) // keep like components together
           tempOrder = tempOrder.concat(matchingComponents.sort())
         }
+
         this.activeProfile.rt[profileName].ptOrder = tempOrder
       }
     },


### PR DESCRIPTION
Fixes: 
- Custom order when profile changes
- Custom order when number of components change between records

There could be situations where the custom order could prevent components from displaying. One was if there is a change to a profile that adds a component that does not exist in the custom order, it would not show. There's some logic that tries to adjust for this.

The other more common case is saving an order in a record that has 1 subject and then loading a record that has 5. Four of the subject wouldn't appear. To correct for this, the custom order is made of only the `primary` component. `primary` meaning it has an unqualified id. `id` not `id_<date>`. All components that are built from the same base will appear together. They are still moved individually, but moving the primary and saving will move all related components.

The catch is that to reorder and save that order, the user needs to move the `primary` component. These now appear <ins>underlined</ins> in the properties panel.