### PR TITLE
Fix issue with usage order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 
 ## [1.2.15] - 2025-04-22
+### Fix
+- Issue with usage sorting selecting the wrong entry
+
+### Changed
+- Move `Hub` left of `Works` in lookups
+
 ### Added
 - Support for usage statistics from Suggest2
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1537,6 +1537,39 @@ methods: {
     this.$refs.subjectInput.focus()
   },
 
+  /**
+   * Build the pick lookup so we can adjust the sorting here.
+   *
+   * Without rebuilding the picklookup list, selectiong will be off.
+   * We do it here so that we can adjust the current search results without
+   * needing to do another search.
+   *
+   */
+  buildPickLookup: function(){
+    for (let x in this.searchResults.subjectsComplex){
+      this.pickLookup[x] = this.searchResults.subjectsComplex[x]
+    }
+
+    for (let x in this.searchResults.subjectsChildrenComplex){
+      this.pickLookup[x] = this.searchResults.subjectsChildrenComplex[x]
+    }
+
+    for (let x in this.searchResults.subjectsSimple){
+      this.pickLookup[parseInt(x)+parseInt(this.searchResults.subjectsComplex.length)] = this.searchResults.subjectsSimple[x]
+    }
+
+    for (let x in this.searchResults.subjectsChildren){
+      this.pickLookup[parseInt(x)+parseInt(this.searchResults.subjectsChildrenComplex.length)] = this.searchResults.subjectsChildren[x]
+    }
+
+    for (let x in this.searchResults.names){
+      this.pickLookup[(this.searchResults.names.length - x)*-1] = this.searchResults.names[x]
+    }
+
+    for (let x in this.searchResults.exact){
+      this.pickLookup[(this.searchResults.names.length - x)*-1-2] = this.searchResults.exact[x]
+    }
+  },
 
   // some context messing here, pass the debounce func a ref to the vue "this" as that to ref in the function callback
   searchApis: debounce(async (searchString, searchStringFull, that) => {
@@ -1658,29 +1691,32 @@ methods: {
 
     that.pickPostion = that.searchResults.subjectsSimple.length + that.searchResults.subjectsComplex.length -1
 
-    for (let x in that.searchResults.subjectsComplex){
-      that.pickLookup[x] = that.searchResults.subjectsComplex[x]
-    }
+    // sort? searchResults
+    that.buildPickLookup()
 
-    for (let x in that.searchResults.subjectsChildrenComplex){
-      that.pickLookup[x] = that.searchResults.subjectsChildrenComplex[x]
-    }
+    // for (let x in that.searchResults.subjectsComplex){
+    //   that.pickLookup[x] = that.searchResults.subjectsComplex[x]
+    // }
 
-    for (let x in that.searchResults.subjectsSimple){
-      that.pickLookup[parseInt(x)+parseInt(that.searchResults.subjectsComplex.length)] = that.searchResults.subjectsSimple[x]
-    }
+    // for (let x in that.searchResults.subjectsChildrenComplex){
+    //   that.pickLookup[x] = that.searchResults.subjectsChildrenComplex[x]
+    // }
 
-    for (let x in that.searchResults.subjectsChildren){
-      that.pickLookup[parseInt(x)+parseInt(that.searchResults.subjectsChildrenComplex.length)] = that.searchResults.subjectsChildren[x]
-    }
+    // for (let x in that.searchResults.subjectsSimple){
+    //   that.pickLookup[parseInt(x)+parseInt(that.searchResults.subjectsComplex.length)] = that.searchResults.subjectsSimple[x]
+    // }
 
-    for (let x in that.searchResults.names){
-      that.pickLookup[(that.searchResults.names.length - x)*-1] = that.searchResults.names[x]
-    }
+    // for (let x in that.searchResults.subjectsChildren){
+    //   that.pickLookup[parseInt(x)+parseInt(that.searchResults.subjectsChildrenComplex.length)] = that.searchResults.subjectsChildren[x]
+    // }
 
-    for (let x in that.searchResults.exact){
-      that.pickLookup[(that.searchResults.names.length - x)*-1-2] = that.searchResults.exact[x]
-    }
+    // for (let x in that.searchResults.names){
+    //   that.pickLookup[(that.searchResults.names.length - x)*-1] = that.searchResults.names[x]
+    // }
+
+    // for (let x in that.searchResults.exact){
+    //   that.pickLookup[(that.searchResults.names.length - x)*-1-2] = that.searchResults.exact[x]
+    // }
 
     for (let k in that.pickLookup){
       that.pickLookup[k].picked = false
@@ -1921,6 +1957,8 @@ methods: {
           }
         })
 
+        this.buildPickLookup()
+
       } else if (typeSort == 'useageDesc'){
         this.searchResults[r] = records.sort((a,b) => {
           if (a.count === undefined){
@@ -1935,9 +1973,11 @@ methods: {
             return 1
           }
         })
-      }
-    }
 
+        this.buildPickLookup()
+      }
+
+    }
   },
 
   buildCount: function(subject){

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1691,32 +1691,7 @@ methods: {
 
     that.pickPostion = that.searchResults.subjectsSimple.length + that.searchResults.subjectsComplex.length -1
 
-    // sort? searchResults
     that.buildPickLookup()
-
-    // for (let x in that.searchResults.subjectsComplex){
-    //   that.pickLookup[x] = that.searchResults.subjectsComplex[x]
-    // }
-
-    // for (let x in that.searchResults.subjectsChildrenComplex){
-    //   that.pickLookup[x] = that.searchResults.subjectsChildrenComplex[x]
-    // }
-
-    // for (let x in that.searchResults.subjectsSimple){
-    //   that.pickLookup[parseInt(x)+parseInt(that.searchResults.subjectsComplex.length)] = that.searchResults.subjectsSimple[x]
-    // }
-
-    // for (let x in that.searchResults.subjectsChildren){
-    //   that.pickLookup[parseInt(x)+parseInt(that.searchResults.subjectsChildrenComplex.length)] = that.searchResults.subjectsChildren[x]
-    // }
-
-    // for (let x in that.searchResults.names){
-    //   that.pickLookup[(that.searchResults.names.length - x)*-1] = that.searchResults.names[x]
-    // }
-
-    // for (let x in that.searchResults.exact){
-    //   that.pickLookup[(that.searchResults.names.length - x)*-1-2] = that.searchResults.exact[x]
-    // }
 
     for (let k in that.pickLookup){
       that.pickLookup[k].picked = false

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -561,20 +561,19 @@ export const useConfigStore = defineStore('config', {
 
     "https://preprod-8230.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-        "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'", "all":true},
         "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
         "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'"},
+        "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>&searchtype='keyword'", "all":true},
       }
     ]},
 
     "https://preprod-8088.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-        "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
         "Hubs - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
         "Hubs - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
-
+        "Works - Left Anchored":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Keyword":{"url":"https://preprod-8080.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
       }
     ]},
 
@@ -583,29 +582,31 @@ export const useConfigStore = defineStore('config', {
 
     "https://preprod-8295.id.loc.gov/resources/works" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
         "Hubs - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
         "Hubs - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
+
       }
     ]},
 
     "https://preprod-8210.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
         "Hubs - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
         "Hubs - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
+
       }
     ]},
 
 
     "https://preprod-8295.id.loc.gov/resources/works/" : {"name":"Works", "processor" : 'lcAuthorities', "type":"complex", "modes":[
       {
-        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
         "Hubs - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
         "Hubs - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/hubs/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Left Anchored":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+        "Works - Keyword":{"url":"https://preprod-8295.id.loc.gov/resources/works/suggest2/?q=?<QUERY>&count=25&offset=<OFFSET>", "all":true},
       }
     ]},
 


### PR DESCRIPTION
The results were reordered, but the underlying structure was unchanged. The result was that the user could get the wrong result. Now the underlying structure should change to match the sort.

Also reorder hub/works in the lookups.