### PR TITLE
Voyager Diacritic Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.27] - 2025-05-19
+### Fixed
+- Voyager diacritic entry mode not being seen as a change
+
+
 ## [1.2.26] - 2025-05-15
 ### Update
 - Added remove row buttons to advanced NAR mode.
 - Added sorting to XML so the MARC XML produced from NAR creation will sort correctly in voyager display
 
-### Add 
+### Add
 - Added diacritic support to advanced NAR mode.
 
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -713,7 +713,7 @@ export default {
 
         // turn off mode
         this.nextInputIsVoyagerModeDiacritics  =false
-
+        this.valueChanged(event)
         event.target.style.removeProperty('background-color')
         event.preventDefault()
         return false

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 2,
-    versionPatch: 26,
+    versionPatch: 27,
 
 
 
@@ -67,7 +67,7 @@ export const useConfigStore = defineStore('config', {
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
       },
-      
+
 
       staging:{
 


### PR DESCRIPTION
Fix: voyager diacritic entry mode not showing in preview

This entry method didn't recognize the diacritic as a change in value. The result was that if the only change was adding the diacritic, it would show in the form but not the XML or MARC.