### PR TITLE
add STATS! to the load -> Show All screen

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -21,6 +21,7 @@ export const useConfigStore = defineStore('config', {
 
         // util  : 'http://localhost:5200/',
         // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+        util  :  'https://editor.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',


### PR DESCRIPTION
Adds stats to the Show All screen:

Can be triggered with a `/bfe2/quartz/load#stats` URL

![image](https://github.com/user-attachments/assets/a3d4ad19-0584-49d2-9723-4dec94227ef4)
