### PR TITLE
Overhaul Complex Modal Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [1.2.22] - 2025-05-02
 ### Update
 - Hub URIs from hub creation
+- Complex Search Details
+
+### Add
+- Ability to populate Class Numbers from Complex Search Details
+
+### Fix
+- Prompt to login when click ClassWeb link in Complex Search Details
 
 
 ## [1.2.21] - 2025-04-30

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -135,7 +135,7 @@
       <div v-if="structure.propertyURI=='http://id.loc.gov/ontologies/bibframe/classificationPortion'">
 
         <a style="color:black" v-if="lccFeatureData.classNumber" :href="'https://classweb.org/min/minaret?app=Class&mod=Search&look=1&query=&index=id&cmd2=&auto=1&Fspan='+lccFeatureData.classNumber+'&Fcaption=&Fkeyword=&Fterm=&Fcap_term=&count=75&display=1&table=schedules&logic=0&style=0&cmd=Search'" target="_blank">ClassWeb Search: {{ lccFeatureData.classNumber }}</a><br/>
-        <a style="color:black" v-if="lccFeatureData.classNumber" :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+lccFeatureData.classNumber" target="_blank">ClassWeb Browse: {{ lccFeatureData.classNumber }}</a><br/>
+        <a style="color:black" v-if="lccFeatureData.classNumber" :href="'https://classweb.org/min/minaret?app=Class&auto=1&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+lccFeatureData.classNumber" target="_blank">ClassWeb Browse: {{ lccFeatureData.classNumber }}</a><br/>
 
         <a style="color:black" v-if="lccFeatureData.firstSubject" :href="'https://classweb.org/min/minaret?app=Corr&mod=Search&count=75&auto=1&close=1&display=1&menu=/Auto/&iname=sh2l&iterm='+lccFeatureData.firstSubject" target="_blank">ClassWeb Search: {{ lccFeatureData.firstSubject }}</a>
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -87,7 +87,7 @@
         },
         panelDetailOrder: {
           biographical: [
-            "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","birthplaces", "deathdates", "locales",
+            "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
             "activityfields","occupations","languages", "sees"
           ],
           important: [
@@ -1175,7 +1175,7 @@
                             <ul class="bio-list">
                               <template v-for="key in panelDetailOrder[group]">
                                 <template v-if="['birthdates', 'deathdates', 'birthplaces','locales','activityfields','occupations', 'languages'].includes(key) && activeContext.extra[key] && activeContext.extra[key].length>0">
-                                  <li class="bio-details" v-bind:key="'var' + idx">
+                                  <li class="bio-details">
                                     <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
                                     {{ activeContext.extra[key].join(" ; ")}}
                                   </li>
@@ -1197,12 +1197,12 @@
                                 </template>
                                 <template v-else>
                                   <ul class="bio-list">
-                                    <li class="bio-details" v-bind:key="'var' + idx" v-if="key=='lcclasss'" v-for="v in activeContext.extra['lcclasss']">
+                                    <li class="bio-details" v-if="key=='lcclasss'" v-for="v in activeContext.extra['lcclasss']">
                                       <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
                                       <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
                                       <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
                                     </li>
-                                    <li class="bio-details" v-bind:key="'var' + idx" v-if="key != 'lcclasss'">
+                                    <li class="bio-details" v-if="key != 'lcclasss'">
                                       <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
                                       {{ activeContext.extra[key].join(" ; ") }}
                                     </li>
@@ -1236,9 +1236,9 @@
                                                 <template v-else-if="key == 'broaders' || key == 'relateds' || key == 'sees'">
                                                   <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
                                                 </template>
-                                                <teamplate v-else-if="key == 'notes'">
+                                                <template v-else-if="key == 'notes'">
                                                   <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
-                                                </teamplate>
+                                                </template>
                                                 <template v-else>
                                                   {{v}}
                                                 </template>
@@ -1251,34 +1251,6 @@
                               </AccordionList>
                           </div>
                           </template>
-                      <!-- </div> -->
-                    <!-- </template> -->
-                    <!-- modal-context-data-title-add-gap -->
-                    <!-- <div v-if="activeContext.extra[key] && activeContext.extra[key].length>0">
-                      <br>
-                      <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
-                          <template v-if="v.startsWith('http')">
-                            <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
-                          </template>
-                          <template v-else-if="key == 'lcclasss'">
-                            <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
-                          </template>
-                          <template v-else-if="key == 'broaders' || key == 'relateds' || key == 'sees'">
-                            <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
-                          </template>
-                          <teamplate v-else-if="key == 'notes'">
-                            <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
-                          </teamplate>
-                          <template v-else>
-                            {{v}}
-                          </template>
-                        </li>
-                        <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ activeContext.extra[key] }}</li>
-                      </ul>
-
-                    </div> -->
                   </template>
               </template>
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -91,7 +91,7 @@
             "activityfields","occupations","languages", "sees"
           ],
           important: [
-            "sources", "lcclasss", "identifiers","gacs","broaders",
+            "gacs", "sources", "lcclasss", "identifiers","broaders",
           ],
           administrative: [
             "notes", "collections", "subjects", "marcKeys"

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -85,18 +85,24 @@
           "sees": "See Also"
 
         },
