### PR TITLE
Change Hub order in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [1.2.16] - 2025-04-23
 ### Changed
 - Final page message is less cryptic
+- Order of Hubs in subject search
 
 
 ## [1.2.15] - 2025-04-22

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1043,7 +1043,8 @@
                       Searching...
                     </option>
                     <template v-if="!isSimpleLookup()">
-                      <option v-for="(r,idx) in activeComplexSearch.sort((a,b) => (a.label > b.label ? 1 : (a.label < b.label) ? -1 : 0))" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
+                      <!-- .sort((a,b) => (a.label > b.label ? 1 : (a.label < b.label) ? -1 : 0)) -->
+                      <option v-for="(r,idx) in activeComplexSearch" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
                         <div class="option-text">
                           <span v-html="generateLabel(r)"></span>
                         </div>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1044,7 +1044,7 @@
                     </option>
                     <template v-if="!isSimpleLookup()">
                       <!-- .sort((a,b) => (a.label > b.label ? 1 : (a.label < b.label) ? -1 : 0)) -->
-                      <option v-for="(r,idx) in activeComplexSearch" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
+                      <option v-for="(r,idx) in activeComplexSearch.sort((a,b) => (a.label > b.label ? 1 : (a.label < b.label) ? -1 : 0))" :data-label="r.label" :value="r.uri" v-bind:key="idx" :style="(r.depreciated || r.undifferentiated) ? 'color:red' : ''" class="complex-lookup-result">
                         <div class="option-text">
                           <span v-html="generateLabel(r)"></span>
                         </div>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1768,6 +1768,9 @@ methods: {
 
     if (that.preferenceStore.returnValue('--b-edit-complex-include-usage')){
       that.applySort()
+    } else {
+      that.selectedSortOrder = 'alpha'
+      that.applySort()
     }
   }, 500),
 
@@ -3324,6 +3327,7 @@ mounted: function(){
     this.selectedSortOrder = 'useageDesc'
     this.applySort()
   } else {
+    console.info("mounted: sort")
     this.selectedSortOrder = 'alpha'
     this.applySort()
   }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -164,7 +164,7 @@
                     <div v-if="searchResults && searchResults.subjectsSimple.length>0" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">Simple</span>
                       <div v-for="(subject,idx) in searchResults.subjectsSimple" @click="selectContext(searchResults.subjectsComplex.length + idx)" @mouseover="loadContext(searchResults.subjectsComplex.length + idx)" :data-id="searchResults.subjectsComplex.length + idx" :key="subject.uri" :class="['fake-option', {'unselected':(pickPostion != searchResults.subjectsComplex.length + idx ), 'selected':(pickPostion == searchResults.subjectsComplex.length + idx ), 'picked': (pickLookup[searchResults.subjectsComplex.length + idx] && pickLookup[searchResults.subjectsComplex.length + idx].picked), 'literal-option':(subject.literal)}]" >
-                      {{subject.suggestLabel}}
+                        {{ subject.suggestLabel }}
                         <span  v-if="subject.literal">
                           {{subject.label}}
                         </span>
@@ -1667,12 +1667,12 @@ methods: {
     if (that.searchMode == 'WORKS' || that.searchMode == 'HUBS'){
       for (let s of that.searchResults.subjectsSimple){
         if (s.suggestLabel && s.suggestLabel.includes(' (USE ')){
-          s.suggestLabel = s.label
+          s.suggestLabel = s.label + " (USE FOR " + s.vlabel + ")"
         }
       }
       for (let s of that.searchResults.subjectsComplex){
         if (s.suggestLabel && s.suggestLabel.includes(' (USE ')){
-          s.suggestLabel = s.label
+          s.suggestLabel = s.label + " (USE FOR " + s.vlabel + ")"
         }
       }
     }
@@ -1916,6 +1916,10 @@ methods: {
 
   applySort: function(){
     let typeSort = this.selectedSortOrder
+
+    if (this.searchMode == 'WORKS' || this.searchMode == 'HUBS'){
+      typeSort = 'alpha'
+    }
 
     for (let r in this.searchResults){
       let records = this.searchResults[r]
@@ -3318,6 +3322,9 @@ before: function () {},
 mounted: function(){
   if (this.preferenceStore.returnValue('--b-edit-complex-include-usage')){
     this.selectedSortOrder = 'useageDesc'
+    this.applySort()
+  } else {
+    this.selectedSortOrder = 'alpha'
     this.applySort()
   }
 },

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -3327,7 +3327,6 @@ mounted: function(){
     this.selectedSortOrder = 'useageDesc'
     this.applySort()
   } else {
-    console.info("mounted: sort")
     this.selectedSortOrder = 'alpha'
     this.applySort()
   }

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2364,8 +2364,8 @@ const utilsNetwork = {
       let subjectUrlTemporal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_TemporalSubdivisions'
       let subjectUrlGenre = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=5').replace("<OFFSET>", "1")+'&rdftype=GenreForm'
 
-      let subjectUrlComplexSubdivison1 = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',  encodeURIComponent(complexSub[0])).replace('&count=25','&count='+numResultsComplex/3).replace("<OFFSET>", "1")+'&rdftype=ComplexType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
-      let subjectUrlComplexSubdivison2 = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',  encodeURIComponent(complexSub[1])).replace('&count=25','&count='+numResultsComplex/3).replace("<OFFSET>", "1")+'&rdftype=ComplexType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+      let subjectUrlComplexSubdivison1 = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',  encodeURIComponent(complexSub[0])).replace('&count=25','&count='+Math.ceil(numResultsComplex/3)).replace("<OFFSET>", "1")+'&rdftype=ComplexType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
+      let subjectUrlComplexSubdivison2 = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',  encodeURIComponent(complexSub[1])).replace('&count=25','&count='+Math.ceil(numResultsComplex/3)).replace("<OFFSET>", "1")+'&rdftype=ComplexType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
       let subjectUrlComplexSubdivison3 = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>', searchVal).replace('&count=25','&count='+numResultsComplex/3).replace("<OFFSET>", "1")+'&rdftype=ComplexType&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
       // let worksUrlKeyword = useConfigStore().lookupConfig['https://preprod-8080.id.loc.gov/resources/works'].modes[0]['Works - Keyword'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsSimple).replace("<OFFSET>", "1")
@@ -2707,7 +2707,7 @@ const utilsNetwork = {
       if (mode == "HUBS"){
         // over write the subjects if we are doing a work search
         resultsSubjectsSimple = resultsHubsAnchored
-        resultsSubjectsComplex = resultsHubsKeyword
+        resultsSubjectsComplex = [] //resultsHubsKeyword
       }
 
       //determine position of search and set results accordingly


### PR DESCRIPTION
The results of `subject components` no longer has the `complex` results which were keyword based.

There is greater pairity between the results of the `subject components` & `Hub as subject` searches.

Some changes related to the sort order for Hubs. It'll always be `alpha` because there's no useage statistics for them.