### PR TITLE
[BFP-391] Type Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - How `indirect geo` can be entered to account for more usecases
 
 ### Add
-- Local Marva validation to check that `type` is set
+- [BFP-391] Local Marva validation to check that `type` is set
 
 
 ## [1.2.22] - 2025-05-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Update
 - How `indirect geo` can be entered to account for more usecases
 
+### Add
+- Local Marva validation to check that `type` is set
+
 
 ## [1.2.22] - 2025-05-02
 ### Update

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -198,8 +198,17 @@ export default {
         let elementId = this.structure['@guid'] + "-select"
         this.$nextTick(() => {
           window.setTimeout(()=> {
-            let target = document.getElementById(elementId.trim() )
+            let target = document.getElementById(elementId.trim())
             target.className += " validation-error no-type"
+
+            for (let child of target.childNodes){
+              if (child.value && child.value == 'empty'){
+                child.selected = true
+              } else {
+                child.selected = false
+              }
+            }
+
           },10);
         });
       } else if (userValue['@type'] && !userValue['@type'].includes("Subject") && this.rtLookup[useId].resourceURI == userValue['@type']){
@@ -253,10 +262,15 @@ export default {
     },
 
     allRtTemplate(){
-      let templates = []
+      // Provide a default
+      let templates = [{
+        id: 'empty',
+        resourceLabel: 'Select Type'
+      }]
       for (let id of this.structure.valueConstraint.valueTemplateRefs){
         templates.push(JSON.parse(JSON.stringify(this.rtLookup[id])))
       }
+
       return templates
     },
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -192,7 +192,9 @@ export default {
 
       // if this is true, a default value is being "used" because the incoming value
       // doesn't match an available option
-      if (userValue['@type'] && this.rtLookup[useId].resourceURI != userValue['@type']){
+      // ignore for subjects
+      if (userValue['@type'] && !userValue['@type'].includes("Subject") && this.rtLookup[useId].resourceURI != userValue['@type']){
+
         let elementId = this.structure['@guid'] + "-select"
         this.$nextTick(() => {
           window.setTimeout(()=> {
@@ -200,7 +202,7 @@ export default {
             target.className += " validation-error no-type"
           },10);
         });
-      } else if (userValue['@type'] && this.rtLookup[useId].resourceURI == userValue['@type']){
+      } else if (userValue['@type'] && !userValue['@type'].includes("Subject") && this.rtLookup[useId].resourceURI == userValue['@type']){
         // remove the class
         this.$nextTick(() => {
           window.setTimeout(()=> {

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -335,7 +335,11 @@ export default {
         this.manualOverride = null
       }
 
-      this.profileStore.changeRefTemplate(this.guid, this.propertyPath, nextRef, thisRef)
+      try{
+        this.profileStore.changeRefTemplate(this.guid, this.propertyPath, nextRef, thisRef)
+      } catch {
+        console.warn("Couldn't change the template. nextRef: ", nextRef)
+      }
     }
 
 

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -111,8 +111,6 @@ export default {
         userValue = this.structure.userValue[this.structure.propertyURI][0]
       }
 
-      //TODO: for RBMS, where the URI is the same as Genre/Form, it'll always use G/F. Get it to not do this
-
       // do we have user data and a possible @type to use
       if (userValue['@type']){
         // loop thrugh all the refs and see if there is a URI that matches it better

--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -1,5 +1,4 @@
 <template>
-
   <template  v-if="structure.valueConstraint.valueTemplateRefs.length > 1">
     <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode') == true">
       <select :class="{'label-bold': preferenceStore.returnValue('--b-edit-main-splitpane-edit-show-field-labels-bold')}" style="display: inline; width: 20px; border-color:whitesmoke; background-color: transparent;" @change="templateChange($event)">
@@ -190,7 +189,33 @@ export default {
 
       // do not render recursivly if the thing we are trying to render recursivly is one the of the things thAT WER ARE RENDERING TO BEGIN WITHHHHH!!!1
       // if (this.parentStructure && this.parentStructure.indexOf(useId) ==-1){
-        if (this.rtLookup[useId]){
+
+      // if this is true, a default value is being "used" because the incoming value
+      // doesn't match an available option
+      if (userValue['@type'] && this.rtLookup[useId].resourceURI != userValue['@type']){
+        let elementId = this.structure['@guid'] + "-select"
+        this.$nextTick(() => {
+          window.setTimeout(()=> {
+            let target = document.getElementById(elementId.trim() )
+            target.className += " validation-error no-type"
+          },10);
+        });
+      } else if (userValue['@type'] && this.rtLookup[useId].resourceURI == userValue['@type']){
+        // remove the class
+        this.$nextTick(() => {
+          window.setTimeout(()=> {
+            let targets = document.getElementsByClassName("validation-error no-type")
+            for (let target of targets){
+              if (target.id.includes(this.structure['@guid'])){
+                target.classList.remove("validation-error")
+                target.classList.remove("no-type")
+              }
+            }
+          },10);
+        });
+      }
+
+      if (this.rtLookup[useId]){
           let use = JSON.parse(JSON.stringify(this.rtLookup[useId]))
 
           return use
@@ -454,6 +479,11 @@ select{
 }
 .label-bold{
   font-weight: bold;
+}
+
+.validation-error.no-type{
+  border: 2px solid red;
+  color: red;
 }
 
 </style>

--- a/src/components/panels/nav/ValidateModal.vue
+++ b/src/components/panels/nav/ValidateModal.vue
@@ -174,10 +174,15 @@
               <span v-if="!Object.keys(validationResults).includes('error')" >
                 <span v-if="status === 'validated'">Validation found the following:</span>
                   <ul v-for="({level, message}) in validationMessage">
-                    <li :class="['level-' + level, {'action-jump': message[1]}]" @click="jumpToComponent(message)">
-                      <span v-if="message[1]" :class="['material-icons']">move_down</span>
-                      {{ level }}: {{ message[0] }}
-                    </li>
+                    <template v-if="level == 'SUCCESS' && validationMessage.length > 1">
+                      <!-- Don't show the success message when there's a message from Marvas -->
+                    </template>
+                    <template v-else>
+                      <li :class="['level-' + level, {'action-jump': message[1]}]" @click="jumpToComponent(message)">
+                        <span v-if="message[1]" :class="['material-icons']">move_down</span>
+                        {{ level }}: {{ message[0] }}
+                      </li>
+                    </template>
                   </ul>
               </span>
               <span v-else>

--- a/src/components/panels/nav/ValidateModal.vue
+++ b/src/components/panels/nav/ValidateModal.vue
@@ -55,6 +55,11 @@
 
         },
 
+        validateForm: function(){
+          let elements = document.getElementsByClassName("validation-error")
+          return elements
+        },
+
         post: async function(){
           //console.log("** validating **")
           const config = useConfigStore()
@@ -67,6 +72,18 @@
             this.validationResults = await this.profileStore.validateRecord()
           } catch(err) {
             this.validationResults = {"error": err}
+          }
+
+          let internalErrors = this.validateForm()
+          for (let error of internalErrors){
+            let guid = error.id.replace("-select", "")
+            let classes = [...error.classList]
+            let issue = String(classes[classes.indexOf("validation-error") + 1])
+            let target = this.profileStore.returnStructureByGUID(guid)
+            this.validationResults.validation.push({
+              level: "WARNING",
+              message: target.propertyLabel + " has an issue '" + issue + "'<<" + guid + ">>"
+            })
           }
 
           this.validating = false
@@ -99,13 +116,20 @@
               }
               return [msg, matchComponent.at(-1), null]
             }
+          } else if (msg.includes("<<") && msg.includes(">>")){
+            let matchGuid = msg.match(/<<(.*)>>/)
+            msg = msg.replace(matchGuid[0],"")
+            return [msg, matchGuid[1], null]
           } else {
             return [msg, null, null]
           }
         },
 
         jumpToComponent:function(processedMessage){
-          const jumpTarget = this.profileStore.returnComponentByPropertyLabel(processedMessage[1], processedMessage[2])
+          let jumpTarget = this.profileStore.returnComponentByPropertyLabel(processedMessage[1], processedMessage[2])
+          if (!jumpTarget){
+            jumpTarget = this.profileStore.returnStructureByGUID(processedMessage[1])
+          }
           if (jumpTarget){
             this.done()
             this.activeComponent = jumpTarget
@@ -143,7 +167,7 @@
           :sticks="['br']"
           :stickSize="22"
         >
-          <div id="error-holder" ref="errorHolder" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
+          <div id="error-holder" ref="errorHolder">
             <h1 v-if="validating == true">Validating please wait...</h1>
 
             <div v-if="validating == false">

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -20,13 +20,16 @@ export const useConfigStore = defineStore('config', {
         util  : 'http://localhost:9401/util/',
 
         // util  : 'http://localhost:5200/',
-        // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
+        util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
         // util  :  'https://editor.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',
         publish : 'http://localhost:9401/util/publish/staging',
-        validate: 'http://localhost:5200/validate',
+
+        // validate: 'http://localhost:5200/validate',
+        validate: 'https://preprod-3001.id.loc.gov/bfe2/util/validate',
+
         publishNar: 'http://localhost:9401/util/nacostub/staging',
         bfdb : 'https://preprod-8230.id.loc.gov/',
         shelfListing: 'https://preprod-8230.id.loc.gov/',


### PR DESCRIPTION
Perform a check against `rtLookup` with the `useId` as the Key and compare the `resourceUri` to `userValue[@type]`. If there is no match, we'll take it to mean that the `rdf:type` for the component isn't set to an available option. We'll adjust the class of that component so that it is highlighted in red. There's also a dummy option to `Select Type` to give an indication of what to do.

![image](https://github.com/user-attachments/assets/6a7e55de-81d5-4cdf-8ed8-12b7acecd4e9)

The error will also get picked up by the Validation and incorporated into the results with the ability to jump directly to that component.

![image](https://github.com/user-attachments/assets/9078fe10-bc9b-426f-8520-2a33693e961f)