-        panelDetailOrder: {
-          biographical: [
+        panelDetailOrder: [
             "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
-            "activityfields","occupations","languages", "sees"
-          ],
-          important: [
+            "activityfields","occupations","languages", "sees",
             "gacs", "sources", "lcclasss", "identifiers","broaders",
-          ],
-          administrative: [
             "notes", "collections", "subjects", "marcKeys"
-          ]
-        },
+        ],
+        // panelDetailOrder: {
+        //   primary: [
+        //     "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
+        //     "activityfields","occupations","languages", "sees"
+        //   ],
+        //   secondary: [
+        //     "gacs", "sources", "lcclasss", "identifiers","broaders",
+        //   ],
+        //   administrative: [
+        //     "notes", "collections", "subjects", "marcKeys"
+        //   ]
+        // },
       }
     },
     computed: {
@@ -1149,103 +1155,98 @@
 
                   </div>
 
-                  <template v-for="(value, group) in panelDetailOrder">
-                    <!-- <template v-for="key in panelDetailOrder[group]"> -->
-                      <!-- <div v-if="activeContext.extra[key] && activeContext.extra[key].length>0"> -->
 
-                          <template v-if="group == 'biographical'">
-                            <template v-for="key in panelDetailOrder[group]">
-                              <template v-if="activeContext.extra[key] && activeContext.extra[key].length>0 && ['nonlatinLabels', 'variantLabels', 'varianttitles', 'contributors', 'relateds', 'sees'].includes(key)">
+                    <!-- Labels & Relationships -->
+                    <template v-for="key in panelDetailOrder">
+                      <div v-if="activeContext.extra[key] && activeContext.extra[key].length>0">
+                        <template v-if="activeContext.extra[key] && activeContext.extra[key].length>0 && ['nonlatinLabels', 'variantLabels', 'varianttitles', 'contributors', 'relateds', 'sees'].includes(key)">
+                          <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                          <ul class="details-list">
+                            <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
+                              <span v-if="key !='sees' && key !='relateds'">{{v}}</span>
+                              <div v-else-if="key == 'relateds'">
+                                {{v}}<button class="material-icons see-search" @click="searchValueLocal = v">search</button>
+                              </div>
+                              <div v-else>
+                                <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                                <button class="material-icons see-search" @click="searchValueLocal = v">search</button>
+                              </div>
+                            </li>
+                          </ul>
+                        </template>
+                      </div>
+                    </template>
+
+                    <!-- Primary -->
+                    <ul class="details-list">
+                      <template v-for="key in panelDetailOrder">
+                        <template v-if="['birthdates', 'deathdates', 'birthplaces','locales','activityfields','occupations', 'languages'].includes(key) && activeContext.extra[key] && activeContext.extra[key].length>0">
+                          <li class="details-details">
+                            <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                            {{ activeContext.extra[key].join(" ; ")}}
+                          </li>
+                        </template>
+                      </template>
+                    </ul>
+
+                    <!-- Secondary -->
+                    <template v-for="key in panelDetailOrder">
+                      <div v-if="activeContext.extra[key] && activeContext.extra[key].length>0">
+                        <template v-if="key == 'sources'">
+                          <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                          <ul>
+                            <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
+                              {{v}}
+                            </li>
+                          </ul>
+                        </template>
+                        <template v-else>
+                          <ul class="details-list">
+                            <li class="details-details" v-if="key=='lcclasss'" v-for="v in activeContext.extra['lcclasss']">
+                              <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                              <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
+                              <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
+                            </li>
+                            <li class="details-details" v-if='["gacs", "identifiers","broaders",].includes(key)'>
+                              <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                              {{ activeContext.extra[key].join(" ; ") }}
+                            </li>
+                          </ul>
+                        </template>
+                      </div>
+                    </template>
+
+                    <!-- Admin -->
+                    <div class="admin-fields">
+                        <br>
+                        <hr>
+                        <AccordionList  :open-multiple-items="true">
+                          <AccordionItem id="admin-fields" default-closed>
+                            <template #summary>
+                              <div>Extra Details</div>
+                            </template>
+                            <template v-for="key in panelDetailOrder">
+                              <template v-if='activeContext.extra[key] && activeContext.extra[key].length>0 && ["notes", "collections", "subjects", "marcKeys"].includes(key)'>
                                 <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
-                                <ul class="bio-list">
+                                <ul>
                                   <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
-
-                                    <span v-if="key !='sees' && key !='relateds'">{{v}}</span>
-                                    <div v-else-if="key == 'relateds'">
-                                      {{v}}<button class="material-icons see-search" @click="searchValueLocal = v">search</button>
-                                    </div>
-                                    <div v-else>
-                                      <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
-                                      <button class="material-icons see-search" @click="searchValueLocal = v">search</button>
-                                    </div>
+                                    <template v-if="v.startsWith('http')">
+                                      <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
+                                    </template>
+                                    <template v-else-if="key == 'notes'">
+                                      <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
+                                    </template>
+                                    <template v-else>
+                                      {{v}}
+                                    </template>
                                   </li>
+                                  <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ activeContext.extra[key] }}</li>
                                 </ul>
                               </template>
                             </template>
