### PR TITLE
auto-size on ss insert and fix paired line lengthening on large fields

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 4,
+    versionPatch: 5,
 
 
     regionUrls: {


### PR DESCRIPTION
Fixes: When using scriptshifter to transliterate a large amount of text the literal field will now resize to be more than one line.