### PR TITLE
Add Subject Usage Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 
+## [1.2.15] - 2025-04-22
+### Added
+- Support for usage statistics from Suggest2
+
+
 ## [1.2.14] - 2025-04-21
 ### Fixed
 - Not being able to load resource without subjects

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -92,12 +92,13 @@
                   <!-- <button @click="searchModeSwitch('WORKS')" :data-tooltip="'Shortcut: CTRL+ALT+4'" :class="['simptip-position-bottom',{'active':(searchMode==='WORKS')}]">Works</button> -->
                   <button @click="searchModeSwitch('HUBS')" :data-tooltip="'Shortcut: CTRL+ALT+5'" :class="['simptip-position-bottom',{'active':(searchMode==='HUBS')}]">Hubs</button>
 
-                  | Sort:
-                  <select v-model="selectedSortOrder" @change="applySort">
-                    <option value="default">Select and option</option>
-                    <option value="alpha">Alpha</option>
-                    <option value="useageDesc">Highest Usage</option>
-                  </select>
+                  <template v-if="preferenceStore.returnValue('--b-edit-complex-include-usage')">
+                    | Sort:
+                    <select v-model="selectedSortOrder" @change="applySort">
+                      <option value="alpha">Alpha</option>
+                      <option value="useageDesc">Highest Usage</option>
+                    </select>
+                  </template>
                 </div>
 
 
@@ -135,7 +136,8 @@
                           <span> [LCNAF]</span>
                           <span v-if="name.collections">
                             {{ this.buildAddtionalInfo(name.collections) }}
-                            <span v-if="name.count && name.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(name.count, searchResults.names)}">{{ buildCount(name) }}</span>
+                            <!-- :style="{'background-color': setBackgroundColor(name.count, searchResults.names)}" -->
+                            <span v-if="name.count && name.count > 0" class="usage-count" >{{ buildCount(name) }}</span>
                           </span>
                           <div class="may-sub-container" style="display: inline;">
                             <AuthTypeIcon v-if="name.collections && name.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
@@ -150,7 +152,8 @@
                         {{subjectC.suggestLabel}}<span></span>
                         <span v-if="subjectC.collections">
                           {{ this.buildAddtionalInfo(subjectC.collections) }}
-                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsComplex)}">{{ buildCount(subjectC) }}</span>
+                          <!-- :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsComplex)}" -->
+                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count" >{{ buildCount(subjectC) }}</span>
                         </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subjectC.collections && subjectC.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
@@ -168,7 +171,8 @@
                         <span  v-if="subject.literal">[Literal]</span>
                         <span v-if="!subject.literal">
                           {{ this.buildAddtionalInfo(subject.collections) }}
-                          <span v-if="subject.count && subject.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subject.count, searchResults.subjectsSimple)}">{{ buildCount(subject) }}</span>
+                          <!-- :style="{'background-color': setBackgroundColor(subject.count, searchResults.subjectsSimple)}" -->
+                          <span v-if="subject.count && subject.count > 0" class="usage-count">{{ buildCount(subject) }}</span>
                         </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
@@ -184,7 +188,8 @@
                         {{subjectC.suggestLabel}}<span></span>
                         <span v-if="subjectC.collections">
                           {{ this.buildAddtionalInfo(subjectC.collections) }}
-                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsChildrenComplex)}">{{ buildCount(subjectC) }}</span>
+                          <!-- :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsChildrenComplex)}" -->
+                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count">{{ buildCount(subjectC) }}</span>
                         </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subjectC.collections && subjectC.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
@@ -198,7 +203,8 @@
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
                         <span v-if="!subject.literal">
                           {{ this.buildAddtionalInfo(subject.collections) }}
-                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsChildrenComplex)}">{{ buildCount(subjectC) }}</span>
+                          <!-- :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsChildrenComplex)}" -->
+                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count">{{ buildCount(subjectC) }}</span>
                         </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
@@ -778,8 +784,9 @@ li::before {
 }*/
 
 .usage-count {
-  color: white;
-  text-shadow: black 0px 0px 10px;
+  color: ;
+  /* color: white;
+  text-shadow: black 0px 0px 10px; */
 }
 
 </style>