-                            <ul class="bio-list">
-                              <template v-for="key in panelDetailOrder[group]">
-                                <template v-if="['birthdates', 'deathdates', 'birthplaces','locales','activityfields','occupations', 'languages'].includes(key) && activeContext.extra[key] && activeContext.extra[key].length>0">
-                                  <li class="bio-details">
-                                    <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                                    {{ activeContext.extra[key].join(" ; ")}}
-                                  </li>
-                                </template>
-                              </template>
-                            </ul>
-
-                          </template>
-                          <template v-else-if="group == 'important'">
-                            <template v-for="key in panelDetailOrder[group]">
-                              <template v-if="activeContext.extra[key] && activeContext.extra[key].length>0">
-                                <template v-if="key == 'sources'">
-                                  <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                                  <ul>
-                                    <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
-                                      {{v}}
-                                    </li>
-                                  </ul>
-                                </template>
-                                <template v-else>
-                                  <ul class="bio-list">
-                                    <li class="bio-details" v-if="key=='lcclasss'" v-for="v in activeContext.extra['lcclasss']">
-                                      <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                                      <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
-                                      <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
-                                    </li>
-                                    <li class="bio-details" v-if="key != 'lcclasss'">
-                                      <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                                      {{ activeContext.extra[key].join(" ; ") }}
-                                    </li>
-
-                                  </ul>
-                                </template>
-                              </template>
-                            </template>
-                          </template>
-                          <template v-else-if="group == 'administrative'">
-                            <div class="admin-fields">
-                              <br>
-                              <hr>
-                              <AccordionList  :open-multiple-items="true">
-                                <AccordionItem id="admin-fields" default-closed>
-                                  <template #summary>
-                                    <div>Extra Details</div>
-                                  </template>
-                                  <template v-for="key in panelDetailOrder[group]">
-                                    <template v-if="activeContext.extra[key] && activeContext.extra[key].length>0">
-
-                                            <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
-                                            <ul>
-                                              <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
-                                                <template v-if="v.startsWith('http')">
-                                                  <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
-                                                </template>
-                                                <template v-else-if="key == 'notes'">
-                                                  <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
-                                                </template>
-                                                <template v-else>
-                                                  {{v}}
-                                                </template>
-                                              </li>
-                                              <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ activeContext.extra[key] }}</li>
-                                            </ul>
-                                    </template>
-                                  </template>
-                                </AccordionItem>
-                              </AccordionList>
-                          </div>
-                          </template>
-                  </template>
+                          </AccordionItem>
+                        </AccordionList>
+                    </div>
               </template>
 
               <template v-else-if="activeContext !== null">
@@ -1602,18 +1603,18 @@
   color: red;
 }
 
