### PR TITLE
Less cryptic message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 
+## [1.2.16] - 2025-04-23
+### Changed
+- Final page message is less cryptic
+
+
 ## [1.2.15] - 2025-04-22
 ### Fix
 - Issue with usage sorting selecting the wrong entry

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -305,7 +305,7 @@
               offset = 0
               this.currentPage--
               this.doSearch()
-              alert("Other pages are just an illusion. This is the end.")
+              alert("You've reached last page with results. The other pages are empty.")
             }
           }, 100)
         } else {

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1682,7 +1682,7 @@ const utilsExport = {
 		}
 	}
 	let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)
-	// console.info("strXmlBasic: ", strXmlBasic)
+	console.info("strXmlBasic: ", strXmlBasic)
 	return {
 		xmlDom: rdf,
 		xmlStringFormatted: strXmlFormatted,

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 15,
+    versionPatch: 16,
 
 
     regionUrls: {


### PR DESCRIPTION
Make the message when "Next page" would return empty results clearer.

`Other pages are just an illusion. This is the end.` > `You've reached last page with results. The other pages are empty.`