### PR TITLE
[BFP-379] Update Complex Heading Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.5] - 2025-04-07
+### Fixed
+- Improved complex subject lookups
+
+
 ## [1.2.4] - 2025-04-04
 ### Changed
 - Update Default library components: `Bib/Index`, `Color Ill., Color Map`, `Index` [BFP-370]

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -103,7 +103,7 @@
                     <div v-if="searchResults && searchResults.exact.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">Known Label</span>
                       <div v-for="(subject,idx) in searchResults.exact" @click="selectContext((searchResults.names.length - idx)*-1-2)" @mouseover="loadContext((searchResults.names.length - idx)*-1-2)" :data-id="((searchResults.names.length - idx)*-1-2)" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1-2 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1-2 ), 'picked': (pickLookup[(searchResults.names.length - idx)*-1-2] && pickLookup[(searchResults.names.length - idx)*-1-2].picked) }]" >
-                        <template v-if="subject.label == activeComponent.label.replace('‑', '-')">
+                        <template v-if="subject.label == activeComponent.label.replaceAll('‑', '-')">
                           {{subject.label}}
                         </template>
                         <template v-else>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2005,19 +2005,18 @@ methods: {
     }
 
     if (this.pickLookup[this.pickPostion].complex){
-      // if it is a complex authorized heading then just replace the whole things with it
-      // console.info("this.subjectString: ", this.subjectString)
-      // console.info("this.pickPostion: ", this.pickPostion)
-      // console.info("this.pickLookup[this.pickPostion].label: ", this.pickLookup[this.pickPostion].label)
+      // if it is a complex authorized heading then just replace the whole things with it, sometimes
+      let splitString = this.subjectString.split('--')
+      if (splitString.includes(this.pickLookup[this.pickPostion].label.replaceAll('-','‑'))){
+        let idx = splitString.indexOf(this.pickLookup[this.pickPostion].label.replaceAll('-','‑'))
+        if (idx == this.activeComponentIndex){
+          splitString[this.activeComponentIndex] = this.pickLookup[this.pickPostion].label.replaceAll('-','‑')
+          this.subjectString = splitString.join('--')
+        }
+      } else {
+        this.subjectString = this.pickLookup[this.pickPostion].label
+      }
 
-      // let splitString = this.subjectString.split('--')
-      // console.info("splitString: ", splitString)
-      // splitString[this.activeComponentIndex] = this.pickLookup[this.pickPostion].label.replaceAll('-','‑')
-
-      // this.subjectString = splitString.join('--')
-
-      this.subjectString = this.pickLookup[this.pickPostion].label
-      console.info("this.subjectString: ", this.subjectString)
 
       this.activeComponentIndex = 0
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1659,7 +1659,6 @@ methods: {
   }, 500),
 
   navStringClick: function(event){
-    console.info("navStringClick")
     // when clicked send it over to the navString func with fake key property to trigger if statement
     event.key='ArrowLeft'
     this.navString(event)

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1659,6 +1659,7 @@ methods: {
   }, 500),
 
   navStringClick: function(event){
+    console.info("navStringClick")
     // when clicked send it over to the navString func with fake key property to trigger if statement
     event.key='ArrowLeft'
     this.navString(event)
@@ -2007,20 +2008,21 @@ methods: {
     if (this.pickLookup[this.pickPostion].complex){
       // if it is a complex authorized heading then just replace the whole things with it, sometimes
       let splitString = this.subjectString.split('--')
-      if (splitString.includes(this.pickLookup[this.pickPostion].label.replaceAll('-','‑'))){
-        let idx = splitString.indexOf(this.pickLookup[this.pickPostion].label.replaceAll('-','‑'))
+      let splitStringLower = this.subjectString.toLowerCase().split('--')
+
+      if (splitStringLower.includes(this.pickLookup[this.pickPostion].label.replaceAll('-','‑').toLowerCase())){
+        let idx = splitStringLower.indexOf(this.pickLookup[this.pickPostion].label.replaceAll('-','‑').toLowerCase())
         if (idx == this.activeComponentIndex){
           splitString[this.activeComponentIndex] = this.pickLookup[this.pickPostion].label.replaceAll('-','‑')
           this.subjectString = splitString.join('--')
         }
       } else {
+        // Replace the whole thing
         this.subjectString = this.pickLookup[this.pickPostion].label
+        this.componetLookup = {}
+        this.activeComponentIndex = 0
       }
 
-
-      this.activeComponentIndex = 0
-
-      // this.componetLookup = {}
       this.componetLookup[this.activeComponentIndex] = {}
 
       this.componetLookup[this.activeComponentIndex][this.pickLookup[this.pickPostion].label] = this.pickLookup[this.pickPostion]
@@ -2377,7 +2379,6 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
-    console.info("subjectStringChanged: ", this.subjectString)
     this.subjectString=this.subjectString.replace("—", "--")
     this.validateOkayToAdd()
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2006,10 +2006,22 @@ methods: {
 
     if (this.pickLookup[this.pickPostion].complex){
       // if it is a complex authorized heading then just replace the whole things with it
+      // console.info("this.subjectString: ", this.subjectString)
+      // console.info("this.pickPostion: ", this.pickPostion)
+      // console.info("this.pickLookup[this.pickPostion].label: ", this.pickLookup[this.pickPostion].label)
+
+      // let splitString = this.subjectString.split('--')
+      // console.info("splitString: ", splitString)
+      // splitString[this.activeComponentIndex] = this.pickLookup[this.pickPostion].label.replaceAll('-','‑')
+
+      // this.subjectString = splitString.join('--')
+
       this.subjectString = this.pickLookup[this.pickPostion].label
+      console.info("this.subjectString: ", this.subjectString)
+
       this.activeComponentIndex = 0
 
-      this.componetLookup = {}
+      // this.componetLookup = {}
       this.componetLookup[this.activeComponentIndex] = {}
 
       this.componetLookup[this.activeComponentIndex][this.pickLookup[this.pickPostion].label] = this.pickLookup[this.pickPostion]
@@ -2366,6 +2378,7 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
+    console.info("subjectStringChanged: ", this.subjectString)
     this.subjectString=this.subjectString.replace("—", "--")
     this.validateOkayToAdd()
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2690,9 +2690,8 @@ const utilsNetwork = {
       if (pos == 0){
         exact = exact.concat(resultsExactName)
         exact = exact.concat(resultsExactSubject)
-        resultsSubjectsComplex = resultsSubjectsComplex.concat(resultsSubjectsComplexSearchVal.filter((item) => !resultsSubjectsComplex.includes(item)))
+        resultsSubjectsComplex = resultsSubjectsComplex.concat(resultsSubjectsComplexSearchVal.filter((item) => !resultsSubjectsComplex.some((o) => o.label == item.label))) //dedupe
       }
-
 
       let results = {
         'subjectsSimple': pos == 0 ? resultsSubjectsSimple : resultsPayloadSubjectsSimpleSubdivision,

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -27,6 +27,7 @@ const utilsNetwork = {
       "controllerSubjectsSimple": new AbortController(),
       "controllerPayloadSubjectsSimpleSubdivision": new AbortController(),
       "controllerSubjectsComplexPart": new AbortController(),
+      "controllerSubjectsComplexSearchVal": new AbortController(),
       "controllerSubjectsComplex": new AbortController(),
       "controllerHierarchicalGeographic": new AbortController(),
       "controllerWorksAnchored": new AbortController(),
@@ -2347,6 +2348,7 @@ const utilsNetwork = {
       let namesGeoUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsNames).replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic'
       let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
+      let subjectUrlComplexSearchVal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimple = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")+'&rdftype=SimpleType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlSimpleSubdivison = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=SimpleType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
@@ -2442,6 +2444,14 @@ const utilsNetwork = {
         searchValue: searchVal
       }
 
+      let searchPayloadSubjectsComplexSearchVal = {
+        processor: 'lcAuthorities',
+        url: [subjectUrlComplexSearchVal],
+        searchValue: searchVal,
+        subjectSearch: true,
+        signal: this.controllers.controllerSubjectsComplexSearchVal.signal,
+      }
+
       let searchPayloadSubjectsComplex = {
         processor: 'lcAuthorities',
         url: [subjectUrlComplex],
@@ -2521,6 +2531,7 @@ const utilsNetwork = {
       let resultsSubjectsSimple=[]
       let resultsPayloadSubjectsSimpleSubdivision=[]
       let resultsSubjectsComplex=[]
+      let resultsSubjectsComplexSearchVal=[]
       let resultsSubjectsComplexPart=[]
       let resultsHierarchicalGeographic=[]
       let resultsWorksAnchored=[]
@@ -2535,8 +2546,10 @@ const utilsNetwork = {
       let resultsExactName = []
       let resultsExactSubject = []
 
+
+
       if (mode == "LCSHNAF"){
-        [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic, resultsExactName, resultsExactSubject] = await Promise.all([
+        [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic, resultsExactName, resultsExactSubject, resultsSubjectsComplexSearchVal] = await Promise.all([
             this.searchComplex(searchPayloadNames),
             this.searchComplex( searchPayloadNamesGeo),
             this.searchComplex(searchPayloadNamesSubdivision),
@@ -2546,6 +2559,7 @@ const utilsNetwork = {
             this.searchComplex(searchPayloadHierarchicalGeographic),
             this.searchExact(exactPayloadName),
             this.searchExact(exactPayloadSubject),
+            this.searchComplex(searchPayloadSubjectsComplexSearchVal),
         ]);
 
       } else if (mode == "CHILD"){
@@ -2592,6 +2606,11 @@ const utilsNetwork = {
       if (resultsSubjectsComplex.length>0){
         resultsSubjectsComplex.pop()
       }
+      if (resultsSubjectsComplexSearchVal.length>0){
+        resultsSubjectsComplexSearchVal.pop()
+      }
+
+
       if (resultsChildrenSubjectsComplex.length>0){
         resultsChildrenSubjectsComplex.pop()
       }
@@ -2638,6 +2657,12 @@ const utilsNetwork = {
 
       //determine position of search and set results accordingly
       let searchPieces = complexVal.split("--")
+      if (searchVal.includes("--")){
+        let valPieces = searchVal.split("--")
+        let firstMatch = searchPieces.indexOf(valPieces[0])
+        searchPieces.splice(firstMatch, valPieces.length, searchVal)
+      }
+
       let pos = searchPieces.indexOf(searchVal)
 
       if (resultsExactName && resultsExactName.length > 0){
@@ -2661,10 +2686,13 @@ const utilsNetwork = {
           exact = exact.concat(resultsExactSubject)
         }
       }
+
       if (pos == 0){
         exact = exact.concat(resultsExactName)
         exact = exact.concat(resultsExactSubject)
+        resultsSubjectsComplex = resultsSubjectsComplex.concat(resultsSubjectsComplexSearchVal.filter((item) => !resultsSubjectsComplex.includes(item)))
       }
+
 
       let results = {
         'subjectsSimple': pos == 0 ? resultsSubjectsSimple : resultsPayloadSubjectsSimpleSubdivision,

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 4,
+    versionPatch: 5,
 
 
     regionUrls: {


### PR DESCRIPTION
Fix: 
- Complex headings not appearing sometimes
- Known Label results sometimes being listed as `variant` with complex headings

If a record is loaded with a complex heading and the user adds subdivisions to it, clicking back on the complex heading would fail to show the authorized form in the results. This was because of how the search was conducted. The complex search used the entire string, `original heading + subdivision`, which would not return the original heading by itself.

This change adds a search to look for complex headings, terms that have `--` in them, in addition to the other complex lookup.

There's also an attempt to make string updates smarter. Before, if you added a complex heading, it would replace the entire search string. Now, if there is an existing heading that matching the incoming heading, we'll try to match it so nothing get erased.