-.bio-list {
+.details-list {
   columns: 3;
   break-inside: avoid;
 }
-.bio-list:has(.bio-details){
+.details-list:has(.details-details){
   margin-top: 10px;
   padding-left: 0px;
   columns: 2;
   break-inside: avoid;
 }
 
-.bio-details {
+.details-details {
   list-style: none;
 }
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1230,12 +1230,6 @@
                                                 <template v-if="v.startsWith('http')">
                                                   <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
                                                 </template>
-                                                <template v-else-if="key == 'lcclasss'">
-                                                  <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
-                                                </template>
-                                                <template v-else-if="key == 'broaders' || key == 'relateds' || key == 'sees'">
-                                                  <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
-                                                </template>
                                                 <template v-else-if="key == 'notes'">
                                                   <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
                                                 </template>
@@ -1375,8 +1369,9 @@
     margin-top: 0;
     margin-bottom: 0;
   }
-  .modal-context-data-li{
 
+  .modal-context-data-li{
+    /* list-style: none; */
   }
 
   h3{
@@ -1628,6 +1623,8 @@
   font-size: 14px;
   border-radius: 50%;
 }
+
+
 
 
 </style>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -221,7 +221,6 @@
                 </div>
 
                 <!-- Results Panel -->
-                <!-- !!{{ contextData }} -->
                 <div :style="`${this.preferenceStore.styleModalBackgroundColor()}; ${this.preferenceStore.styleModalTextColor()};`"  :class="['subject-editor-container-right', {'subject-editor-container-right-lowres':lowResMode}]">
                   <div v-if="contextRequestInProgress" style="font-weight: bold;">Retrieving data...</div>
                   <div class="modal-context" :style="{ }" v-if="Object.keys(contextData).length>0">
@@ -242,7 +241,123 @@
 
                     <br><br>
 
-                    <template v-for="key in panelDetailOrder">
+                    <template v-for="(value, group) in panelDetailOrder">
+                    <!-- <template v-for="key in panelDetailOrder[group]"> -->
+                      <!-- <div v-if="activeContext.extra[key] && activeContext.extra[key].length>0"> -->
+
+                          <template v-if="group == 'biographical'">
+                            <template v-for="key in panelDetailOrder[group]">
+                              <template v-if="contextData[key] && contextData[key].length>0 && ['nonlatinLabels', 'variantLabels', 'varianttitles', 'contributors', 'relateds', 'sees'].includes(key)">
+                                <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                                <ul class="bio-list">
+                                  <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
+
+                                    <span v-if="key !='sees' && key !='relateds'">{{v}}</span>
+                                    <div v-else-if="key == 'relateds'">
+                                      {{v}}<button class="material-icons see-search" @click="newSearch(v)">search</button>
+                                    </div>
+                                    <div v-else>
+                                      <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                                      <button class="material-icons see-search" @click="newSearch(v)">search</button>
+                                    </div>
+                                  </li>
+                                </ul>
+                              </template>
+                            </template>
+                            <ul class="bio-list">
+                              <template v-for="key in panelDetailOrder[group]">
+                                <template v-if="['birthdates', 'deathdates', 'birthplaces','locales','activityfields','occupations', 'languages'].includes(key) && contextData[key] && contextData[key].length>0">
+                                  <li class="bio-details">
+                                    <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                                    {{ contextData[key].join(" ; ")}}
+                                  </li>
+                                </template>
+                              </template>
+                            </ul>
+
+                          </template>
+                          <template v-else-if="group == 'important'">
+                            <template v-for="key in panelDetailOrder[group]">
+                              <template v-if="contextData[key] && contextData[key].length>0">
+                                <template v-if="key == 'sources'">
+                                  <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                                  <ul>
+                                    <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
+                                      {{v}}
+                                    </li>
+                                  </ul>
+                                </template>
+                                <template v-else>
+
+                                  <template v-if="['lcclasss', 'broaders'].includes(key)">
+                                    <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                                    <ul  class="bio-list">
+                                      <template v-for="v in contextData[key]">
+                                        <li class="" v-if="key=='lcclasss'">
+                                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
+                                          <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
+                                        </li>
+                                        <li class="" v-else-if="key == 'broaders'">
+                                          <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                                          <button class="material-icons see-search" @click="newSearch(v)">search</button>
+                                        </li>
+                                      </template>
+                                    </ul>
+                                  </template>
+                                  <template v-else>
+                                    <ul class="bio-list">
+                                      <li class="bio-details">
+                                        <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                                        {{ contextData[key].join(" ; ") }}
+                                      </li>
+                                    </ul>
+                                  </template>
+                                </template>
+                              </template>
+                            </template>
+                          </template>
+                          <template v-else-if="group == 'administrative'">
+                            <div class="admin-fields">
+                              <br>
+                              <hr>
+                              <AccordionList  :open-multiple-items="true">
+                                <AccordionItem id="admin-fields" default-closed>
+                                  <template #summary>
+                                    <div>Extra Details</div>
+                                  </template>
+                                  <template v-for="key in panelDetailOrder[group]">
+                                    <template v-if="contextData[key] && contextData[key].length>0">
+
+                                            <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                                            <ul>
+                                              <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
+                                                <template v-if="v.startsWith('http')">
+                                                  <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
+                                                </template>
+                                                <template v-else-if="key == 'lcclasss'">
+                                                  <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
+                                                </template>
+                                                <template v-else-if="key == 'broaders' || key == 'relateds' || key == 'sees'">
+                                                  <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                                                </template>
+                                                <template v-else-if="key == 'notes'">
+                                                  <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
+                                                </template>
+                                                <template v-else>
+                                                  {{v}}
+                                                </template>
+                                              </li>
+                                              <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ contextData[key] }}</li>
+                                            </ul>
+                                    </template>
+                                  </template>
+                                </AccordionItem>
+                              </AccordionList>
+                          </div>
+                          </template>
+                  </template>
+
+                    <!-- <template v-for="key in panelDetailOrder">
                     <div v-if="contextData[key] && contextData[key].length>0">
                       <div class="modal-context-data-title modal-context-data-title-add-gap">{{ this.labelMap[key] }}:</div>
                       <ul>
@@ -252,7 +367,6 @@
                           </template>
                           <template v-else-if="key == 'lcclasss'">
                             <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
-                            <!-- <a :href="'https://id.loc.gov/authorities/classification/'+v" target="_blank">{{v}}</a> -->
                           </template>
                           <template v-else-if="key == 'broaders' || key == 'sees'">
                             <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
@@ -267,7 +381,7 @@
                         <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ contextData[key] }}</li>
                       </ul>
                     </div>