@@ -932,22 +939,26 @@ data: function() {
       "languages","lcclasss","identifiers","broaders","gacs","collections",
       "sources", "subjects", "marcKeys"
     ],
-    selectedSortOrder: "alpha",
+    selectedSortOrder: ""
 
   }
 },
 
 computed: {
-
   ...mapStores(usePreferenceStore),
   ...mapState(usePreferenceStore, ['diacriticUseValues', 'diacriticUse','diacriticPacks']),
-
-
-
 },
 methods: {
+  /**
+   * Set the background color for the usage numbers. Based on 5 color heat map
+   * https://stackoverflow.com/questions/12875486/what-is-the-algorithm-to-create-colors-for-a-heatmap
+   *
+   * @param value - the value of the term that will create the color
+   * @param records - a list of records to get the min/max
+   *
+   * @return the CSS value for the background color
+   */
   setBackgroundColor: function(value, records){
-    // 5 color heatmap: https://stackoverflow.com/questions/12875486/what-is-the-algorithm-to-create-colors-for-a-heatmap
     let range =  records.map((r) => r.count).filter(n => n != undefined)
     let min = Math.min(...range)
     let max = Math.max(...range)
@@ -1743,6 +1754,10 @@ methods: {
         }
       // },100)
     })
+
+    if (that.preferenceStore.returnValue('--b-edit-complex-include-usage')){
+      that.applySort()
+    }
   }, 500),
 
   navStringClick: function(event){
@@ -3285,7 +3300,12 @@ created: function () {
 },
 
 before: function () {},
-mounted: function(){},
+mounted: function(){
+  if (this.preferenceStore.returnValue('--b-edit-complex-include-usage')){
+    this.selectedSortOrder = 'useageDesc'
+    this.applySort()
+  }
+},
 
 
 updated: function() {

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -120,7 +120,6 @@
                         <span v-if="subject.collections && subject.collections.includes('LCNAF')"> [LCNAF]</span>
                         <span v-if="subject.collections">
                           {{ this.buildAddtionalInfo(subject.collections) }}
-                          {{ buildCount(subject) }}
                         </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
@@ -134,7 +133,10 @@
                         <span v-if="name.suggestLabel && name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
                           <span v-else>{{name.suggestLabel}}</span>
                           <span> [LCNAF]</span>
-                          <span v-if="name.collections"> {{ this.buildAddtionalInfo(name.collections) }} {{ buildCount(name) }}</span>
+                          <span v-if="name.collections">
+                            {{ this.buildAddtionalInfo(name.collections) }}
+                            <span v-if="name.count && name.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(name.count, searchResults.names)}">{{ buildCount(name) }}</span>
+                          </span>
                           <div class="may-sub-container" style="display: inline;">
                             <AuthTypeIcon v-if="name.collections && name.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                           </div>
@@ -146,7 +148,10 @@
                       <span class="subject-results-heading">Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
-                        <span v-if="subjectC.collections"> {{ this.buildAddtionalInfo(subjectC.collections) }} {{ buildCount(subjectC) }}</span>
+                        <span v-if="subjectC.collections">
+                          {{ this.buildAddtionalInfo(subjectC.collections) }}
+                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsComplex)}">{{ buildCount(subjectC) }}</span>
+                        </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subjectC.collections && subjectC.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                         </div>
@@ -163,7 +168,7 @@
                         <span  v-if="subject.literal">[Literal]</span>
                         <span v-if="!subject.literal">
                           {{ this.buildAddtionalInfo(subject.collections) }}
-                          <span v-if="subject.count && subject.count > 0" class="usage-count">{{ buildCount(subject) }}</span>
+                          <span v-if="subject.count && subject.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subject.count, searchResults.subjectsSimple)}">{{ buildCount(subject) }}</span>
                         </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
@@ -177,7 +182,10 @@
                       <span class="subject-results-heading">CYAC Complex</span>
                       <div v-for="(subjectC,idx) in searchResults.subjectsChildrenComplex" @click="selectContext(idx)" @mouseover="loadContext(idx)" :data-id="idx" :key="subjectC.uri" :class="['fake-option', {'unselected':(pickPostion != idx), 'selected':(pickPostion == idx), 'picked': (pickLookup[idx] && pickLookup[idx].picked)}]">
                         {{subjectC.suggestLabel}}<span></span>
