### PR TITLE
Populate NAR 670 $b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.10] - 2025-04-15
+### Changed
+- NAR modal populates `670 $b` with statement of responsibilty when possible
+- NAR modal layout change
 
 ## [1.2.9] - 2025-04-14
 ### Fixed

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -75,6 +75,7 @@
         mainTitleDate: null,
         mainTitleNote: '',
         workURI: false,
+        statementOfResponsibility: null,
 
         tmpXML:false,
 
@@ -888,7 +889,11 @@
       this.mainTitle = this.profileStore.nacoStubReturnMainTitle()
       this.mainTitleLccn = this.profileStore.nacoStubReturnLCCN()
       this.mainTitleDate = this.profileStore.nacoStubReturnDate()
+      this.statementOfResponsibility = this.profileStore.nacoStubReturnSoR()
 
+      if (this.statementOfResponsibility){
+        this.mainTitleNote = "statement of responsibility (" + this.statementOfResponsibility  + ")"
+      }
 
       this.workURI =  this.profileStore.nacoStubReturnWorkURI()
       // console.log("this.workURIthis.workURIthis.workURI",this.workURI)
@@ -1152,7 +1157,11 @@
                       </div>
                 </template>
 
-                <input placeholder="670 $b (optional)" v-model="mainTitleNote" style="width:100%; margin-bottom:0.25em"/>
+                <div style="white-space: nowrap; display: inline-block; width: 80%">
+                  <span class="material-icons edit-icon">edit</span>
+                  <label>670 $b: </label>
+                  <input placeholder="(optional)" v-model="mainTitleNote" style="width:100%; margin-bottom:0.25em"/>
+                </div>
 
                 <template v-if="mainTitle && mainTitleDate && mainTitleLccn">
                   <div style="font-family: monospace; background-color: whitesmoke;">670 $a{{ mainTitle }},{{ mainTitleDate }}{{ (mainTitleNote!='') ? `$b${mainTitleNote}` : '' }}$w(DLC){{ mainTitleLccn }}</div>
@@ -1419,7 +1428,12 @@ select{
     color: green;
     font-size: 20px;
     padding-right: 5px;
+  }
 
+  .edit-icon {
+    color: black;
+    font-size: 20px;
+    padding-right: 5px;
   }
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5356,6 +5356,29 @@ export const useProfileStore = defineStore('profile', {
     },
 
     /**
+     * Look for the Statement of Responsibility in the record to add to the 670 $b
+     *
+     */
+    nacoStubReturnSoR(){
+      for (let rt of this.activeProfile.rtOrder){
+        if (rt.indexOf(":Instance")>-1){
+          for (let pt of this.activeProfile.rt[rt].ptOrder){
+            pt = this.activeProfile.rt[rt].pt[pt]
+            if (pt.propertyURI == "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"){
+              if (pt.userValue
+                  && pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement']
+                  && pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement'][0]
+                  && pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement'][0]['http://id.loc.gov/ontologies/bibframe/responsibilityStatement']
+                )
+                return pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement'][0]['http://id.loc.gov/ontologies/bibframe/responsibilityStatement']
+            }
+          }
+        }
+      }
+      return false
+    },
+
+    /**
      * Retrieves the main title from the NACO stub work profile by traversing the resource template structure.
      * Looks for a property with URI "http://id.loc.gov/ontologies/bibframe/title" and extracts its main title value.
      *


### PR DESCRIPTION
Changes: 
- NAR Modal `670 $b` will prepopulate with the statement of the responsibility from the instance when it is available.
- Change the layout of the `670 $b` to match the other 670 fields

![image](https://github.com/user-attachments/assets/dd91f936-e694-4444-a7e3-542922c56b6c)
