### PR TITLE
Bfp 389 stub nar improvments4

### DIFF
--- a/public/test_files/2023548475.xml
+++ b/public/test_files/2023548475.xml
@@ -1,0 +1,363 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:bf="http://id.loc.gov/ontologies/bibframe/"
+    xmlns:bflc="http://id.loc.gov/ontologies/bflc/"
+    xmlns:lclocal="http://id.loc.gov/ontologies/lclocal/"
+    xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:pmo="http://performedmusicontology.org/ontology/"
+    xmlns:streams="info:lc/streams#"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/">
+    <bf:Work rdf:about="http://id.loc.gov/resources/works/24184525">
+        <bflc:aap>Robu, Adriana Maria. Discursul public</bflc:aap>
+        <bflc:aap-normalized>robuadrianamariadiscursulpublic</bflc:aap-normalized>
+        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Text"/>
+        <bf:content>
+            <bf:Content rdf:about="http://id.loc.gov/vocabulary/contentTypes/txt">
+                <rdfs:label>text</rdfs:label>
+                <bf:code>txt</bf:code>
+            </bf:Content>
+        </bf:content>
+        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Monograph"/>
+        <bf:language>
+            <bf:Language rdf:about="http://id.loc.gov/vocabulary/languages/rum">
+                <rdfs:label xml:lang="en">Romanian</rdfs:label>
+                <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rum</bf:code>
+            </bf:Language>
+        </bf:language>
+        <bf:intendedAudience>
+            <bf:IntendedAudience rdf:about="http://id.loc.gov/vocabulary/maudience/adu">
+                <rdfs:label>adult</rdfs:label>
+                <bf:code>adu</bf:code>
+            </bf:IntendedAudience>
+        </bf:intendedAudience>
+        <bf:contribution>
+            <bf:Contribution>
+                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/PrimaryContribution"/>
+                <bf:agent>
+                    <bf:Agent>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Person"/>
+                        <rdfs:label>Robu, Adriana Maria</rdfs:label>
+                        <bflc:marcKey>1001 $aRobu, Adriana Maria.$d1900-2000</bflc:marcKey>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/aut">
+                        <rdfs:label>author</rdfs:label>
+                        <bf:code>aut</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+        <bf:title>
+            <bf:Title>
+                <bf:mainTitle>Discursul public</bf:mainTitle>
+            </bf:Title>
+        </bf:title>
+        <bf:contribution>
+            <bf:Contribution>
+                <bf:agent>
+                    <bf:Agent>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Person"/>
+                        <rdfs:label>Condurache, Daniel</rdfs:label>
+                        <bflc:marcKey>7001 $aCondurache, Daniel.$4pre</bflc:marcKey>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/pre">
+                        <rdfs:label>presenter</rdfs:label>
+                        <bf:code>pre</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+        <dcterms:isPartOf rdf:resource="http://id.loc.gov/resources/works"/>
+        <bf:hasInstance rdf:resource="http://id.loc.gov/resources/instances/24184525"/>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/n">
+                        <rdfs:label>new</rdfs:label>
+                        <bf:code>n</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-05</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-05-05T14:22:51</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlcmrc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress, Network Development and MARC Standards Office</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC-MRC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlcmrc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlcmrc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:generationProcess rdf:resource="https://github.com/lcnetdev/marc2bibframe2/tree/v2.10-dev"/>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-05-05T14:26:57.329489-04:00</bf:date>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:descriptionLevel rdf:resource="http://id.loc.gov/ontologies/bibframe-2-5-0/"/>
+                <bflc:encodingLevel>
+                    <bflc:EncodingLevel rdf:about="http://id.loc.gov/vocabulary/menclvl/5">
+                        <rdfs:label>preliminary</rdfs:label>
+                        <bf:code>5</bf:code>
+                    </bflc:EncodingLevel>
+                </bflc:encodingLevel>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/aacr">
+                        <rdfs:label>Anglo-American cataloguing rules</rdfs:label>
+                        <bf:code>aacr</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:identifiedBy>
+                    <bf:Local>
+                        <rdf:value>24184525</rdf:value>
+                        <bf:assigner>
+                            <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                                <rdfs:label>United States, Library of Congress</rdfs:label>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                            </bf:Organization>
+                        </bf:assigner>
+                    </bf:Local>
+                </bf:identifiedBy>
+                <lclocal:d906>=906     $a 0 $b ibc $c origres $d 3 $e ncip $f 20 $g y-gencatlg</lclocal:d906>
+                <lclocal:d925>=925  0  $a acquire $b * shelf copies $x policy default</lclocal:d925>
+                <lclocal:d955>=955     $b fc80 2025-05-05 z-processor</lclocal:d955>
+                <bf:note>
+                    <bf:Note>
+                        <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/internal"/>
+                        <rdfs:label>040  $aDLC$cDLC</rdfs:label>
+                    </bf:Note>
+                </bf:note>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/pcc">
+                        <rdfs:label>Program for Cooperative Cataloging</rdfs:label>
+                        <bf:code>pcc</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+    </bf:Work>
+    <bf:Instance rdf:about="http://id.loc.gov/resources/instances/24184525">
+        <bf:issuance>
+            <bf:Issuance rdf:about="http://id.loc.gov/vocabulary/issuance/mono">
+                <rdfs:label>single unit</rdfs:label>
+                <bf:code>mono</bf:code>
+            </bf:Issuance>
+        </bf:issuance>
+        <bf:provisionActivity>
+            <bf:ProvisionActivity>
+                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Publication"/>
+                <bf:date rdf:datatype="http://id.loc.gov/datatypes/edtf">2022</bf:date>
+                <bf:place>
+                    <bf:Place rdf:about="http://id.loc.gov/vocabulary/countries/rm">
+                        <rdfs:label xml:lang="en">Romania</rdfs:label>
+                        <bf:code rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rm</bf:code>
+                    </bf:Place>
+                </bf:place>
+                <bflc:simplePlace>Bucureşti</bflc:simplePlace>
+                <bflc:simpleAgent>Editura Universităţii din Bucureşti - Bucharest University Press</bflc:simpleAgent>
+                <bflc:simpleDate>2022</bflc:simpleDate>
+            </bf:ProvisionActivity>
+        </bf:provisionActivity>
+        <bf:publicationStatement>Bucureşti: Editura Universităţii din Bucureşti - Bucharest University Press, 2022</bf:publicationStatement>
+        <bf:media>
+            <bf:Media rdf:about="http://id.loc.gov/vocabulary/mediaTypes/n">
+                <rdfs:label>unmediated</rdfs:label>
+                <bf:code>n</bf:code>
+            </bf:Media>
+        </bf:media>
+        <bf:identifiedBy>
+            <bf:Lccn>
+                <rdf:value>  2023548475</rdf:value>
+            </bf:Lccn>
+        </bf:identifiedBy>
+        <bf:identifiedBy>
+            <bf:Isbn>
+                <rdf:value>9786061613748</rdf:value>
+            </bf:Isbn>
+        </bf:identifiedBy>
+        <bf:identifiedBy>
+            <bf:Isbn>
+                <rdf:value>6061613741</rdf:value>
+            </bf:Isbn>
+        </bf:identifiedBy>
+        <bf:responsibilityStatement>Adriana Maria Robu ; pref. de Daniel Condurache.</bf:responsibilityStatement>
+        <bf:title>
+            <bf:Title>
+                <bf:mainTitle>Discursul public</bf:mainTitle>
+                <bf:subtitle>ghid pentru dezvoltarea abilităţii dea vorbi în public</bf:subtitle>
+            </bf:Title>
+        </bf:title>
+        <bf:extent>
+            <bf:Extent>
+                <rdfs:label>199 p.</rdfs:label>
+            </bf:Extent>
+        </bf:extent>
+        <bf:note>
+            <bf:Note>
+                <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/physical"/>
+                <rdfs:label>il.</rdfs:label>
+            </bf:Note>
+        </bf:note>
+        <bf:dimensions>21 cm</bf:dimensions>
+        <bf:note>
+            <bf:Note>
+                <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/biblio"/>
+                <rdfs:label>Include bibliogr.</rdfs:label>
+            </bf:Note>
+        </bf:note>
+        <dcterms:isPartOf rdf:resource="http://id.loc.gov/resources/instances"/>
+        <bf:instanceOf rdf:resource="http://id.loc.gov/resources/works/24184525"/>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/n">
+                        <rdfs:label>new</rdfs:label>
+                        <bf:code>n</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2025-05-05</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-05-05T14:22:51</bf:date>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:status>
+                    <bf:Status rdf:about="http://id.loc.gov/vocabulary/mstatus/c">
+                        <rdfs:label>changed</rdfs:label>
+                        <bf:code>c</bf:code>
+                    </bf:Status>
+                </bf:status>
+                <bf:agent>
+                    <bf:Agent rdf:about="http://id.loc.gov/vocabulary/organizations/dlcmrc">
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>United States, Library of Congress, Network Development and MARC Standards Office</rdfs:label>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC-MRC</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlcmrc</bf:code>
+                        <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlcmrc</bf:code>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:generationProcess rdf:resource="https://github.com/lcnetdev/marc2bibframe2/tree/v2.10-dev"/>
+                <bf:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-05-05T14:26:57.329489-04:00</bf:date>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+        <bf:adminMetadata>
+            <bf:AdminMetadata>
+                <bf:descriptionLevel rdf:resource="http://id.loc.gov/ontologies/bibframe-2-5-0/"/>
+                <bflc:encodingLevel>
+                    <bflc:EncodingLevel rdf:about="http://id.loc.gov/vocabulary/menclvl/5">
+                        <rdfs:label>preliminary</rdfs:label>
+                        <bf:code>5</bf:code>
+                    </bflc:EncodingLevel>
+                </bflc:encodingLevel>
+                <bf:descriptionConventions>
+                    <bf:DescriptionConventions rdf:about="http://id.loc.gov/vocabulary/descriptionConventions/aacr">
+                        <rdfs:label>Anglo-American cataloguing rules</rdfs:label>
+                        <bf:code>aacr</bf:code>
+                    </bf:DescriptionConventions>
+                </bf:descriptionConventions>
+                <bf:identifiedBy>
+                    <bf:Local>
+                        <rdf:value>24184525</rdf:value>
+                        <bf:assigner>
+                            <bf:Organization rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+                                <rdfs:label>United States, Library of Congress</rdfs:label>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</bf:code>
+                                <bf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</bf:code>
+                            </bf:Organization>
+                        </bf:assigner>
+                    </bf:Local>
+                </bf:identifiedBy>
+                <lclocal:d906>=906     $a 0 $b ibc $c origres $d 3 $e ncip $f 20 $g y-gencatlg</lclocal:d906>
+                <lclocal:d925>=925  0  $a acquire $b * shelf copies $x policy default</lclocal:d925>
+                <lclocal:d955>=955     $b fc80 2025-05-05 z-processor</lclocal:d955>
+                <bf:note>
+                    <bf:Note>
+                        <rdf:type rdf:resource="http://id.loc.gov/vocabulary/mnotetype/internal"/>
+                        <rdfs:label>040  $aDLC$cDLC</rdfs:label>
+                    </bf:Note>
+                </bf:note>
+                <bf:descriptionAuthentication>
+                    <bf:DescriptionAuthentication rdf:about="http://id.loc.gov/vocabulary/marcauthen/pcc">
+                        <rdfs:label>Program for Cooperative Cataloging</rdfs:label>
+                        <bf:code>pcc</bf:code>
+                    </bf:DescriptionAuthentication>
+                </bf:descriptionAuthentication>
+            </bf:AdminMetadata>
+        </bf:adminMetadata>
+    </bf:Instance>
+</rdf:RDF>

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2064,7 +2064,7 @@ const utilsExport = {
 		return marcTxt
 	},
 