-                        <span v-if="subjectC.collections"> {{ this.buildAddtionalInfo(subjectC.collections) }} {{ buildCount(subjectC) }}</span>
+                        <span v-if="subjectC.collections">
+                          {{ this.buildAddtionalInfo(subjectC.collections) }}
+                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsChildrenComplex)}">{{ buildCount(subjectC) }}</span>
+                        </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subjectC.collections && subjectC.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                         </div>
@@ -188,7 +196,10 @@
                     <span class="subject-results-heading">CYAC Simple</span>
                       <div v-for="(subject,idx) in searchResults.subjectsChildren" @click="selectContext(searchResults.subjectsChildrenComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsChildrenComplex.length + idx)" :data-id="searchResults.subjectsChildrenComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsChildrenComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsChildrenComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsChildrenComplex.length + idx] && pickLookup[searchResults.subjectsChildrenComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >{{subject.suggestLabel}}<span  v-if="subject.literal">
                         {{subject.label}}</span> <span  v-if="subject.literal">[Literal]</span>
-                        <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }} {{ buildCount(subjectC) }}</span>
+                        <span v-if="!subject.literal">
+                          {{ this.buildAddtionalInfo(subject.collections) }}
+                          <span v-if="subjectC.count && subjectC.count > 0" class="usage-count" :style="{'background-color': setBackgroundColor(subjectC.count, searchResults.subjectsChildrenComplex)}">{{ buildCount(subjectC) }}</span>
+                        </span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                         </div>
@@ -767,11 +778,8 @@ li::before {
 }*/
 
 .usage-count {
-  /**
-  var h = (1.0 - value) * 240
-  return "hsl(" + h + ", 100%, 50%)";
-   */
-  background-color: blue;
+  color: white;
+  text-shadow: black 0px 0px 10px;
 }
 
 </style>
@@ -926,8 +934,6 @@ data: function() {
     ],
     selectedSortOrder: "alpha",
 
-
-
   }
 },
 
@@ -940,6 +946,17 @@ computed: {
 
 },
 methods: {
+  setBackgroundColor: function(value, records){
+    // 5 color heatmap: https://stackoverflow.com/questions/12875486/what-is-the-algorithm-to-create-colors-for-a-heatmap
+    let range =  records.map((r) => r.count).filter(n => n != undefined)
+    let min = Math.min(...range)
+    let max = Math.max(...range)
+
+    let normalizedValue = (value - min) / (max - min)
+
+    let h = (1.0 - normalizedValue) * 240
+    return "hsl(" + h + ", 100%, 50%)";
+  },
   rewriteURI: function(uri){
     if (!uri){ return false }
     let returnUrls = useConfigStore().returnUrls
@@ -1897,6 +1914,8 @@ methods: {
             return 0 //-1
           } else if ( a.count > b.count){
             return -1
+          } else if (a.count == 0 && b.count == 0){
+            return 0
           } else {
             return 1
           }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -153,7 +153,7 @@
                           {{subject.label}}
                         </span>
                         <span  v-if="subject.literal">[Literal]</span>
-                        <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }} {{ subject.count }}!!</span>
+                        <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }} [{{ subject.count }}]</span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                         </div>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -153,7 +153,7 @@
                           {{subject.label}}
                         </span>
                         <span  v-if="subject.literal">[Literal]</span>
-                        <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }}</span>
+                        <span v-if="!subject.literal"> {{ this.buildAddtionalInfo(subject.collections) }} {{ subject.count }}!!</span>
                         <div class="may-sub-container" style="display: inline;">
                           <AuthTypeIcon v-if="subject.collections && subject.collections.includes('http://id.loc.gov/authorities/subjects/collection_SubdivideGeographically')" :type="'may subd geog'"></AuthTypeIcon>
                         </div>

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -499,7 +499,8 @@ const utilsNetwork = {
                     total: r.count,
                     undifferentiated: false,
                     subdivision: searchPayload.subdivision ? true : false,
-                    count: Object.keys(hit).includes("subject-of") ? hit["subject-of"] : 0
+                    countSubj: Object.keys(hit).includes("subject-of") ? hit["subject-of"] : 0,
+                    countName: Object.keys(hit).includes("contributions") ? hit["contributions"] : 0
                   }
 
                   if (hitAdd.label=='' && hitAdd.suggestLabel.includes('DEPRECATED')){

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -445,9 +445,7 @@ const utilsNetwork = {
               urlTemplate[idx] = urlTemplate[idx].replace('q=?','q=')+'&searchtype=keyword'
             }
           }