-                  </template>
+                  </template> -->
 
 
                     <div v-if="this.pickCurrent != null">
@@ -803,6 +917,28 @@ li::before {
   color: red;
 }
 
+.bio-list {
+  columns: 3;
+  break-inside: avoid;
+}
+.bio-list:has(.bio-details){
+  margin-top: 10px;
+  padding-left: 0px;
+  columns: 2;
+  break-inside: avoid;
+}
+
+.bio-details {
+  list-style: none;
+}
+
+.see-search{
+  width: 25px;
+  height: 25px;
+  font-size: 14px;
+  border-radius: 50%;
+}
+
 </style>
 
 <style>
@@ -816,15 +952,16 @@ li::before {
 <script>
 
 import { usePreferenceStore } from '@/stores/preference'
+import { useProfileStore } from '@/stores/profile'
 import { useConfigStore } from '@/stores/config'
-import { mapStores, mapState } from 'pinia'
+import { mapStores, mapState, mapWritableState } from 'pinia'
 import { VueFinalModal } from 'vue-final-modal'
 
 import AuthTypeIcon from "@/components/panels/edit/fields/helpers/AuthTypeIcon.vue";
 
 import utilsNetwork from '@/lib/utils_network';
 
-
+import { AccordionList, AccordionItem } from "vue3-rich-accordion";
 
 const debounce = (callback, wait) => {
 let timeoutId = null;
@@ -845,7 +982,8 @@ name: "SubjectEditor",
 components: {
   VueFinalModal,
   AuthTypeIcon,
-
+  AccordionList,
+  AccordionItem
 },
 props: {
   structure: Object,
@@ -928,6 +1066,7 @@ data: function() {
       "variantLabels": "Variants",
       "varianttitles": "Varants Titles",
       "birthdates": "Date of Birth",
+      "deathdates": "Date of Death",
       "birthplaces": "Place of Birth",
       "locales": "Associated Locales",
       "activityfields": "Fields of Activity",
@@ -947,12 +1086,18 @@ data: function() {
       "countSubj": "Subject ff",
       "countName": "Contributor to",
     },
-    panelDetailOrder: [
-      "countSubj", "countName", "notes","nonlatinLabels","variantLabels", "varianttitles", "sees", "contributors",
-      "relateds","birthdates","birthplaces","locales","activityfields","occupations",
-      "languages","lcclasss","identifiers","broaders","gacs","collections",
-      "sources", "subjects", "marcKeys"
-    ],
+    panelDetailOrder: {
+      biographical: [
+        "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
+        "activityfields","occupations","languages", "sees"
+      ],
+      important: [
+        "sources", "lcclasss", "identifiers","gacs","broaders",
+      ],
+      administrative: [
+        "notes", "collections", "subjects", "marcKeys"
+      ]
+    },
     selectedSortOrder: ""
 
   }
@@ -961,8 +1106,32 @@ data: function() {
 computed: {
   ...mapStores(usePreferenceStore),
   ...mapState(usePreferenceStore, ['diacriticUseValues', 'diacriticUse','diacriticPacks']),
+  ...mapState(useProfileStore, ['returnComponentByPropertyLabel']),
+
+  ...mapWritableState(useProfileStore, ['activeProfile', 'setValueLiteral']),
 },
 methods: {
+  // Conduct a new search on "related" term
+  newSearch: function(v){
+    this.subjectString = v
+    this.subjectStringChanged()
+    this.searchApis(v, v, this)
+  },
+
+
+  // Add class number from details to Marva
+  addClassNumber: function(classNum){
+    let profile = this.activeProfile
+
+    let targetComponent = this.returnComponentByPropertyLabel('Classification numbers')
+
+    let propertyPath = [
+      { level: 0, propertyURI: "http://id.loc.gov/ontologies/bibframe/classification" },
+      { level: 1, propertyURI: "http://id.loc.gov/ontologies/bibframe/classificationPortion" }
+    ]
+
+    this.setValueLiteral(targetComponent['@guid'], null, propertyPath, classNum, null, null)
+  },
   checkUsable: function(data){
     let notes = data.extra.notes || []
     if (notes.includes("THIS 1XX FIELD CANNOT BE USED UNDER RDA UNTIL THIS RECORD HAS BEEN REVIEWED AND/OR UPDATED")){
@@ -1335,6 +1504,7 @@ methods: {
   },
 
   focusInput: function(){
+    console.info("focus")
     this.$nextTick(() => {
 
       let timeoutFocus = window.setTimeout(()=>{
@@ -2624,6 +2794,7 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
+    console.info("subjectStringChanged")
     this.subjectString=this.subjectString.replace("—", "--")
     this.validateOkayToAdd()
 
@@ -2631,6 +2802,8 @@ methods: {
     if (this.initialLoad == true) {
       let pieces = this.$refs.subjectInput.value.replace("—", "--").split("--")
       let lastPiece = pieces.at(-1)
+      console.info("lastPiece: ", lastPiece)
+      console.info("full: ", this.$refs.subjectInput.value.replace("—", "--"))
       this.searchApis(lastPiece, this.$refs.subjectInput.value.replace("—", "--"), this)
       this.initialLoad = false
     }
@@ -3380,6 +3553,7 @@ mounted: function(){
 
 
 updated: function() {
+  console.info("updated")
   // preselect the search type, if a children's subject
   if (this.searchType.includes("Childrens")){
     this.searchMode = "CHILD"

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -334,12 +334,6 @@
                                                 <template v-if="v.startsWith('http')">
                                                   <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
                                                 </template>
-                                                <template v-else-if="key == 'lcclasss'">
-                                                  <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
-                                                </template>
-                                                <template v-else-if="key == 'broaders' || key == 'relateds' || key == 'sees'">
-                                                  <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
-                                                </template>
                                                 <template v-else-if="key == 'notes'">
                                                   <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
                                                 </template>
@@ -1504,7 +1498,6 @@ methods: {
   },
 
   focusInput: function(){
-    console.info("focus")
     this.$nextTick(() => {
 
       let timeoutFocus = window.setTimeout(()=>{
@@ -2794,7 +2787,6 @@ methods: {
   },
 
   subjectStringChanged: async function(event){
-    console.info("subjectStringChanged")
     this.subjectString=this.subjectString.replace("—", "--")
     this.validateOkayToAdd()
 
@@ -2802,8 +2794,6 @@ methods: {
     if (this.initialLoad == true) {
       let pieces = this.$refs.subjectInput.value.replace("—", "--").split("--")
       let lastPiece = pieces.at(-1)
-      console.info("lastPiece: ", lastPiece)
-      console.info("full: ", this.$refs.subjectInput.value.replace("—", "--"))
       this.searchApis(lastPiece, this.$refs.subjectInput.value.replace("—", "--"), this)
       this.initialLoad = false
     }
@@ -3553,7 +3543,6 @@ mounted: function(){
 
 
 updated: function() {
-  console.info("updated")
   // preselect the search type, if a children's subject
   if (this.searchType.includes("Childrens")){
     this.searchMode = "CHILD"

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -241,142 +241,110 @@
 
                     <br><br>
 
-                    <template v-for="(value, group) in panelDetailOrder">
-                    <!-- <template v-for="key in panelDetailOrder[group]"> -->
-                      <!-- <div v-if="activeContext.extra[key] && activeContext.extra[key].length>0"> -->
 
-                          <template v-if="group == 'biographical'">
-                            <template v-for="key in panelDetailOrder[group]">
-                              <template v-if="contextData[key] && contextData[key].length>0 && ['nonlatinLabels', 'variantLabels', 'varianttitles', 'contributors', 'relateds', 'sees'].includes(key)">
+                    <!-- Labels & Relationships -->
+                    <template v-for="key in panelDetailOrder">
+                      <div v-if="contextData[key] && contextData[key].length>0">
+                        <template v-if="contextData[key] && contextData[key].length>0 && ['nonlatinLabels', 'variantLabels', 'varianttitles', 'contributors', 'relateds', 'sees'].includes(key)">
+                          <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                          <ul class="details-list">
+                            <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
+                              <span v-if="key !='sees' && key !='relateds'">{{v}}</span>
+                              <div v-else-if="key == 'relateds'">
+                                {{v}}<button class="material-icons see-search" @click="newSearch(v)">search</button>
+                              </div>
+                              <div v-else>
+                                <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                                <button class="material-icons see-search" @click="newSearch(v)">search</button>
+                              </div>
+                            </li>
+                          </ul>
+                        </template>
+                      </div>
+                    </template>
+
+                    <!-- Primary -->
+                    <ul class="details-list">
+                      <template v-for="key in panelDetailOrder">
+                        <template v-if="['birthdates', 'deathdates', 'birthplaces','locales','activityfields','occupations', 'languages', 'gacs'].includes(key) && contextData[key] && contextData[key].length>0">
+                          <li class="details-details">
+                            <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                            {{ contextData[key].join(" ; ")}}
+                          </li>
+                        </template>
+                      </template>
+                    </ul>
+
+                    <!-- Secondary -->
+                    <template v-for="key in panelDetailOrder">
+                      <div v-if="contextData[key] && contextData[key].length>0">
+                        <template v-if="key == 'sources'">
+                          <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                          <ul>
+                            <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
+                              {{v}}
+                            </li>
+                          </ul>
+                        </template>
+                        <template v-else>
+                          <template v-if="['lcclasss', 'broaders'].includes(key)">
+                            <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                            <ul  class="details-list">
+                              <template v-for="v in contextData[key]">
+                                <li class="modal-context-data-li" v-if="key=='lcclasss'">
+                                  <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
+                                  <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
+                                </li>
+                                <li class="modal-context-data-li" v-else-if="key == 'broaders'">
+                                  {{v}}
+                                  <button class="material-icons see-search" @click="newSearch(v)">search</button>
+                                </li>
+                              </template>
+                            </ul>
+                          </template>
+                          <template v-else-if='["identifiers"].includes(key)'>
+                            <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                            <ul class="details-list">
+                              <li class="details-details modal-context-data-li">
+                                {{ contextData[key].join(" ; ") }}
+                              </li>
+                            </ul>
+                          </template>
+                        </template>
+                      </div>
+                    </template>
+
+                    <!-- Admin -->
+                    <div class="admin-fields">
+                        <br>
+                        <hr>
+                        <AccordionList  :open-multiple-items="true">
+                          <AccordionItem id="admin-fields" default-closed>
+                            <template #summary>
+                              <div>Extra Details</div>
+                            </template>
+                            <template v-for="key in panelDetailOrder">
+                              <template v-if='contextData[key] && contextData[key].length>0 && ["notes", "collections", "subjects", "marcKeys"].includes(key)'>
                                 <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
-                                <ul class="bio-list">
+                                <ul>
                                   <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
-
-                                    <span v-if="key !='sees' && key !='relateds'">{{v}}</span>
-                                    <div v-else-if="key == 'relateds'">
-                                      {{v}}<button class="material-icons see-search" @click="newSearch(v)">search</button>
-                                    </div>
-                                    <div v-else>
-                                      <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
-                                      <button class="material-icons see-search" @click="newSearch(v)">search</button>
-                                    </div>
+                                    <template v-if="v.startsWith('http')">
+                                      <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
+                                    </template>
+                                    <template v-else-if="key == 'notes'">
+                                      <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
+                                    </template>
+                                    <template v-else>
+                                      {{v}}
+                                    </template>
                                   </li>
+                                  <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ contextData[key] }}</li>
                                 </ul>
                               </template>
                             </template>
-                            <ul class="bio-list">
-                              <template v-for="key in panelDetailOrder[group]">
-                                <template v-if="['birthdates', 'deathdates', 'birthplaces','locales','activityfields','occupations', 'languages'].includes(key) && contextData[key] && contextData[key].length>0">
-                                  <li class="bio-details">
-                                    <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                                    {{ contextData[key].join(" ; ")}}
-                                  </li>
-                                </template>
-                              </template>
-                            </ul>
-
-                          </template>
-                          <template v-else-if="group == 'important'">
-                            <template v-for="key in panelDetailOrder[group]">
-                              <template v-if="contextData[key] && contextData[key].length>0">
-                                <template v-if="key == 'sources'">
-                                  <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                                  <ul>
-                                    <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
-                                      {{v}}
-                                    </li>
-                                  </ul>
-                                </template>
-                                <template v-else>
-
-                                  <template v-if="['lcclasss', 'broaders'].includes(key)">
-                                    <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
-                                    <ul  class="bio-list">
-                                      <template v-for="v in contextData[key]">
-                                        <li class="" v-if="key=='lcclasss'">
-                                          <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
-                                          <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
-                                        </li>
-                                        <li class="" v-else-if="key == 'broaders'">
-                                          {{v}}
-                                          <button class="material-icons see-search" @click="newSearch(v)">search</button>
-                                        </li>
-                                      </template>
-                                    </ul>
-                                  </template>
-                                  <template v-else>
-                                    <ul class="bio-list">
-                                      <li class="bio-details">
-                                        <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                                        {{ contextData[key].join(" ; ") }}
-                                      </li>
-                                    </ul>
-                                  </template>
-                                </template>
-                              </template>
-                            </template>
-                          </template>
-                          <template v-else-if="group == 'administrative'">
-                            <div class="admin-fields">
-                              <br>
-                              <hr>
-                              <AccordionList  :open-multiple-items="true">
-                                <AccordionItem id="admin-fields" default-closed>
-                                  <template #summary>
-                                    <div>Extra Details</div>
-                                  </template>
-                                  <template v-for="key in panelDetailOrder[group]">
-                                    <template v-if="contextData[key] && contextData[key].length>0">
-
-                                            <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
-                                            <ul>
-                                              <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
-                                                <template v-if="v.startsWith('http')">
-                                                  <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
-                                                </template>
-                                                <template v-else-if="key == 'notes'">
-                                                  <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
-                                                </template>
-                                                <template v-else>
-                                                  {{v}}
-                                                </template>
-                                              </li>
-                                              <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ contextData[key] }}</li>
-                                            </ul>
-                                    </template>
-                                  </template>
-                                </AccordionItem>
-                              </AccordionList>
-                          </div>
-                          </template>
-                  </template>
-
-                    <!-- <template v-for="key in panelDetailOrder">
-                    <div v-if="contextData[key] && contextData[key].length>0">
-                      <div class="modal-context-data-title modal-context-data-title-add-gap">{{ this.labelMap[key] }}:</div>
-                      <ul>
-                        <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
-                          <template v-if="v.startsWith('http')">
-                            <a target="_blank" :href="v">{{ v.split("/").at(-1).split("_").at(-1) }}</a>
-                          </template>
-                          <template v-else-if="key == 'lcclasss'">
-                            <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{v}}</a>
-                          </template>
-                          <template v-else-if="key == 'broaders' || key == 'sees'">
-                            <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
-                          </template>
-                          <template v-else-if="key == 'notes'">
-                            <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
-                          </template>
-                          <template v-else>
-                            {{v}}
-                          </template>
-                        </li>
-                        <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ contextData[key] }}</li>
-                      </ul>
+                          </AccordionItem>
+                        </AccordionList>
                     </div>
-                  </template> -->
-
 
                     <div v-if="this.pickCurrent != null">
                       <div class="clear-selected">
@@ -911,19 +879,20 @@ li::before {
   color: red;
 }
 
-.bio-list {
+.details-list {
   columns: 3;
   break-inside: avoid;
 }
-.bio-list:has(.bio-details){
+.details-list:has(.details-details){
   margin-top: 10px;
   padding-left: 0px;
   columns: 2;
   break-inside: avoid;
 }
 
-.bio-details {
+.details-details {
   list-style: none;
+  break-inside: avoid;
 }
 
 .see-search{
@@ -1080,18 +1049,13 @@ data: function() {
       "countSubj": "Subject ff",
       "countName": "Contributor to",
     },
-    panelDetailOrder: {
-      biographical: [
-        "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
-        "activityfields","occupations","languages", "sees"
-      ],
-      important: [
-        "sources", "lcclasss", "identifiers","gacs","broaders",
-      ],
-      administrative: [
-        "notes", "collections", "subjects", "marcKeys"
-      ]
-    },
+
+    panelDetailOrder: [
+            "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces", "gacs",
+            "locales", "activityfields","occupations","languages", "sees",
+            "sources", "lcclasss", "identifiers","broaders",
+            "notes", "collections", "subjects", "marcKeys"
+        ],
     selectedSortOrder: ""
 
   }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -298,7 +298,7 @@
                                           <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
                                         </li>
                                         <li class="" v-else-if="key == 'broaders'">
-                                          <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
+                                          {{v}}
                                           <button class="material-icons see-search" @click="newSearch(v)">search</button>
                                         </li>
                                       </template>

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1918,6 +1918,9 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
+      console.info("setValueLiteral")
+      console.info("fieldguid: ", fieldGuid)
+      console.info("propertyPath: ", propertyPath)
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5647,6 +5647,7 @@ export const useProfileStore = defineStore('profile', {
      * @requires activeProfile - Profile must be loaded with valid RT structure
      */
     nacoStubReturnInstanceURI(){
+      console.info("active: ", this.activeProfile)
       for (let rt of this.activeProfile.rtOrder){
         if (rt.indexOf(":Instance")>-1){
           if (this.activeProfile.rt[rt].URI){

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1918,9 +1918,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
-      console.info("setValueLiteral")
-      console.info("fieldguid: ", fieldGuid)
-      console.info("propertyPath: ", propertyPath)
       // make a copy of the property path, dont modify the linked one passed
       propertyPath = JSON.parse(JSON.stringify(propertyPath))
 


### PR DESCRIPTION
Update: Complex Search Details
Add: Ability to populate Class Numbers from Complex Search Details
Fix: Prompt to login when click ClassWeb link in Complex Search Details

This is an initial rework of the layout. It makes the details panel more condensed. It also adds some features to help navigate. `Related` and `Broader` field have a search button next them that will perform a search on that heading in Marva.

![image](https://github.com/user-attachments/assets/a5261a38-e4cf-40a0-8f00-a71138a38dfb)

