### PR TITLE
Fix Load Failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 
+## [1.2.14] - 2025-04-21
+### Fixed
+- Not being able to load resource without subjects
+
+
 ## [1.2.12] - 2025-04-18
 ### Fixed
 - Custom Order changing the order of fields when records are loaded in

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -2287,12 +2287,12 @@ const utilsParse = {
           subjects.push(subjUserValue)
           subjectOrder.push(pt)
           let source
-          if (subjUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://id.loc.gov/ontologies/bibframe/source']){
+          if (subjUserValue['http://id.loc.gov/ontologies/bibframe/subject'] && subjUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://id.loc.gov/ontologies/bibframe/source']){
             source = subjUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['http://id.loc.gov/ontologies/bibframe/source'][0]['@id']
             if (source == 'http://id.loc.gov/authorities/subjects'){
               source = 'lcsh'
             }
-          } else if (subjUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@id'].includes("id.loc.gov")){
+          } else if (subjUserValue['http://id.loc.gov/ontologies/bibframe/subject'] && subjUserValue['http://id.loc.gov/ontologies/bibframe/subject'][0]['@id'].includes("id.loc.gov")){
             source = "lcsh"
           } else {
             source = "unknown"

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 13,
+    versionPatch: 14,
 
 
     regionUrls: {


### PR DESCRIPTION
Fix: fail to load record with no subjects

This was caused by trying to groups subjects together, but there are no subjects in the resource.

