### PR TITLE
Fix `Jurisdictions` being of type `Organization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Ability to find and use complex subdivisions in the subject builder
 
+### Fixed
+- Fix `Jurisdictions` being of type `Organization`
+
+
 ## [1.2.10] - 2025-04-15
 ### Changed
 - NAR modal populates `670 $b` with statement of responsibilty when possible

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1758,8 +1758,16 @@ methods: {
         this.pickLookup[this.pickPostion].marcKey = this.contextData.marcKey
       }
       let types = this.pickLookup[this.pickPostion].extra['rdftypes']
+
       this.contextData.type = types.includes("Hub") ? "bf:Hub" :  types.includes("Work") ? "bf:Work" : "madsrdf:" +  types[0]
       this.contextData.typeFull = this.contextData.type.replace('madsrdf:', 'http://www.loc.gov/mads/rdf/v1#')
+
+      //Check if it's a Jurisdiction, and overwrite
+      if (this.pickLookup[this.pickPostion].extra['collections'].includes("http://id.loc.gov/authorities/names/collection_Jurisdictions")){
+        this.contextData.type = "bf:Jursidiction"
+      this.contextData.typeFull = "http://id.loc.gov/ontologies/bibframe/Jurisdiction"
+      }
+
       this.contextData.gacs = this.pickLookup[this.pickPostion].extra.gacs
 
     } else {


### PR DESCRIPTION
When a subject was a `jurisdiction`, it was being given the type `Organization` which was throwing off the conversion. This was because `Jurisdiction` is defined in `extra.collections` but type was determined solely by the values in `extra.rdfTypes`.

Now, we'll do a backup check of the `collections` and set the type to `Jurisdiction` when appropriate.