### PR TITLE
Duration datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Prevent `Insert Default Values` from removing existing data
 
+### Fixed
+- Fix `bf:duration` causing Marva to crash
+
 
 ## [1.2.18] - 2025-04-28
 ### Added

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -435,7 +435,6 @@ export default {
     * @return {object} profile
     */
     setComplexValue: function(contextValue){
-      console.info("setComplexValue: ", contextValue)
       if (contextValue.literal){
         this.profileStore.setValueComplex(
             this.guid,

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -185,7 +185,7 @@ const utilsExport = {
   * @return {boolean}
   */
 	createLiteral: function(property,userValue){
-        let p = this.createElByBestNS(property)
+		let p = this.createElByBestNS(property)
 
 
 		// it should be stored under the same key
@@ -945,9 +945,9 @@ const utilsExport = {
                                     if (keys.length>0){
 										for (let key2 of keys){
 											if (typeof value1[key2] == 'string' || typeof value1[key2] == 'number'){
-                                                    let p2 = this.createLiteral(key2, value1)
-                                                    xmlLog.push(`Creating literal ${JSON.stringify(value1)}`)
-                                                    if (p2!==false) bnodeLvl1.appendChild(p2);
+												xmlLog.push(`Creating literal ${JSON.stringify(value1)}`)
+												let p2 = this.createLiteral(key2, value1)
+												if (p2!==false) bnodeLvl1.appendChild(p2);
 											}else if (Array.isArray(value1[key2])){
 												for (let arrayValue of value1[key2]){
 													let keysLevel2 = Object.keys(arrayValue).filter(k => (!k.includes('@') ? true : false ) )

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -288,9 +288,15 @@ const utilsProfile = {
           // first we test to see if the type is a literal (the type returned, not the property of the value), if so then we
           // don't need to set the type, as its not a blank node, just a nested property
           if (utilsRDF.isUriALiteral(type) === false){
+
+            // for duration set datatype
+            if(pt.propertyURI == 'http://id.loc.gov/ontologies/bibframe/duration'){
+              pointer[p][0]['@datatype'] = type
+            }
+
             // if it doesn't yet have a type then go ahead and set it
             // OR if the suggested type is PrimaryContribution, override the existing type
-            if (!pointer[p][0]['@type'] || type.includes("PrimaryContribution")){
+            else if (!pointer[p][0]['@type'] || type.includes("PrimaryContribution")){
               pointer[p][0]['@type'] = type
             }
           }else{

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -48,12 +48,12 @@ export const useConfigStore = defineStore('config', {
         // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
         // offical stage profiles inside the firewall
-        // starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
-        // profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
+        starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
+        profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
 
         // offical prod profiles inside the firewall
-        starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
-        profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
+        // starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
+        // profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -513,6 +513,7 @@ export const useProfileStore = defineStore('profile', {
       let order = usePreferenceStore().loadOrder()
 
       for (let profileName in order){
+        if (!Object.keys(this.activeProfile.rt).includes(profileName)){ continue }
         let currentOrder = this.activeProfile.rt[profileName].ptOrder
         let customOrder = order[profileName]
         let tempOrder = []


### PR DESCRIPTION
Fix: Marva crash when `bf:duration` is populated

If the duration was given an `datatype URI` in the profile, entering a
value in Marva would cause a crash. This was because the URI would be
placed into `@type` and then Marva would understand the `userValue` as a
blankNode in `utils_export.js`. When it tried to `createLiteral()` it would
run into an issue and crash. Additionally, for `bf:duration` it needs an
`@datatype` to generate the correct XML, but nothing in Marva tries to
populate `@datatype`

The fix is an exception in `setTypesForBlankNode()` that will set the
`@datatype` instead of `@type` for duration. This fixes the crash and generates the
correct XML. "Correct" meaning it follows the pattern for `bf:duration`
in the ontology example.