### PR TITLE
Fix complex subject xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Update to Default Library `Index` & `Bib` [BFP-381]
+- Change the XML structure of `ComplexSubjects`
 
 
 ## [1.2.6] - 2025-04-08

--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -2602,6 +2602,5 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
             if (sGenre$ == "Drama" && sCountry$ == "Sweden" && sDewey$ == "Period1600") dewey = "839.72/5"
         }
 
-        console.info("dewey: ", dewey)
         return dewey
     }

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1682,7 +1682,7 @@ const utilsExport = {
 		}
 	}
 	let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)
-
+	// console.info("strXmlBasic: ", strXmlBasic)
 	return {
 		xmlDom: rdf,
 		xmlStringFormatted: strXmlFormatted,

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -2287,7 +2287,6 @@ const utilsParse = {
       if (obj && obj.userValue){
         obj = obj.userValue
       }
-      console.info("      processing: ", obj)
       if (Array.isArray(obj)){
         obj.forEach(function (child) {
           process(child, func);

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2850,8 +2850,6 @@ export const useProfileStore = defineStore('profile', {
                     break
                 }
 
-                console.info("     p: ", p.propertyURI)
-
                 if (!currentUserValuePos[p.propertyURI]){
                     currentUserValuePos[p.propertyURI] = []
                 }
@@ -3120,7 +3118,6 @@ export const useProfileStore = defineStore('profile', {
             // they changed something
             this.dataChanged()
 
-            console.info("userValue: ", userValue)
             // console.log("USERVALUE IS",userValue)
             pt.userValue = userValue
         }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2850,7 +2850,7 @@ export const useProfileStore = defineStore('profile', {
                     break
                 }
 
-
+                console.info("     p: ", p.propertyURI)
 
                 if (!currentUserValuePos[p.propertyURI]){
                     currentUserValuePos[p.propertyURI] = []
@@ -2862,6 +2862,10 @@ export const useProfileStore = defineStore('profile', {
                   thisLevelType = await utilsRDF.suggestTypeNetwork(p.propertyURI)
                 }
 
+                // if it's a complexSubject, replace bf:Topic with madsrdf:ComplexSubject -- the conversion expects this
+                if (thisLevelType == "http://id.loc.gov/ontologies/bibframe/Topic" && propertyPath.some((obj) => obj.propertyURI == "http://www.loc.gov/mads/rdf/v1#componentList")){
+                  thisLevelType = 'madsrdf:ComplexSubject'
+                }
 
                 let thisLevel = {'@guid':short.generate()}
                 if (!utilsRDF.isUriALiteral(thisLevelType)){
@@ -3116,6 +3120,7 @@ export const useProfileStore = defineStore('profile', {
             // they changed something
             this.dataChanged()
 
+            console.info("userValue: ", userValue)
             // console.log("USERVALUE IS",userValue)
             pt.userValue = userValue
         }


### PR DESCRIPTION
Updates: XML for `ComplexSubjects`

`ComplexSubjects` were being defined as `bf:Topic` but the conversion wants `madsrdf:ComplexSubject`. This causes issues with Hub subjects where subdividing them would cause the `$a` to disappear.