### PR TITLE
Details Updates

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -86,23 +86,11 @@
 
         },
         panelDetailOrder: [
-            "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
+            "notes","nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
             "activityfields","occupations","languages", "sees",
             "gacs", "sources", "lcclasss", "identifiers","broaders",
-            "notes", "collections", "subjects", "marcKeys"
+            "collections", "subjects", "marcKeys"
         ],
-        // panelDetailOrder: {
-        //   primary: [
-        //     "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces",  "locales",
-        //     "activityfields","occupations","languages", "sees"
-        //   ],
-        //   secondary: [
-        //     "gacs", "sources", "lcclasss", "identifiers","broaders",
-        //   ],
-        //   administrative: [
-        //     "notes", "collections", "subjects", "marcKeys"
-        //   ]
-        // },
       }
     },
     computed: {
@@ -1171,6 +1159,14 @@
                                 <a target="_blank" :href="'https://id.loc.gov/authorities/label/'+v">{{v}}</a>
                                 <button class="material-icons see-search" @click="searchValueLocal = v">search</button>
                               </div>
+                            </li>
+                          </ul>
+                        </template>
+                        <template v-else-if="key == 'notes' && !activeContext.extra.rdftypes.includes('Name')">
+                          <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                          <ul>
+                            <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
+                              <span :class="{unusable: v.includes('CANNOT BE USED UNDER RDA')}">{{ v }}</span>
                             </li>
                           </ul>
                         </template>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -260,7 +260,7 @@
                             </li>
                           </ul>
                         </template>
-                        <template v-if="key == 'notes' && !contextData.collections.includes('http://id.loc.gov/authorities/names/collection_LCNAF')">
+                        <template v-if="key == 'notes' && (!contextData.collections.includes('http://id.loc.gov/authorities/names/collection_LCNAF') && !contextData.rdftypes.includes('Hub'))">
                           <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
                           <ul>
                             <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -261,7 +261,6 @@
                           </ul>
                         </template>
                         <template v-if="key == 'notes' && !contextData.collections.includes('http://id.loc.gov/authorities/names/collection_LCNAF')">
-                          {{ contextData.collections }}
                           <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
                           <ul>
                             <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -295,8 +295,8 @@
                           </ul>
                         </template>
                         <template v-else>
-                          <template v-if="['lcclasss', 'broaders'].includes(key)">
-                            <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
+                          <template v-if="['lcclasss', 'broaders', 'identifiers'].includes(key)">
+                            <div class="modal-context-data-title" v-if="key != 'identifiers'">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
                             <ul  class="details-list">
                               <template v-for="v in contextData[key]">
                                 <li class="modal-context-data-li" v-if="key=='lcclasss'">
@@ -308,12 +308,8 @@
                                   <button class="material-icons see-search" @click="newSearch(v)">search</button>
                                 </li>
                               </template>
-                            </ul>
-                          </template>
-                          <template v-else-if='["identifiers"].includes(key)'>
-                            <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                            <ul class="details-list">
-                              <li class="details-details modal-context-data-li">
+                              <li class="details-details" v-if="key == 'identifiers'">
+                                <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
                                 {{ contextData[key].join(" ; ") }}
                               </li>
                             </ul>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -260,6 +260,15 @@
                             </li>
                           </ul>
                         </template>
+                        <template v-if="key == 'notes' && !contextData.collections.includes('http://id.loc.gov/authorities/names/collection_LCNAF')">
+                          {{ contextData.collections }}
+                          <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                          <ul>
+                            <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])" v-for="(v, idx) in contextData[key] " v-bind:key="'var' + idx">
+                              {{v}}
+                            </li>
+                          </ul>
+                        </template>
                       </div>
                     </template>
 
@@ -1056,10 +1065,10 @@ data: function() {
     },
 
     panelDetailOrder: [
-            "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces", "gacs",
+            "notes", "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds","birthdates","deathdates", "birthplaces", "gacs",
             "locales", "activityfields","occupations","languages", "sees",
             "sources", "lcclasss", "identifiers","broaders",
-            "notes", "collections", "subjects", "marcKeys"
+            "collections", "subjects", "marcKeys"
         ],
     selectedSortOrder: ""
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -505,6 +505,7 @@ export const useConfigStore = defineStore('config', {
 				{
 					'MARC Audience':{"url": "https://id.loc.gov/vocabulary/maudience.html"},
 					'LCDGT':{"url": "https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+          'LCSH':{"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 				}
 			]
 		},

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -505,7 +505,7 @@ export const useConfigStore = defineStore('config', {
 				{
 					'MARC Audience':{"url": "https://id.loc.gov/vocabulary/maudience.html"},
 					'LCDGT':{"url": "https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
-          'LCSH':{"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+          // 'LCSH':{"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 				}
 			]
 		},

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -1518,13 +1518,12 @@ export const useProfileStore = defineStore('profile', {
       propertyPath = propertyPath.filter((v)=> { return (v.propertyURI!=='http://www.w3.org/2002/07/owl#sameAs')  })
 
       // if there's a code in the label, take it out
-      const code = URI.split("/").at(-1)  // is this reliable?
-      if (label.match("(" + code + ")")){
-        label = label.replace("(" + code + ")", "")
+      if (URI){
+        const code = URI.split("/").at(-1)  // is this reliable?
+        if (label.match("(" + code + ")")){
+          label = label.replace("(" + code + ")", "")
+        }
       }
-      // if (label.match(/\(.*\)/g)){
-      //   label = label.replace(/\(.*\)/g, "")
-      // }
 
       let lastProperty = propertyPath.at(-1).propertyURI
       // locate the correct pt to work on in the activeProfile


### PR DESCRIPTION
Some updates to details panel:
- `notes` shows up for anything that is not a `Name` or `Hub` to show scope notes at the top
- `identifiers` take up less space

Fix: Not being able to enter a literal in a simple lookup   
- was caused by look for a URI when there was none.