### PR TITLE
Sort non latin on add

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 5,
+    versionPatch: 6,
 
 
     regionUrls: {

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2172,6 +2172,7 @@ export const useProfileStore = defineStore('profile', {
           }
 
           // also build the paired literal lines
+          this.reorderAllNonLatinLiterals()
           utilsParse.buildPairedLiteralsIndicators(this.activeProfile)
         }
 


### PR DESCRIPTION
Fixes: When adding a non-literal via scriptshifter it will resort the literals order based on preference.