### PR TITLE
Rare Materials Dual LCGFT/RBMS Lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 
+## [1.2.18] - 2025-04-28
+### Added
+- Manual override for RBMS to support dual LCGFT/RBMS lookup
+
+
+
 ## [1.2.16] - 2025-04-23
 ### Changed
 - Final page message is less cryptic

--- a/src/components/panels/edit/fields/Main.vue
+++ b/src/components/panels/edit/fields/Main.vue
@@ -38,7 +38,7 @@
       :level="level+1"
       :structure="structure"
       :guid="guid"
-      :readOnly="readOnly"       
+      :readOnly="readOnly"
     />
 
     <!-- {{structure}} -->
@@ -212,9 +212,6 @@ export default {
         }
       })
       return type
-
-
-
     },
 
     returnBackgroundColor(){

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -88,7 +88,6 @@ export default {
 
 
     thisRtTemplate(){
-      console.info("thisRtTemplate")
       if (this.manualOverride !== null){
         for (let tmpid of this.structure.valueConstraint.valueTemplateRefs){
           console.log('tmpid',tmpid)
@@ -103,9 +102,6 @@ export default {
 
       // // grab the first component from the struecture, but there might be mutluple ones
       let useId = this.structure.valueConstraint.valueTemplateRefs[0]
-
-      console.info("\n\nuseId: ", useId)
-      console.info("\tstructure: ", this.structure)
 
       let foundBetter = false
 
@@ -122,19 +118,12 @@ export default {
       if (userValue['@type']){
         // loop thrugh all the refs and see if there is a URI that matches it better
         this.structure.valueConstraint.valueTemplateRefs.forEach((tmpid)=>{
-          console.info("tmpid: ", tmpid, "--", foundBetter)
           //if tmpid is 'lc:RT:bf2:Agents:Contribution', need to look somehwere else
           if (foundBetter) return false
 
-          console.info("\tLookup[tmpid]: ", this.rtLookup[tmpid] )
-          console.info("\tuserValue: ", userValue)
-
           let selection = this.structure['@guid']+'-select'
-          console.info("selection: ", selection)
-
           if (tmpid == "lc:RT:bf2:Agents:Contribution"){
           } else if (this.structure.id != this.rtLookup[tmpid].id && this.rtLookup[tmpid].resourceURI === userValue['@type']){
-            console.info("\t### Found better: ", tmpid)
             useId = tmpid
             foundBetter = true
           }
@@ -178,9 +167,6 @@ export default {
         for (let idx in this.structure.valueConstraint.valueTemplateRefs){
           let template = this.structure.valueConstraint.valueTemplateRefs[idx]
 
-          console.info("\ttemplate: ", template)
-          console.info("\tparentUserValue: ", parentUserValue)
-
           if (parentUserValue && parentUserValue["@root"] == "http://id.loc.gov/ontologies/bibframe/contribution" && parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"]){
             let target = parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"][0]["http://id.loc.gov/ontologies/bibframe/agent"]
             if (target){
@@ -207,7 +193,6 @@ export default {
         if (this.rtLookup[useId]){
           let use = JSON.parse(JSON.stringify(this.rtLookup[useId]))
 
-          console.info("use: ", use)
           return use
           // this.multiTemplateSelect = use.resourceLabel
           // this.multiTemplateSelectURI = useId
@@ -297,7 +282,6 @@ export default {
   methods: {
 
     templateChange(event){
-      console.info("templateChange: ", event.target.value)
       let nextRef = this.allRtTemplate.filter((v)=>{ return (v.id === event.target.value) })[0]
       let thisRef = this.thisRtTemplate
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -88,6 +88,7 @@ export default {
 
 
     thisRtTemplate(){
+      console.info("thisRtTemplate")
       if (this.manualOverride !== null){
         for (let tmpid of this.structure.valueConstraint.valueTemplateRefs){
           console.log('tmpid',tmpid)
@@ -102,6 +103,10 @@ export default {
 
       // // grab the first component from the struecture, but there might be mutluple ones
       let useId = this.structure.valueConstraint.valueTemplateRefs[0]
+
+      console.info("\n\nuseId: ", useId)
+      console.info("\tstructure: ", this.structure)
+
       let foundBetter = false
 
       let userValue = this.structure.userValue
@@ -111,14 +116,25 @@ export default {
         userValue = this.structure.userValue[this.structure.propertyURI][0]
       }
 
+      //TODO: for RBMS, where the URI is the same as Genre/Form, it'll always use G/F. Get it to not do this
+
       // do we have user data and a possible @type to use
       if (userValue['@type']){
         // loop thrugh all the refs and see if there is a URI that matches it better
         this.structure.valueConstraint.valueTemplateRefs.forEach((tmpid)=>{
+          console.info("tmpid: ", tmpid, "--", foundBetter)
           //if tmpid is 'lc:RT:bf2:Agents:Contribution', need to look somehwere else
           if (foundBetter) return false
+
+          console.info("\tLookup[tmpid]: ", this.rtLookup[tmpid] )
+          console.info("\tuserValue: ", userValue)
+
+          let selection = this.structure['@guid']+'-select'
+          console.info("selection: ", selection)
+
           if (tmpid == "lc:RT:bf2:Agents:Contribution"){
           } else if (this.structure.id != this.rtLookup[tmpid].id && this.rtLookup[tmpid].resourceURI === userValue['@type']){
+            console.info("\t### Found better: ", tmpid)
             useId = tmpid
             foundBetter = true
           }
@@ -161,6 +177,10 @@ export default {
 
         for (let idx in this.structure.valueConstraint.valueTemplateRefs){
           let template = this.structure.valueConstraint.valueTemplateRefs[idx]
+
+          console.info("\ttemplate: ", template)
+          console.info("\tparentUserValue: ", parentUserValue)
+
           if (parentUserValue && parentUserValue["@root"] == "http://id.loc.gov/ontologies/bibframe/contribution" && parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"]){
             let target = parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"][0]["http://id.loc.gov/ontologies/bibframe/agent"]
             if (target){
@@ -171,7 +191,7 @@ export default {
                 useId = typeMap[type]
               }
             } else { //there's no user agent
-            let target = parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"]
+              let target = parentUserValue["http://id.loc.gov/ontologies/bibframe/contribution"]
               let type = target[0]["@type"]
               if (type && this.rtLookup[template].resourceURI === type){
                 useId = template
@@ -187,6 +207,7 @@ export default {
         if (this.rtLookup[useId]){
           let use = JSON.parse(JSON.stringify(this.rtLookup[useId]))
 
+          console.info("use: ", use)
           return use
           // this.multiTemplateSelect = use.resourceLabel
           // this.multiTemplateSelectURI = useId
@@ -276,12 +297,15 @@ export default {
   methods: {
 
     templateChange(event){
+      console.info("templateChange: ", event.target.value)
       let nextRef = this.allRtTemplate.filter((v)=>{ return (v.id === event.target.value) })[0]
       let thisRef = this.thisRtTemplate
 
       //If the selection is for Children's Subjects, use manual override
       if(nextRef.id == "lc:RT:bf2:Topic:Childrens:Components"){
         this.manualOverride = "lc:RT:bf2:Topic:Childrens:Components"
+      } else if (nextRef.id == 'lc:RT:bf2:RareMat:RBMS'){
+        this.manualOverride = "lc:RT:bf2:RareMat:RBMS"
       } else {
         this.manualOverride = null
       }

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1684,7 +1684,9 @@ const utilsExport = {
 		}
 	}
 	let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)
-	console.info("strXmlBasic: ", strXmlBasic)
+
+	// console.info("strXmlBasic: ", strXmlBasic)
+
 	return {
 		xmlDom: rdf,
 		xmlStringFormatted: strXmlFormatted,

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -42,16 +42,16 @@ export const useConfigStore = defineStore('config', {
         // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
 
         // offical prod profiles that work outside firewall
-        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
-        starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
+        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
+        // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
         // offical stage profiles inside the firewall
         // starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
         // profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
 
         // offical prod profiles inside the firewall
-        // starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
-        // profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
+        starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
+        profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
 
 
 


### PR DESCRIPTION
This supports a dual lookup for the rare materials profile for the genre/form to include LCGFT/RBMS.

In the profile, these 2 source have the same Resource URI. Marva couldn't distinguish between them because they look the same and so the dropdown menu wouldn't change the loaded template. But now there's a manual override when the new ref is `lc:RT:bf2:RareMat:RBMS` that will get it to find the correct template.

Changing the profile has implications for how the XML will be created.