### PR TITLE
Improve Reaching the Last Page Before Expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Move `Hub` left of `Works` in lookups
+- How pagination deals with getting no results
 
 ### Added
 - Support for usage statistics from Suggest2

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -305,7 +305,7 @@
               offset = 0
               this.currentPage--
               this.doSearch()
-              alert("This is the end. The other pages are just an illusion. Going back 1 page.")
+              alert("Other pages are just an illusion. This is the end.")
             }
           }, 100)
         } else {

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -279,7 +279,7 @@
             }
           })
 
-          // wrapping this in setTimeout might not be needed anymore
+        // wrapping this in setTimeout might not be needed anymore
         if (searchPayload.type == 'complex'){
           this.searchTimeout = window.setTimeout(async ()=>{
             this.activeComplexSearchInProgress = true
@@ -298,6 +298,15 @@
 
             this.activeComplexSearchInProgress = false
             this.initalSearchState =false
+
+            if (this.activeComplexSearch.length == 0 && offset > 0){
+              // reset offset, set the page back one
+              // this can happen because the "total" given from the suggest service reflects the number before deduping.
+              offset = 0
+              this.currentPage--
+              this.doSearch()
+              alert("This is the end. The other pages are just an illusion. Going back 1 page.")
+            }
           }, 100)
         } else {
           let filter = function(obj, target){

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -18,7 +18,7 @@ export const useConfigStore = defineStore('config', {
         util  : 'http://localhost:9401/util/',
 
         // util  : 'http://localhost:5200/',
-        // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+        util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',


### PR DESCRIPTION
The pagination depends on the number of `total` results that `suggest2` says it found. But sometimes this number can be misleading. The number is based on the number of results prior to deduping. The result can be that Marva says there are `5` pages, but there are really only `3`. 

If Marva doesn't have any hits, the search could become unusable because the offset/page get set too far, but also the page navigation will disappear. Instead, if there are no results and the offset is > 0, the user will be sent back to the previous page.

Page 4 of `euripides. medea` has the following results. Starting at `75` with a total of `102` results would suggest that there are results, but `hits` is `0`.

```json
{
  "q": "euripides. medea*",
  "count": 102,
  "pagesize": 25,
  "start": 75,
  "sortmethod": "alpha",
  "searchtype": "left-anchored",
  "directory": "/resources/hubs/",
  "hits": []
}
```