### PR TITLE
look in the full profiles for a useValuesFrom value if cannot find it…

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -16,7 +16,10 @@ export const useConfigStore = defineStore('config', {
 
         ldpjs : 'http://localhost:9401/api-staging/',
         util  : 'http://localhost:9401/util/',
+
         // util  : 'http://localhost:5200/',
+        // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',
         publish : 'http://localhost:9401/util/publish/staging',
@@ -24,17 +27,33 @@ export const useConfigStore = defineStore('config', {
         publishNar: 'http://localhost:9401/util/nacostub/staging',
         bfdb : 'https://preprod-8230.id.loc.gov/',
         shelfListing: 'https://preprod-8230.id.loc.gov/',
-        profiles : 'http://localhost:9401/util/profiles/profile/prod',
+
+        // localhost server stage profiles
+        // profiles : 'http://localhost:9401/util/profiles/profile/stage',
+        // starting: 'http://localhost:9401/util/profiles/starting/stage',
+
+        // localhost server prod profiles
+        // profiles : 'http://localhost:9401/util/profiles/profile/prod',
         // starting: 'http://localhost:9401/util/profiles/starting/prod',
 
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
-        // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
+        // offical stage profiles that work outside firewall
+        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
         // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
-        starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
-        profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
 
-        util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+        // offical prod profiles that work outside firewall
+        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+        starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
+
+        // offical stage profiles inside the firewall
+        // starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
+        // profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
+
+        // offical prod profiles inside the firewall
+        // starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
+        // profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
+
+
+        
 
         id: 'https://id.loc.gov/',
         env : 'staging',

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5295,9 +5295,7 @@ export const useProfileStore = defineStore('profile', {
       for (let rt of this.activeProfile.rtOrder){
         for (let pt of this.activeProfile.rt[rt].ptOrder){
           let purl = utilsParse.namespaceUri(this.activeProfile.rt[rt].pt[pt].propertyURI)
-
           if (purl == property){
-            console.log(this.activeProfile.rt[rt].pt[pt])
             if (this.activeProfile.rt[rt].pt[pt].valueConstraint && this.activeProfile.rt[rt].pt[pt].valueConstraint.useValuesFrom && this.activeProfile.rt[rt].pt[pt].valueConstraint.useValuesFrom.length>0){
               return this.activeProfile.rt[rt].pt[pt].valueConstraint.useValuesFrom[0]
             }
@@ -5306,6 +5304,33 @@ export const useProfileStore = defineStore('profile', {
 
         }
       }
+
+
+      // we didn't find it see if it has instead a templateref value
+      for (let rt of this.activeProfile.rtOrder){
+        for (let pt of this.activeProfile.rt[rt].ptOrder){
+          let purl = utilsParse.namespaceUri(this.activeProfile.rt[rt].pt[pt].propertyURI)
+          if (purl == property){
+            if (this.activeProfile.rt[rt].pt[pt].valueConstraint && this.activeProfile.rt[rt].pt[pt].valueConstraint.valueTemplateRefs && this.activeProfile.rt[rt].pt[pt].valueConstraint.valueTemplateRefs.length>0){
+              let lookForTemplate = this.activeProfile.rt[rt].pt[pt].valueConstraint.valueTemplateRefs[0]
+              for (let pName in this.profiles){
+                if (this.profiles[pName].rtOrder.includes(lookForTemplate)){
+                  for (let p of this.profiles[pName].rt[lookForTemplate].ptOrder){
+                    let purl2 = utilsParse.namespaceUri(this.profiles[pName].rt[lookForTemplate].pt[p].propertyURI)                    
+                    if (purl2 == property || purl2 == 'owl:sameAs'){
+                      if (this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint && this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint.useValuesFrom && this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint.useValuesFrom.length>0){
+                        return this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint.useValuesFrom[0]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+
       return false
     },
 


### PR DESCRIPTION
profile.returnProfileLookupUrl will now look into the profiles and sub templates if it cannot find the useValuesFrom at the active level. This happens if there are multiple lookups on a active profile template and the the one we need doesn't make it into the activeprofile property.
