### PR TITLE
Fix complex subject selection subject

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2226,24 +2226,29 @@ methods: {
       let splitString = this.subjectString.split('--')
       let splitStringLower = this.subjectString.toLowerCase().split('--')
 
+
       // if the selected heading is made of parts of the search string
       let replacePos = []
       if (this.searchStringPos > 0){ // we're looking at a subdivision and we've got a complex heading. Figure out if the pieces
         replacePos = [this.searchStringPos]
         let incomingPieces = this.pickLookup[this.pickPostion].label.toLowerCase().split("‑‑")
-        for (let termIdx in incomingPieces){
 
-          //check if the next piece is in the incoming
-          if (incomingPieces[termIdx].includes(splitStringLower[this.searchStringPos+1])){
-            replacePos.push(this.searchStringPos+1)
+        if (splitStringLower.length != incomingPieces.length){
+          for (let termIdx in incomingPieces){
+
+            //check if the next piece is in the incoming
+            if (incomingPieces[termIdx].includes(splitStringLower[this.searchStringPos+1])){
+              replacePos.push(this.searchStringPos+1)
+            }
+            //check if the prev piece is in the incoming
+            else if (incomingPieces[termIdx].includes(splitStringLower[this.searchStringPos-1])){
+              replacePos.unshift(this.searchStringPos-1)
+            }
           }
-          //check if the prev piece is in the incoming
-          else if (incomingPieces[termIdx].includes(splitStringLower[this.searchStringPos-1])){
-            replacePos.unshift(this.searchStringPos-1)
-          }
+        } else {
+          replacePos = []
         }
       }
-
 
       if (splitStringLower.includes(this.pickLookup[this.pickPostion].label.replaceAll('-','‑').toLowerCase())){
         let idx = splitStringLower.indexOf(this.pickLookup[this.pickPostion].label.replaceAll('-','‑').toLowerCase())


### PR DESCRIPTION
A complex heading that should replace the entire typed string could come in off, if the cursor isn't on the first word.

![image](https://github.com/user-attachments/assets/64d83fad-7c40-406a-a3cc-28ad0f5eeca9)
