### PR TITLE
Add RDA indicator for Hub lookup

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -168,6 +168,20 @@
         }
         return true
       },
+
+      checkFromRda: function(data){
+        let notes = data.extra.notes || []
+        let isRda = false
+
+        for (let note of notes){
+          if (note.includes("$erda")){
+            isRda = true
+          }
+        }
+
+        return isRda
+      },
+
       checkFromAuth: function(data){
         let notes = data.extra.notes || []
         let identifiers = data.extra.identifiers || []
@@ -784,7 +798,7 @@
 
       displayProvisonalNAR(){
 
-        
+
         if (this.structure && this.structure.valueConstraint && this.structure.valueConstraint.useValuesFrom && this.structure.valueConstraint.useValuesFrom.length>0 && this.structure.valueConstraint.useValuesFrom.join(' ').indexOf('id.loc.gov/authorities/names')>-1){
           return true
         }
@@ -1063,6 +1077,7 @@
                         <div :class="['option-text', {unusable: !checkUsable(r)}]">
                           <span v-html="generateLabel(r)"></span>
                           <span v-if="checkFromAuth(r)" class="from-auth"> (Auth)</span>
+                          <span v-if="checkFromRda(r)" class="from-rda"> [RDA]</span>
                         </div>
                       </option>
                     </template>
@@ -1482,6 +1497,7 @@
   font-weight: bold;
 }
 
+.from-rda,
 .from-auth {
   font-weight: bold;
 }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -172,6 +172,7 @@
                         <span v-if="!subject.literal">
                           {{ this.buildAddtionalInfo(subject.collections) }}
                           <span class="from-auth" v-if="checkFromAuth(subject)"> (Auth)</span>
+                          <span class="from-rda" v-if="checkFromRda(subject)"> [RDA]</span>
                           <!-- :style="{'background-color': setBackgroundColor(subject.count, searchResults.subjectsSimple)}" -->
                           <span v-if="subject.count && subject.count > 0" class="usage-count">{{ buildCount(subject) }}</span>
                         </span>
@@ -793,6 +794,7 @@ li::before {
   text-shadow: black 0px 0px 10px; */
 }
 
+.from-rda,
 .from-auth {
   font-weight: bold;
 }
@@ -967,6 +969,18 @@ methods: {
       return false
     }
     return true
+  },
+  checkFromRda: function(data){
+    let notes = data.extra.notes || []
+    let isRda = false
+
+    for (let note of notes){
+      if (note.includes("$erda")){
+        isRda = true
+      }
+    }
+
+    return isRda
   },
   checkFromAuth: function(data){
     let notes = data.extra.notes || []

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 19,
+    versionPatch: 20,
 
 
 


### PR DESCRIPTION
This is based on the presence of the `extra.notes` includes an `040 $erda`

![image](https://github.com/user-attachments/assets/1b311028-6603-48f9-9515-2e7b7b20a837)
