### PR TITLE
Fix stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to this project will be documented in this file.
 ## [1.2.28] - 2025-05-21
 ### Changed
 - How admin metadata is added to records to support IBC records
+- Load Show All Stats now only shows the first 1000 records with a button to show all
 ### Add
 - Create Quick Hub modal now has a reset button
 - Create Quick Hub modal will save inputed data when closed ( x button, cancel button, click outside modal) and repopulate that data when opened again. It clears saved data when Hub is posted.
+### Fix
+- Load Show All Stats page did not work correctly on Firefox.
 
 ## [1.2.27] - 2025-05-19
 ### Fix

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "dev-external": "vite --port 4444",
     "dev-e2e": "vite --port 5555",
     "test:e2e": "npx playwright test --headed",
     "build": "vite build",

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -21,7 +21,7 @@ export const useConfigStore = defineStore('config', {
 
         // util  : 'http://localhost:5200/',
         // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
-        util  :  'https://editor.id.loc.gov/bfe2/util/',
+        // util  :  'https://editor.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',
@@ -44,16 +44,16 @@ export const useConfigStore = defineStore('config', {
         // starting: 'http://localhost:9401/util/profiles/starting/prod',
 
         // offical stage profiles that work outside firewall
-        // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
-        // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
+        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+        starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
 
         // offical prod profiles that work outside firewall
         // profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-prod/data.json',
         // starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-prod/data.json',
 
         // offical stage profiles inside the firewall
-        starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
-        profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
+        // starting: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/starting/stage',
+        // profiles: 'https://preprod-3001.id.loc.gov/bfe2/util/profiles/profile/stage',
 
         // offical prod profiles inside the firewall
         // starting: 'https://editor.id.loc.gov/bfe2/util/profiles/starting/prod',
@@ -62,12 +62,30 @@ export const useConfigStore = defineStore('config', {
 
 
         id: 'https://id.loc.gov/',
-        env : 'production',
+        env : 'staging',
         dev: false,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
       },
 
+      externalDev:{
+
+        ldpjs : 'http://localhost:9401/api-staging/',
+        util  : 'http://localhost:9401/util/',
+        utilLang: 'http://localhost:9401/util-lang/',
+        scriptshifter: 'http://localhost:9401/scriptshifter/',
+        publish : 'http://localhost:9401/util/publish/staging',
+        validate: 'http://localhost:5200/validate',
+        profiles: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/profile-stage/data.json',
+        starting: 'https://raw.githubusercontent.com/lcnetdev/bfe-profiles/main/starting-stage/data.json',
+        id: 'https://id.loc.gov/',
+        env : 'staging',
+        dev: true,
+        displayLCOnlyFeatures: true,
+        simpleLookupLang: 'en',
+        publicEndpoints:true,
+
+      },
 
       staging:{
 
@@ -1070,7 +1088,7 @@ export const useConfigStore = defineStore('config', {
       // testing for window here because of running unit tests in node
       if (typeof window !== 'undefined'){
         console.log("window: ", window.location.href)
-        if (window && (!window.location.href.includes('localhost:5555') && window.location.href.startsWith('http://localhost') || window.location.href.startsWith('http://127.0.0.1') )){
+        if (window && (!window.location.href.includes('localhost:5555') && !window.location.href.includes('localhost:4444') && window.location.href.startsWith('http://localhost') || window.location.href.startsWith('http://127.0.0.1') )){
           return state.regionUrls.dev
         }else if (window && window.location.href.startsWith('https://preprod-3001')){
           return state.regionUrls.staging
@@ -1078,6 +1096,8 @@ export const useConfigStore = defineStore('config', {
           return state.regionUrls.production
         }else if (window && window.location.href.includes('bibframe.org')){
           return state.regionUrls.bibframeDotOrg
+        }else if (window && window.location.href.includes('localhost:4444')){          
+          return state.regionUrls.externalDev
         }else if (window && window.location.href.includes('localhost:5555')){
           console.log(">>>>>>>playwrightTestConfig<<<<<<<<<")
           return state.regionUrls.playwrightTestConfig

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -380,9 +380,9 @@
 
         let postedByAgo= {}
         this.allRecords = []
-        console.log("allRecordsRaw",allRecordsRaw)
-        for (let r of allRecordsRaw){
 
+        for (let r of allRecordsRaw){
+          console.log("r",r)
           let obj = {
             'Id': r.eid,
 
@@ -395,10 +395,14 @@
             'User': r.user,
           }
 
-          let date = new Date(r.time);
+          let date = new Date(r.time);      
+          // firefox doesn't like this format, add a space instead of a colon    
+          if (isNaN(date.getTime())) {
+            r.time = r.time.replace(":", " ")      
+            date = new Date(r.time);      
+          }
+          
           let timestamp = date.getTime()/1000;
-          console.log("timestamp",timestamp)
-
 
           dashBoard.byTimePeriod.all.uniqueUsers[r.user]=true
           dashBoard.byTimePeriod.all.workedRecords++
@@ -424,7 +428,7 @@
           }
           this.allRecords.push(obj)
         }
-        console.log("oldestDate",oldestDate)
+
         dashBoard.totalDays = Math.floor((new Date().getTime()/1000 - oldestDate)/86400)
         console.log(dashBoard)
         this.dashBoard = dashBoard

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -380,6 +380,7 @@
 
         let postedByAgo= {}
         this.allRecords = []
+        console.log("allRecordsRaw",allRecordsRaw)
         for (let r of allRecordsRaw){
 
           let obj = {
@@ -396,6 +397,8 @@
 
           let date = new Date(r.time);
           let timestamp = date.getTime()/1000;
+          console.log("timestamp",timestamp)
+
 
           dashBoard.byTimePeriod.all.uniqueUsers[r.user]=true
           dashBoard.byTimePeriod.all.workedRecords++
@@ -421,6 +424,7 @@
           }
           this.allRecords.push(obj)
         }
+        console.log("oldestDate",oldestDate)
         dashBoard.totalDays = Math.floor((new Date().getTime()/1000 - oldestDate)/86400)
         console.log(dashBoard)
         this.dashBoard = dashBoard

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -45,7 +45,10 @@
           </div>
 
           <div id="all-records-table">
-            <DataTable  :loading="isLoadingAllRecords" :rows="allRecords" striped hoverable>
+            <div style="text-align: right;" v-if="dataTableRecords.length == dataTableInitalLimit">
+              <button @click="dataTableRecords=allRecords">Only showing the latest {{ dataTableInitalLimit }} records. Show all {{ allRecords.length }}?</button>
+            </div>
+            <DataTable  :loading="isLoadingAllRecords" :rows="dataTableRecords" striped hoverable>
 
               <!-- { "Id": "e1078432", "RTs": [ "lc:RT:bf2:Monograph:Work" ], "Type": "Monograph", "Status": "unposted", "Urls": [ "http://id.loc.gov/resources/works/e1078432", "http://id.loc.gov/resources/instances/e1078432" ], "Time": "2024-07-10:17:11:53", "User": "asdf (asdf)" } -->
 
@@ -278,6 +281,8 @@
 
         lccnLoadSelected:false,
 
+        dataTableInitalLimit: 1000,
+
 
         displayDashboard:true,
         displayAllRecords: false,
@@ -286,6 +291,7 @@
         dashBoard: {},
 
         allRecords: [],
+        dataTableRecords: [],
         hideOptions: true,
 
       }
@@ -433,8 +439,12 @@
         console.log(dashBoard)
         this.dashBoard = dashBoard
 
+        this.dataTableRecords = this.allRecords.slice(0, this.dataTableInitalLimit)
+
 
         this.isLoadingAllRecords=false
+
+        
       },
 
       returnTimeAgo: function(timestamp){


### PR DESCRIPTION
- Load Show All Stats now only shows the first 1000 records with a button to show all
- Load Show All Stats page did not work correctly on Firefox.

I also added a dev external config store setting and corresponding  npm run dev-external bound to 4444 that uses all external services for when developing outside of LC network.