### PR TITLE
Fix Relationship Population in Marva

### DIFF
--- a/src/lib/auto_dewey.js
+++ b/src/lib/auto_dewey.js
@@ -1974,8 +1974,6 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
                     _convertClassGvSport(letter + number)
                 }
             }
-            console.info("autoDeweyGenre: ", autoDeweyGenre)
-            console.info("sDewey$: ", sDewey$)
             if (autoDeweyGenre && !sDewey$) return [
                 false,
                 {
@@ -2013,24 +2011,18 @@ import lccDeweyMap from "@/lib/LCCtoDewey.json"
 
             if (ruleMatches.length > 1) {
                 for (const rule of ruleMatches) {
-                    console.info("rule: ", rule)
                     let range = rule['LCC Range'].replace(rule.LCC, '').trim()
-                    console.info("\trange: ", range)
                     if (range.charAt(range.length - 1) == '+') {
                         range = range.replace('+', ' - 999999999')
                     }
                     const [rangeStart, rangeEnd] = range.split('-')
-                    console.info('range', range, rangeStart, rangeEnd)
-                    console.info('number', number)
                     if (number * 1 >= rangeStart * 1 && number * 1 <= rangeEnd * 1) {
-                        console.info('number WITHIN range', number)
                         rule.mode = 'basic'
                         return [rule.dewey, rule]
                     }
                 }
 
                 //if no range found just use first (generic) one
-                console.info("ruleMatches: ", ruleMatches)
                 return [ruleMatches, ruleMatches]
                 // return [ruleMatches[0].dewey, ruleMatches[0]]
             }

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -301,25 +301,26 @@ const utilsParse = {
         // console.log('hasAssociatedResource',hasAssociatedResource)
 
       // old Logic
-      if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) && child.innerHTML.indexOf("hasSeries")>-1){
+      if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) && (child.innerHTML.indexOf("hasSeries")>-1 || child.innerHTML.indexOf("bf:Series")>-1)){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
       } else if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) &&  child.innerHTML.indexOf("vocabulary/relationship/series")>-1 && child.innerHTML.indexOf("vocabulary/mstatus/t")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
       } else if ( (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bf/Uncontrolled")>-1) &&  child.innerHTML.indexOf("vocabulary/relationship/series")>-1 && child.innerHTML.indexOf("vocabulary/mstatus/t")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
-      } else if ( (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bibframe/Uncontrolled")>-1) &&  child.innerHTML.indexOf("hasSeries")>-1){
+      } else if ( (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bibframe/Uncontrolled")>-1) && (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 )){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
-      }else if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) && child.innerHTML.indexOf("hasSeries")==-1){
+      }else if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) && (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 )){
         child.setAttribute('local:pthint', 'lc:RT:bf2:RelWorkLookup')
-      } else if ( (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bibframe/Uncontrolled")>-1) &&  child.innerHTML.indexOf("hasSeries")==-1){
+      } else if ( (child.innerHTML.indexOf("bflc/Uncontrolled")>-1||child.innerHTML.indexOf("bibframe/Uncontrolled")>-1) && (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 )){
         child.setAttribute('local:pthint', 'lc:RT:bf2:RelWorkLookup')
       } else if ( (child.innerHTML.indexOf("bf:Hub")>-1 || child.innerHTML.indexOf("bf:Work")>-1) &&  child.innerHTML.indexOf("hasSeries")>-1   ){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHubLookup')
-      } else if ( (child.innerHTML.indexOf("bf:Work")>-1) &&  child.innerHTML.indexOf("hasSeries")==-1   ){
+
+      } else if ( (child.innerHTML.indexOf("bf:Work")>-1) &&  (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 ) ){
         child.setAttribute('local:pthint', 'lc:RT:bf2:RelWorkLookup')
-      } else if ( (child.innerHTML.indexOf("bf:Hub")>-1 ) &&  child.innerHTML.indexOf("hasSeries")==-1   ){
+      } else if ( (child.innerHTML.indexOf("bf:Hub")>-1 ) &&  (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 )  ){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHubLookup')
-      } else if (child.innerHTML.indexOf("bf:Work")>-1){
+      } else if (child.innerHTML.indexOf("bf:Work")>-1 || child.innerHTML.indexOf("bf:Hub")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:RelWorkLookup')
       }else{
       // leave blank?
@@ -376,7 +377,7 @@ const utilsParse = {
 
 
   specialTransforms: {
-    // not currently used
+    //not used currently
   },
 
   updateAdditionalInstanceParentValues: function(profile, instanceName, newRdId){
@@ -578,7 +579,6 @@ const utilsParse = {
       // at this point we have the main piece of the xml tree that has all our data
       // loop through properties we are looking for and build out the the profile
       for (let k in pt){
-
 
         let ptk = JSON.parse(JSON.stringify(pt[k]))
         // make sure each new one has a unique guid
@@ -797,7 +797,6 @@ const utilsParse = {
             // so populateData.userValue['http://id.loc.gov/bibframe/title'] becomes userValue
             populateData.userValue[populateData.propertyURI] = [{}]
             let userValue = populateData.userValue[populateData.propertyURI][0]
-
 
             // we have some special functions to deal with tricky elements
             if (this.specialTransforms[prefixURI]){

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -300,6 +300,7 @@ const utilsParse = {
         // console.log('hasSeries',hasSeries)
         // console.log('hasAssociatedResource',hasAssociatedResource)
 
+      console.info("child: ", child.innerHTML)
       // old Logic
       if ( (child.innerHTML.indexOf("bflc:Uncontrolled")>-1||child.innerHTML.indexOf("bf:Uncontrolled")>-1) && (child.innerHTML.indexOf("hasSeries")>-1 || child.innerHTML.indexOf("bf:Series")>-1)){
         child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHub')
@@ -318,13 +319,14 @@ const utilsParse = {
 
       } else if ( (child.innerHTML.indexOf("bf:Work")>-1) &&  (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 ) ){
         child.setAttribute('local:pthint', 'lc:RT:bf2:RelWorkLookup')
-      } else if ( (child.innerHTML.indexOf("bf:Hub")>-1 ) &&  (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 )  ){
-        child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHubLookup')
+      // } else if ( (child.innerHTML.indexOf("bf:Hub")>-1 ) &&  (child.innerHTML.indexOf("hasSeries")==-1 && child.innerHTML.indexOf("bf:Series")==-1 )  ){
+      //   child.setAttribute('local:pthint', 'lc:RT:bf2:SeriesHubLookup')
       } else if (child.innerHTML.indexOf("bf:Work")>-1 || child.innerHTML.indexOf("bf:Hub")>-1){
         child.setAttribute('local:pthint', 'lc:RT:bf2:RelWorkLookup')
       }else{
       // leave blank?
       }
+      console.info("child: ", child)
 
         // console.log("SETTING SNIFF TEST: ", child.getAttribute('local:pthint'))
         // console.log("-->", child)

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -51,12 +51,12 @@ export const useConfigStore = defineStore('config', {
         // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
         // offical stage profiles inside the firewall
-        // starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
-        // profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
+        starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
+        profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
 
         // offical prod profiles inside the firewall
-        starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
-        profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
+        // starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
+        // profiles: 'https://editor.id.loc.gov/bfe2/util/profiles/profile/prod',
 
 
 
@@ -369,7 +369,7 @@ export const useConfigStore = defineStore('config', {
 
     {lccn:'2023548475',label:"Create NAR test", idUrl:'https://id.loc.gov/resources/instances/2023548475.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
-    
+
 
   ],
 

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -39,7 +39,7 @@
                 <p>Worked Records: {{dashBoard.byTimePeriod.all.workedRecords}}</p>
                 <p>Posted Records: {{dashBoard.byTimePeriod.all.postedRecords}}</p>
               </div>
-              
+
 
             </div>
           </div>
@@ -368,21 +368,21 @@
         let dashBoard = {
           byTimePeriod:{
             'last24Hours':{
-              uniqueUsers: {},              
+              uniqueUsers: {},
               workedRecords: 0,
               postedRecords: 0,
             },
             'last7Days':{
-              uniqueUsers: {},              
+              uniqueUsers: {},
               workedRecords: 0,
               postedRecords: 0,
             },
             'all':{
-              uniqueUsers: {},              
+              uniqueUsers: {},
               workedRecords: 0,
               postedRecords: 0,
             }
-          },          
+          },
           totalDays:0,
 
         }
@@ -430,10 +430,10 @@
           }
           if (timestamp < oldestDate){
             oldestDate = timestamp
-          }         
+          }
           this.allRecords.push(obj)
         }
-        dashBoard.totalDays = Math.floor((new Date().getTime()/1000 - oldestDate)/86400)       
+        dashBoard.totalDays = Math.floor((new Date().getTime()/1000 - oldestDate)/86400)
         console.log(dashBoard)
         this.dashBoard = dashBoard
 


### PR DESCRIPTION
Fix: Marva not distinguishing between `Input transcribed series` and `Search related work/series` in incoming data.

These have similar structures and Marva's helper function, `sniffWorkRelationType()`, needed an update to account for some changes to the profiles. 

Example:  with both fields 2019666477