-
         }
-
 
         let results = []
         for (let url of urlTemplate) {
@@ -462,6 +460,9 @@ const utilsNetwork = {
               url = url.replace('https://id.loc.gov', 'https://preprod-8080.id.loc.gov')
             }
 
+            if (usePreferenceStore().returnValue('--b-edit-complex-include-usage')){
+              url = url + "&usage=true"
+            }
 
             url = url + "&blastdacache=" + Date.now()
 
@@ -485,6 +486,7 @@ const utilsNetwork = {
                 // console.log("URL",url)
                 // console.log("r",r)
                 for (let hit of r.hits){
+                  console.info("hit: ", hit)
                   let hitAdd = {
                     collections: hit.more.collections ? hit.more.collections : [],
                     label: hit.aLabel,
@@ -496,7 +498,8 @@ const utilsNetwork = {
                     extra: hit.more,
                     total: r.count,
                     undifferentiated: false,
-                    subdivision: searchPayload.subdivision ? true : false
+                    subdivision: searchPayload.subdivision ? true : false,
+                    count: Object.keys(hit).includes("subject-of") ? hit["subject-of"] : 0
                   }
 
                   if (hitAdd.label=='' && hitAdd.suggestLabel.includes('DEPRECATED')){

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -486,7 +486,9 @@ const utilsNetwork = {
                 // console.log("URL",url)
                 // console.log("r",r)
                 for (let hit of r.hits){
-                  console.info("hit: ", hit)
+                  let countSubj = Object.keys(hit).includes("subject-of") ? hit["subject-of"] : 0
+                  let countName = Object.keys(hit).includes("contributions") ? hit["contributions"] : 0
+
                   let hitAdd = {
                     collections: hit.more.collections ? hit.more.collections : [],
                     label: hit.aLabel,
@@ -499,8 +501,7 @@ const utilsNetwork = {
                     total: r.count,
                     undifferentiated: false,
                     subdivision: searchPayload.subdivision ? true : false,
-                    countSubj: Object.keys(hit).includes("subject-of") ? hit["subject-of"] : 0,
-                    countName: Object.keys(hit).includes("contributions") ? hit["contributions"] : 0
+                    count: countSubj + countName
                   }
 
                   if (hitAdd.label=='' && hitAdd.suggestLabel.includes('DEPRECATED')){

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 14,
+    versionPatch: 15,
 
 
     regionUrls: {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -56,7 +56,7 @@ export const useConfigStore = defineStore('config', {
 
 
         id: 'https://id.loc.gov/',
-        env : 'staging',
+        env : 'production',
         dev: false,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1036,7 +1036,7 @@ export const usePreferenceStore = defineStore('preference', {
         step: 5,
       },
       '--b-edit-complex-include-usage' : {
-        desc: 'Include the usage numbers for subject headings.',
+        desc: 'Include the usage numbers for subject headings. This might increase search time.',
         descShort: 'Include Usage',
         value: false,
         type: 'boolean',

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1035,6 +1035,15 @@ export const usePreferenceStore = defineStore('preference', {
         range: [5, 100],
         step: 5,
       },
+      '--b-edit-complex-include-usage' : {
+        desc: 'Include the usage numbers for subject headings.',
+        descShort: 'Include Usage',
+        value: false,
+        type: 'boolean',
+        unit: null,
+        group: 'Complex Lookup',
+        range: [true,false]
+      },
 
       //general
       '--c-general-icon-instance-color' : {


### PR DESCRIPTION
Adds usage stats from `suggest2` to the results and the ability to sort based on this value.

This is an opt-in setting. Choosing to use it will set the sort order to `useage descending` by default but it adds a sort option that can be used to set the order to alphabetical.

The number of `subject-of` for a given term is to the right of the germ in square brackets.

![image](https://github.com/user-attachments/assets/0f17b9f1-d7db-4e64-a10d-d8aa87a4be4f)
