### PR TITLE
Subject Updates Type & URL

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -794,6 +794,7 @@
       },
 
       rewriteURI: function(uri){
+        let returnUrls = useConfigStore().returnUrls
 
         if (!uri){
           return false
@@ -804,9 +805,20 @@
         }
 
         if (uri.includes('/resources/hubs/') || uri.includes('/resources/works/') || uri.includes('/resources/instances/') || uri.includes('/resources/items/')){
-          let returnUrls = useConfigStore().returnUrls
           uri = uri.replace('https://id.loc.gov/', returnUrls.bfdb )
           uri = uri.replace('http://id.loc.gov/', returnUrls.bfdb )
+        }
+
+        // use internal links for prodcution
+        if (returnUrls.dev || returnUrls.publicEndpoints){
+          uri = uri.replace('http://preprod.id.','https://id.')
+          uri = uri.replace('https://preprod-8230.id.loc.gov','https://id.loc.gov')
+          uri = uri.replace('https://test-8080.id.lctl.gov','https://id.loc.gov')
+          uri = uri.replace('https://preprod-8080.id.loc.gov','https://id.loc.gov')
+          uri = uri.replace('https://preprod-8288.id.loc.gov','https://id.loc.gov')
+        } else { // if it's not dev or public make sure we're using 8080
+          uri = uri.replace('https://id.loc.gov', 'https://preprod-8080.id.loc.gov')
+          uri = uri.replace('http://id.loc.gov', 'https://preprod-8080.id.loc.gov')
         }
 
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -208,7 +208,7 @@
                     </h3>
 
                     <div class="modal-context-data-title" v-if="contextData.rdftypes">{{contextData.rdftypes.includes('Hub') ? 'Hub' : contextData.rdftypes[0]}}</div>
-                    <a style="color:#2c3e50" :href="contextData.uri" target="_blank" v-if="contextData.literal != true">view on id.loc.gov</a>
+                    <a style="color:#2c3e50" :href="rewriteURI(contextData.uri)" target="_blank" v-if="contextData.literal != true">view on id.loc.gov</a>
 
                     <br><br>
 
@@ -914,6 +914,25 @@ computed: {
 
 },
 methods: {
+  rewriteURI: function(uri){
+    if (!uri){ return false }
+    let returnUrls = useConfigStore().returnUrls
+
+    // use internal links for prodcution
+    if (returnUrls.dev || returnUrls.publicEndpoints){
+      uri = uri.replace('http://preprod.id.','https://id.')
+      uri = uri.replace('https://preprod-8230.id.loc.gov','https://id.loc.gov')
+      uri = uri.replace('https://test-8080.id.lctl.gov','https://id.loc.gov')
+      uri = uri.replace('https://preprod-8080.id.loc.gov','https://id.loc.gov')
+      uri = uri.replace('https://preprod-8288.id.loc.gov','https://id.loc.gov')
+    } else { // if it's not dev or public make sure we're using 8080
+      uri = uri.replace('https://id.loc.gov', 'https://preprod-8080.id.loc.gov')
+      uri = uri.replace('http://id.loc.gov', 'https://preprod-8080.id.loc.gov')
+    }
+
+
+    return uri
+  },
   hasOverFlow: function(element){
     let overflow = element.scrollHeight > element.clientHeight
     return overflow

--- a/src/lib/utils_rdf.js
+++ b/src/lib/utils_rdf.js
@@ -92,8 +92,6 @@ const utilsRDF = {
           }
       }
 
-
-
       // find a template name to use
       if (pt && pt.valueConstraint && pt.valueConstraint && pt.valueConstraint.valueTemplateRefs && pt.valueConstraint.valueTemplateRefs.length>0){
           let possibleTypes = []
@@ -247,6 +245,10 @@ const utilsRDF = {
     if (propertyURI==='http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
       return 'http://www.w3.org/2000/01/rdf-schema#Resource'
     }
+    // If a subject gets edited, we can end up here and it'll return "rdfs:Resource" instead of "bf:Topic"
+    if (propertyURI === 'http://id.loc.gov/ontologies/bibframe/subject'){
+      return 'http://id.loc.gov/ontologies/bibframe/Topic'
+    }
 
 
 
@@ -259,11 +261,6 @@ const utilsRDF = {
 
     let objProp = prop.getElementsByTagName("owl:ObjectProperty")
     let dataProp = prop.getElementsByTagName("owl:DatatypeProperty")
-
-
-
-
-
 
     // console.log("propXml",propXml)
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -18,7 +18,7 @@ export const useConfigStore = defineStore('config', {
         util  : 'http://localhost:9401/util/',
 
         // util  : 'http://localhost:5200/',
-        // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+        util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',
@@ -53,7 +53,7 @@ export const useConfigStore = defineStore('config', {
         // profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
 
 
-        
+
 
         id: 'https://id.loc.gov/',
         env : 'staging',

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5316,7 +5316,7 @@ export const useProfileStore = defineStore('profile', {
               for (let pName in this.profiles){
                 if (this.profiles[pName].rtOrder.includes(lookForTemplate)){
                   for (let p of this.profiles[pName].rt[lookForTemplate].ptOrder){
-                    let purl2 = utilsParse.namespaceUri(this.profiles[pName].rt[lookForTemplate].pt[p].propertyURI)                    
+                    let purl2 = utilsParse.namespaceUri(this.profiles[pName].rt[lookForTemplate].pt[p].propertyURI)
                     if (purl2 == property || purl2 == 'owl:sameAs'){
                       if (this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint && this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint.useValuesFrom && this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint.useValuesFrom.length>0){
                         return this.profiles[pName].rt[lookForTemplate].pt[p].valueConstraint.useValuesFrom[0]


### PR DESCRIPTION
Changes:
* When editing a subject, make sure the type is `bf:Topic`
* For production `view at id.loc.gov` links to `preprod-8080`

When editing a subject, the type was being set to `rdfs:Resource`