-	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements){
+	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements,useAdvancedMode){
 		let marcTxt = ''
 		marcTxt = marcTxt + " 111111111122222222223333333333\n"
 		marcTxt = marcTxt + "       0123456789012345678901234567890123456789\n"
@@ -2277,7 +2277,7 @@ const utilsExport = {
 
 
 
-		if (pos29 === 'b'){
+		if (pos29 === 'b' && !useAdvancedMode){
 
 			let field667 = document.createElementNS(marcNamespace,"marcxml:datafield");
 			field667.setAttribute( 'tag', '667')
@@ -2336,10 +2336,10 @@ const utilsExport = {
 		// 	field670SubfieldsValues.push(`$w (DLC)${mainTitleLccn}`)
 		// }
 
-		marcTextArray.push({txt: this.buildMarcTxtLine('670', ' ', ' ', field670SubfieldsValues), field: '670', fieldInt: 670})
-
-
-		rootEl.appendChild(field670)
+		if (!useAdvancedMode){
+			marcTextArray.push({txt: this.buildMarcTxtLine('670', ' ', ' ', field670SubfieldsValues), field: '670', fieldInt: 670})
+			rootEl.appendChild(field670)
+		}
 
 
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -9,7 +9,7 @@ import utilsMisc from './utils_misc';
 import utilsNetwork from './utils_network';
 import utilsProfile from './utils_profile';
 
-import { parse as parseEDTF } from 'edtf'
+import { parse, parse as parseEDTF } from 'edtf'
 
 import { md5 } from "hash-wasm";
 
@@ -2064,10 +2064,13 @@ const utilsExport = {
 		return marcTxt
 	},
 
-	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667){
+	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements){
 		let marcTxt = ''
-		marcTxt = marcTxt + "111111111122222222223333333333\n"
-		marcTxt = marcTxt + "       123456789012345678901234567890123456789\n"
+		marcTxt = marcTxt + " 111111111122222222223333333333\n"
+		marcTxt = marcTxt + "       0123456789012345678901234567890123456789\n"
+
+		let marcTextArray = []
+
 
 		let marcNamespace = "http://www.loc.gov/MARC21/slim"
 
@@ -2095,6 +2098,8 @@ const utilsExport = {
 		// did they make a 4xx
 		if (fourXXParts && fourXXParts.a && add667){
 			pos29 = 'b'
+		}else if (fourXXParts && fourXXParts.a && !add667){
+			pos29 = 'a'
 		}
 
 		let pos32 = "a"
@@ -2113,15 +2118,19 @@ const utilsExport = {
 		let field001 = document.createElementNS(marcNamespace,"marcxml:controlfield");
 		field001.setAttribute( 'tag', '001')
 		field001.innerHTML = "n"+lccn
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('001',' ',' ',["n"+lccn])
+		
+
+		marcTextArray.push({txt: this.buildMarcTxtLine('001',' ',' ',["n"+lccn]), field: '001', fieldInt: 1})
+
+
 		rootEl.appendChild(field001)
 
 		let field003 = document.createElementNS(marcNamespace,"marcxml:controlfield");
 		field003.setAttribute( 'tag', '003')
 		field003.innerHTML = "DLC"
 		rootEl.appendChild(field003)
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('003',' ',' ',["DLC"])
 
+		marcTextArray.push({txt: this.buildMarcTxtLine('003',' ',' ',["DLC"]), field: '003', fieldInt: 3})
 
 
 
@@ -2130,7 +2139,8 @@ const utilsExport = {
 		field005.setAttribute( 'tag', '005')
 		field005.innerHTML = dateValue
 		rootEl.appendChild(field005)
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('005',' ',' ',[dateValue])
+		
+		marcTextArray.push({txt: this.buildMarcTxtLine('005',' ',' ',[dateValue]), field: '005', fieldInt: 5})
 
 
 
@@ -2145,7 +2155,8 @@ const utilsExport = {
 		field010.appendChild(field010a)
 		rootEl.appendChild(field010)
 
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('010',' ',' ',[`$a n ${lccn}`])
+
+		marcTextArray.push({txt: this.buildMarcTxtLine('010',' ',' ',[`$a n ${lccn}`]), field: '010', fieldInt: 10})
 
 
 		let field040 = document.createElementNS(marcNamespace,"marcxml:datafield");
@@ -2172,7 +2183,7 @@ const utilsExport = {
 		field040c.innerHTML = 'DLC'
 		field040.appendChild(field040c)
 
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('040',' ',' ',[`$a DLC`, `$b eng`, `$e rda`, `$c DLC`])
+		marcTextArray.push({txt: this.buildMarcTxtLine('040',' ',' ',[`$a DLC`, `$b eng`, `$e rda`, `$c DLC`]), field: '040', fieldInt: 40})
 
 
 		rootEl.appendChild(field040)
@@ -2208,7 +2219,8 @@ const utilsExport = {
 			field046.appendChild(field0462)
 			rootEl.appendChild(field046)
 
-			marcTxt =  marcTxt+ this.buildMarcTxtLine('046',' ',' ',subfieldsValues)
+
+			marcTextArray.push({txt: this.buildMarcTxtLine('046',' ',' ',subfieldsValues), field: '046', fieldInt: 46})
 
 
 		}
@@ -2236,7 +2248,7 @@ const utilsExport = {
 		}
 		// 110//$aMiller, Sam$d1933
 		rootEl.appendChild(fieldName)
-		marcTxt =  marcTxt+ this.buildMarcTxtLine(oneXXParts.fieldTag, oneXXParts.indicators.charAt(0).replace(" ","#"), oneXXParts.indicators.charAt(1).replace(" ","#"), oneXXSubfieldsValues)
+		marcTextArray.push({txt: this.buildMarcTxtLine(oneXXParts.fieldTag, oneXXParts.indicators.charAt(0).replace(" ","#"), oneXXParts.indicators.charAt(1).replace(" ","#"), oneXXSubfieldsValues), field: oneXXParts.fieldTag, fieldInt: parseInt(oneXXParts.fieldTag)})
 
 
 		// did they make a 4xx
@@ -2259,7 +2271,8 @@ const utilsExport = {
 			}
 
 			rootEl.appendChild(fieldName4xx)
-			marcTxt =  marcTxt+ this.buildMarcTxtLine(fourXXParts.fieldTag, fourXXParts.indicators.charAt(0).replace(" ","#"), fourXXParts.indicators.charAt(1).replace(" ","#"), fourXXSubfieldsValues)
+			marcTextArray.push({txt: this.buildMarcTxtLine(fourXXParts.fieldTag, fourXXParts.indicators.charAt(0).replace(" ","#"), fourXXParts.indicators.charAt(1).replace(" ","#"), fourXXSubfieldsValues), field: fourXXParts.fieldTag, fieldInt: parseInt(fourXXParts.fieldTag)})
+		
 		}
 
 
@@ -2276,7 +2289,7 @@ const utilsExport = {
 			field667.appendChild(field667a)
 
 			rootEl.appendChild(field667)
-			marcTxt =  marcTxt+ this.buildMarcTxtLine('667', ' ', ' ', ['$a Non-Latin script references not evaluated.'])
+			marcTextArray.push({txt: this.buildMarcTxtLine('667', ' ', ' ', ['$a Non-Latin script references not evaluated.']), field: '667', fieldInt: 667})
 
 
 		}
@@ -2323,8 +2336,9 @@ const utilsExport = {
 		// 	field670SubfieldsValues.push(`$w (DLC)${mainTitleLccn}`)
 		// }
 
+		marcTextArray.push({txt: this.buildMarcTxtLine('670', ' ', ' ', field670SubfieldsValues), field: '670', fieldInt: 670})
 
-		marcTxt =  marcTxt+ this.buildMarcTxtLine('670', ' ', ' ', field670SubfieldsValues)
+
 		rootEl.appendChild(field670)
 
 
@@ -2352,10 +2366,45 @@ const utilsExport = {
 		// they dont need to preview this
 		// marcTxt =  marcTxt+ this.buildMarcTxtLine('985',' ',' ',[`$e MARVA-NAR`, `$d ${field985d.innerHTML}`])
 
+		if (extraMarcStatements && extraMarcStatements.length > 0){
+			for (let x of extraMarcStatements){
+				let field = document.createElementNS(marcNamespace,"marcxml:datafield");
+				field.setAttribute( 'tag', x.fieldTag)
+				field.setAttribute( 'ind1', x.indicators.charAt(0))
+				field.setAttribute( 'ind2', x.indicators.charAt(1))
+
+				let useSubfieldsValues = []
+				for (let key of Object.keys(x)){
+					if (key.length == 1){
+						let subfield = document.createElementNS(marcNamespace,"marcxml:subfield");
+						subfield.setAttribute( 'code', key)
+						subfield.innerHTML = x[key]
+						field.appendChild(subfield)
+						useSubfieldsValues.push(`$${key} ${x[key]}`)
+
+					}
+				}
+				rootEl.appendChild(field)
+				marcTextArray.push({txt: this.buildMarcTxtLine(x.fieldTag, ' ', ' ', useSubfieldsValues), field: x.fieldTag, fieldInt: parseInt(x.fieldTag)})
+
+			}
+		}
 
 
-
-
+		// sort what we have
+		marcTextArray = marcTextArray.sort((a, b) => {
+			if (a.fieldInt < b.fieldInt) {
+			  return -1;
+			}
+			if (a.fieldInt > b.fieldInt) {
+			  return 1;
+			}
+			return 0;
+		  });		
+		  console.log(marcTextArray)
+		  marcTextArray.map((x) => {
+			marcTxt = marcTxt + x.txt
+		  })
 
 
 		console.log(marcTxt)

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -364,8 +364,9 @@ export const useConfigStore = defineStore('config', {
 
     {lccn:'2026888777',label:"Secondary Instance Test", idUrl:'https://id.loc.gov/resources/instances/2026888777.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
+    {lccn:'2023548475',label:"Create NAR test", idUrl:'https://id.loc.gov/resources/instances/2023548475.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
-
+    
 
   ],
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1044,6 +1044,16 @@ export const usePreferenceStore = defineStore('preference', {
         group: 'Complex Lookup',
         range: [true,false]
       },
+      '--b-edit-complex-nar-advanced-mode' : {
+        desc: 'Default to the advanced mode display when creating NARs.',
+        descShort: 'Use NAR Advanced Mode by default',
+        value: false,
+        type: 'boolean',
+        unit: null,
+        group: 'Complex Lookup',
+        range: [true,false]
+      },
+
 
       //general
       '--c-general-icon-instance-color' : {

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5705,10 +5705,10 @@ export const useProfileStore = defineStore('profile', {
       * @param {string} langObj - {uri:"",label:""}
       * @return {String}
       */
-    async buildNacoStub(oneXX,fourXX,mainTitle,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements){
+    async buildNacoStub(oneXX,fourXX,mainTitle,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements,useAdvancedMode){
       console.log(oneXX,fourXX,mainTitle,workURI,zero46)
       let lccn = await utilsNetwork.nacoLccn()
-      let NARData = await utilsExport.createNacoStubXML(oneXX,fourXX,mainTitle,lccn,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements)
+      let NARData = await utilsExport.createNacoStubXML(oneXX,fourXX,mainTitle,lccn,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements,useAdvancedMode)
       NARData.lccn = lccn
       return NARData
     },

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5450,8 +5450,15 @@ export const useProfileStore = defineStore('profile', {
                   && pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement']
                   && pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement'][0]
                   && pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement'][0]['http://id.loc.gov/ontologies/bibframe/responsibilityStatement']
-                )
-                return pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement'][0]['http://id.loc.gov/ontologies/bibframe/responsibilityStatement']
+                ){
+                let sor = pt.userValue['http://id.loc.gov/ontologies/bibframe/responsibilityStatement'][0]['http://id.loc.gov/ontologies/bibframe/responsibilityStatement']
+                
+                if (sor.endsWith(".")) {
+                  sor = sor.slice(0, -1);
+                }
+
+                return sor
+              }
             }
           }
         }
@@ -5657,6 +5664,36 @@ export const useProfileStore = defineStore('profile', {
       return false
     },
 
+    nacoStubReturnPopulatedValue(guid){
+      let pt = utilsProfile.returnPt(this.activeProfile,guid)
+      let URI = null
+      let marcKey = null
+      if (pt && 
+          pt.userValue && 
+          pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'] &&
+          pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0] &&
+          pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'] &&
+          pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'][0]){
+
+            let agent = pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'][0]
+            if (agent && agent['@id']){
+              URI = agent['@id']
+            }
+            if (agent && agent['http://id.loc.gov/ontologies/bflc/marcKey'] &&
+                agent['http://id.loc.gov/ontologies/bflc/marcKey'][0] &&
+                agent['http://id.loc.gov/ontologies/bflc/marcKey'][0]['http://id.loc.gov/ontologies/bflc/marcKey']
+              ){
+                marcKey = agent['http://id.loc.gov/ontologies/bflc/marcKey'][0]['http://id.loc.gov/ontologies/bflc/marcKey']
+            }
+            
+          }
+      
+      return {
+        URI: URI,
+        marcKey: marcKey
+      }
+
+    },
 
 
 
@@ -5668,10 +5705,10 @@ export const useProfileStore = defineStore('profile', {
       * @param {string} langObj - {uri:"",label:""}
       * @return {String}
       */
-    async buildNacoStub(oneXX,fourXX,mainTitle,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667){
+    async buildNacoStub(oneXX,fourXX,mainTitle,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements){
       console.log(oneXX,fourXX,mainTitle,workURI,zero46)
       let lccn = await utilsNetwork.nacoLccn()
-      let NARData = await utilsExport.createNacoStubXML(oneXX,fourXX,mainTitle,lccn,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667)
+      let NARData = await utilsExport.createNacoStubXML(oneXX,fourXX,mainTitle,lccn,workURI, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements)
       NARData.lccn = lccn
       return NARData
     },


### PR DESCRIPTION
Adds Advanced mode to preferences which toggles a new interface in the NAR modal that controls adding all non-1xx/4xx fields, so you manually have control over how the 670/667/4xx variant, etc look. You can also use it to add arbitrary fields...

Add auto hyphenated name 4xx creator.