### PR TITLE
Adjust Component Library to work with Items

### DIFF
--- a/src/components/panels/edit/fields/Ref.vue
+++ b/src/components/panels/edit/fields/Ref.vue
@@ -191,7 +191,7 @@ export default {
       // if this is true, a default value is being "used" because the incoming value
       // doesn't match an available option
       // ignore for subjects
-        if (userValue['@type'] && !this.structure.id.includes("subject") && this.rtLookup[useId].resourceURI != userValue['@type']){
+        if (userValue['@type'] && !(this.structure.id.includes("subject") || this.structure.id.includes("genreform")) && this.rtLookup[useId].resourceURI != userValue['@type']){
         let elementId = this.structure['@guid'] + "-select"
         this.$nextTick(() => {
           window.setTimeout(()=> {
@@ -208,7 +208,7 @@ export default {
 
           },10);
         });
-      } else if (userValue['@type'] && !this.structure.id.includes("subject") && this.rtLookup[useId].resourceURI == userValue['@type']){
+      } else if (userValue['@type'] && !(this.structure.id.includes("subject") || this.structure.id.includes("genreform")) && this.rtLookup[useId].resourceURI == userValue['@type']){
         // remove the class
         this.$nextTick(() => {
           window.setTimeout(()=> {

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -245,6 +245,7 @@ export const useProfileStore = defineStore('profile', {
      * @return {array}
      */
      returnComponentLibrary: (state) => {
+      console.info("returnComponentLibrary")
       // limit to the current profiles being used
       // console.log(state.activeProfile)
       // console.log(state.componentLibrary)
@@ -254,6 +255,7 @@ export const useProfileStore = defineStore('profile', {
       // }
       let results = []
       for (let key in state.activeProfile.rt){
+        console.info("key: ", key)
         // Items have something added to the end of the key
         if (key && key.includes(":Item")){
             if (key.includes("-") || key.includes("_")){
@@ -265,7 +267,8 @@ export const useProfileStore = defineStore('profile', {
                 key = key.slice(0, idx)
             }
         }
-
+        console.info("key2: ", key)
+        console.info("state.componentLibrary.profiles: ", state.componentLibrary.profiles)
         // ther are components saved for this profile
         if (state.componentLibrary.profiles[key]){
           let groups = {}
@@ -5839,7 +5842,7 @@ export const useProfileStore = defineStore('profile', {
      * @param {string} guid - The GUID of the component
      */
     addToComponentLibrary: async function(guid){
-
+      console.info("addToComponentLibrary")
       let structure = JSON.parse(JSON.stringify(this.returnStructureByComponentGuid(guid)))
 
       // clean up component property values for storage
@@ -5866,6 +5869,23 @@ export const useProfileStore = defineStore('profile', {
         }
       }
 
+      console.info("label: ", label)
+      console.info("structure: ", structure)
+
+      if (structure['parentId'].includes(":Item")){
+        let key = structure['parentId']
+        if (key && key.includes(":Item")){
+          if (key.includes("-") || key.includes("_")){
+              let idx
+              idx = key.indexOf("_")
+              if (idx < 0){
+                  idx = key.indexOf("-")
+              }
+              key = key.slice(0, idx)
+          }
+        }
+        structure['parentId'] = key
+      }
 
       this.componentLibrary.profiles[structure['parentId']].groups.push({
         id: short.generate(),

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -245,7 +245,6 @@ export const useProfileStore = defineStore('profile', {
      * @return {array}
      */
      returnComponentLibrary: (state) => {
-      console.info("returnComponentLibrary")
       // limit to the current profiles being used
       // console.log(state.activeProfile)
       // console.log(state.componentLibrary)
@@ -255,7 +254,6 @@ export const useProfileStore = defineStore('profile', {
       // }
       let results = []
       for (let key in state.activeProfile.rt){
-        console.info("key: ", key)
         // Items have something added to the end of the key
         if (key && key.includes(":Item")){
             if (key.includes("-") || key.includes("_")){
@@ -267,8 +265,6 @@ export const useProfileStore = defineStore('profile', {
                 key = key.slice(0, idx)
             }
         }
-        console.info("key2: ", key)
-        console.info("state.componentLibrary.profiles: ", state.componentLibrary.profiles)
         // ther are components saved for this profile
         if (state.componentLibrary.profiles[key]){
           let groups = {}
@@ -5842,7 +5838,6 @@ export const useProfileStore = defineStore('profile', {
      * @param {string} guid - The GUID of the component
      */
     addToComponentLibrary: async function(guid){
-      console.info("addToComponentLibrary")
       let structure = JSON.parse(JSON.stringify(this.returnStructureByComponentGuid(guid)))
 
       // clean up component property values for storage
@@ -5868,9 +5863,6 @@ export const useProfileStore = defineStore('profile', {
           groups:[]
         }
       }
-
-      console.info("label: ", label)
-      console.info("structure: ", structure)
 
       if (structure['parentId'].includes(":Item")){
         let key = structure['parentId']

--- a/tests-playwright/components/complex_lookup/add_nar_class_number.spec.js
+++ b/tests-playwright/components/complex_lookup/add_nar_class_number.spec.js
@@ -1,4 +1,5 @@
 // @ts-check
+// Check Loading a class number from a NAR then saving from the shelflisting tool
 import { test, expect } from '@playwright/test';
 
 test('Load a class number from a NAR', async ({ page }) => {

--- a/tests-playwright/components/complex_lookup/defaults_authority_class_number.spec.js
+++ b/tests-playwright/components/complex_lookup/defaults_authority_class_number.spec.js
@@ -1,0 +1,27 @@
+// @ts-check
+// That adding defaults after load a class number from an authority's details
+import { test, expect } from '@playwright/test';
+
+test('Load a class number from a NAR', async ({ page }) => {
+  await page.goto('http://localhost:5555/bfe2/quartz/');
+
+  await page.getByText('Click Here').click();
+  page.once('dialog', dialog => {
+    console.log(`Dialog message: ${dialog.message()}`);
+    dialog.dismiss().catch(() => {});
+  });
+  await page.getByRole('group').getByRole('button', { name: 'Monograph', exact: true }).click();
+  await page.locator('form').filter({ hasText: 'Search LCSH/LCNAF' }).getByRole('textbox').click();
+  await page.locator('form').filter({ hasText: 'Search LCSH/LCNAFbolt' }).getByRole('textbox').fill('d');
+  await page.getByRole('textbox', { name: 'Enter Subject Headings Here' }).fill('dogs');
+  await page.locator('div').filter({ hasText: /^Dogs \(Auth Hd\) public$/ }).locator('span').first().click();
+  await page.getByRole('listitem').filter({ hasText: 'QL737.C22add' }).getByRole('button').click();
+  await page.getByRole('button', { name: 'Close' }).click();
+  await expect(page.locator('div').filter({ hasText: /^Classification numberClassWeb Search: QL737\.C22ClassWeb Browse: QL737\.C22$/ }).getByRole('textbox')).toHaveValue('QL737.C22');
+  await page.locator('div').filter({ hasText: /^Classification numberClassWeb Search: QL737\.C22ClassWeb Browse: QL737\.C22$/ }).getByRole('textbox').click();
+  await page.getByRole('button', { name: 'bolt' }).click();
+  await page.getByRole('button', { name: 'Insert Default Values' }).click();
+  await expect(page.locator('[id="edit_lc\\:RT\\:bf2\\:Monograph\\:Work_id_loc_gov_ontologies_bibframe_classification__classification_numbers"]')).toContainText('United States, Library of Congress');
+  await expect(page.locator('[id="edit_lc\\:RT\\:bf2\\:Monograph\\:Work_id_loc_gov_ontologies_bibframe_classification__classification_numbers"]')).toContainText('used by assignerx');
+
+});


### PR DESCRIPTION
Updated: Component Library for Items
Fix: g/f selection in items. Was triggering the `select type` warning

Items always seem to have something extra added to their IDs. Not just `...:Item` but `...:Item-0`. When dealing with components for Items, Marva will strip away the extra qualifying information so no matter what the Item has added to it, it'll work as a component for an Item.