### PR TITLE
Fix mismatch IDs for label components

### DIFF
--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5857,13 +5857,6 @@ export const useProfileStore = defineStore('profile', {
         return false
       }
 
-
-      if (!this.componentLibrary.profiles[structure['parentId']]){
-        this.componentLibrary.profiles[structure['parentId']] = {
-          groups:[]
-        }
-      }
-
       if (structure['parentId'].includes(":Item")){
         let key = structure['parentId']
         if (key && key.includes(":Item")){
@@ -5879,6 +5872,15 @@ export const useProfileStore = defineStore('profile', {
         structure['parentId'] = key
       }
 
+
+      if (!this.componentLibrary.profiles[structure['parentId']]){
+        this.componentLibrary.profiles[structure['parentId']] = {
+          groups:[]
+        }
+      }
+
+      console.info("structure['parentId']: ", structure['parentId'])
+      console.info("this.componentLibrary.profiles: ", this.componentLibrary.profiles)
       this.componentLibrary.profiles[structure['parentId']].groups.push({
         id: short.generate(),
         groupId: null,


### PR DESCRIPTION
The name of the group for Item components wasn't properly normalized.