### PR TITLE
add 667 option, remove provisional from label, fix preview typo

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -766,10 +766,8 @@
       },
 
       displayProvisonalNAR(){
-        return true
-        if (!this.preferenceStore.isNarTester()){
-          return false
-        }
+
+        
         if (this.structure && this.structure.valueConstraint && this.structure.valueConstraint.useValuesFrom && this.structure.valueConstraint.useValuesFrom.length>0 && this.structure.valueConstraint.useValuesFrom.join(' ').indexOf('id.loc.gov/authorities/names')>-1){
           return true
         }
@@ -1031,7 +1029,7 @@
               <button @click="forceSearch()">Search</button>
 
               <!-- REMOVE v-if BEFORE PROD USAGE -->
-              <button @click="loadNacoStubModal" style="float: right;" v-if="displayProvisonalNAR() == true">Create Provisional NAR</button>
+              <button @click="loadNacoStubModal" style="float: right;" v-if="displayProvisonalNAR() == true">Create NAR</button>
 
               <hr style="margin-top: 5px;">
               <div>

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -88,6 +88,8 @@
         showPreview: false,
 
 
+        add667: false,
+
 
         scriptShifterOptions: {},
 
@@ -163,7 +165,7 @@
             note = this.mainTitleNote
           }
 
-          let results = await this.profileStore.buildNacoStub(this.oneXXParts,this.fourXXParts, this.mainTitle, this.instanceURI, this.mainTitleDate, this.mainTitleLccn, note, this.zero46)
+          let results = await this.profileStore.buildNacoStub(this.oneXXParts,this.fourXXParts, this.mainTitle, this.instanceURI, this.mainTitleDate, this.mainTitleLccn, note, this.zero46,this.add667)
 
           this.MARCXml = results.xml
           this.MARCText = results.text
@@ -387,6 +389,23 @@
               
             }
 
+            if (dollarKey.a){
+              if (/[A-Z][a-z]+\-[A-Z][a-z]+/.test(dollarKey.a)){
+               console.log("found a hyphenated name")
+               if (dollarKey.a.split(',')[0]){
+                let hyphenated = dollarKey.a.split(',')[0].split('-')
+                console.log(hyphenated)
+               }
+               
+
+               
+              }
+          
+
+            }
+
+
+
 
 
           }else{
@@ -488,7 +507,15 @@
             }
 
 
+            if (this.fourXXParts && this.fourXXParts.a){
+              if (this.profileStore.isLatin(this.fourXXParts.a) === false){
+                this.add667 = true
+              }else if (this.profileStore.isLatin(this.fourXXParts.a) === true){
+                this.add667 = false
+              }
 
+            }
+            
 
 
           }else{
@@ -1272,8 +1299,16 @@
                   <template v-if="zero46 && Object.keys(zero46).length>0">
                     <div class="selectable" style="font-family: monospace; background-color: whitesmoke;">046  {{ (zero46.f) ? ("$f" + zero46.f) : "" }}{{ (zero46.g) ? ("$g" + zero46.g) : "" }}$2edtf</div>
                   </template>
-                    
+                  
+                  <div class="selectable" style="font-family: monospace;"> 
 
+                    <input type="checkbox" v-model="add667" id="add-667"/>
+                    <label for="add-667" style="vertical-align: super; padding-left: 1em;">Add 667 Note</label>
+
+                  </div>
+
+
+                  
 
                 </div>
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2060,7 +2060,7 @@ const utilsExport = {
 		return marcTxt
 	},
 
-	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46){
+	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667){
 		let marcTxt = ''
 		marcTxt = marcTxt + "111111111122222222223333333333\n"
 		marcTxt = marcTxt + "       123456789012345678901234567890123456789\n"
@@ -2089,7 +2089,7 @@ const utilsExport = {
 
 		let pos29 = "n"
 		// did they make a 4xx
-		if (fourXXParts && fourXXParts.a){
+		if (fourXXParts && fourXXParts.a && add667){
 			pos29 = 'b'
 		}
 
@@ -2168,7 +2168,7 @@ const utilsExport = {
 		field040c.innerHTML = 'DLC'
 		field040.appendChild(field040c)
 
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('040',' ',' ',[`$a DLC`, `$b ebg`, `$e rda`, `$c DLC`])
+		marcTxt =  marcTxt+ this.buildMarcTxtLine('040',' ',' ',[`$a DLC`, `$b eng`, `$e rda`, `$c DLC`])
 
 
 		rootEl.appendChild(field040)

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 17,
+    versionPatch: 19,
 
 
 
@@ -19,7 +19,7 @@ export const useConfigStore = defineStore('config', {
         util  : 'http://localhost:9401/util/',
 
         // util  : 'http://localhost:5200/',
-        util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+        // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5614,10 +5614,10 @@ export const useProfileStore = defineStore('profile', {
       * @param {string} langObj - {uri:"",label:""}
       * @return {String}
       */
-    async buildNacoStub(oneXX,fourXX,mainTitle,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46){
+    async buildNacoStub(oneXX,fourXX,mainTitle,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667){
       console.log(oneXX,fourXX,mainTitle,workURI,zero46)
       let lccn = await utilsNetwork.nacoLccn()
-      let NARData = await utilsExport.createNacoStubXML(oneXX,fourXX,mainTitle,lccn,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46)
+      let NARData = await utilsExport.createNacoStubXML(oneXX,fourXX,mainTitle,lccn,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667)
       NARData.lccn = lccn
       return NARData
     },
@@ -6324,9 +6324,18 @@ export const useProfileStore = defineStore('profile', {
     reorderAllNonLatinLiterals(){
       this.activeProfile = utilsParse.reorderAllNonLatinLiterals(this.activeProfile)
 
+    },
+
+    /**
+     * Tests if the passed string contains only Latin characters or includes non-Latin characters.
+     *
+     * @param {string} inputString - The string to test.
+     * @returns {boolean} - True if the string contains only Latin characters, false otherwise.
+     */
+    isLatin(inputString) {
+      // Regex to match common Latin characters, numbers, punctuation, and extended Latin ranges.      
+      return latinRegex.test(inputString);
     }
-
-
 
 
 


### PR DESCRIPTION
Now an option to trigger 667 creation based on non-latin regex test, but can override. Fixed other small labels/typos issues.