### PR TITLE
Fix sometimes mangled `bf:relationship`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 - CopyCat UI to Marva
 
+### Fixes
+- Sometimes mangled relationships in Marva
+
+
+
 ## [1.2.28] - 2025-05-21
 ### Changed
 - How admin metadata is added to records to support IBC records

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -57,7 +57,7 @@
 
 
           <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == true">
-            <div class="lookup-fake-input-text">!!
+            <div class="lookup-fake-input-text">
                 <div class="bfcode-display-mode-holder">
                   <div class="bfcode-display-mode-holder-label" :title="structure.propertyLabel">{{profileStore.returnBfCodeLabel(structure)}}</div>
                   <div class="bfcode-display-mode-holder-value">
@@ -92,9 +92,7 @@
             <div class="lookup-fake-input-entities" v-if="marcDeliminatedLCSHMode == false">
 
 
-              $${{ complexLookupValues }}
               <div v-for="(avl,idx) in complexLookupValues" :class="['selected-value-container']">
-                ##
                 <div class="selected-value-container-auth">
                   <!-- <br>
                   !!{{ avl.type }}
@@ -125,7 +123,6 @@
             </div>
 
             <div class="lookup-fake-input-text">
-              ??
                 <input   v-on:keydown.enter.prevent="submitField" @keyup="navKey" class="can-select" :data-guid="structure['@guid']" v-model="searchValue" ref="lookupInput" @focusin="focused" type="text" @input="textInputEvent($event)" :disabled="readOnly" />
                 <!-- @keydown="keyDownEvent($event)" @keyup="keyUpEvent($event)"  -->
             </div>

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -57,7 +57,7 @@
 
 
           <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == true">
-            <div class="lookup-fake-input-text">
+            <div class="lookup-fake-input-text">!!
                 <div class="bfcode-display-mode-holder">
                   <div class="bfcode-display-mode-holder-label" :title="structure.propertyLabel">{{profileStore.returnBfCodeLabel(structure)}}</div>
                   <div class="bfcode-display-mode-holder-value">
@@ -92,9 +92,9 @@
             <div class="lookup-fake-input-entities" v-if="marcDeliminatedLCSHMode == false">
 
 
-
+              $${{ complexLookupValues }}
               <div v-for="(avl,idx) in complexLookupValues" :class="['selected-value-container']">
-
+                ##
                 <div class="selected-value-container-auth">
                   <!-- <br>
                   !!{{ avl.type }}
@@ -125,6 +125,7 @@
             </div>
 
             <div class="lookup-fake-input-text">
+              ??
                 <input   v-on:keydown.enter.prevent="submitField" @keyup="navKey" class="can-select" :data-guid="structure['@guid']" v-model="searchValue" ref="lookupInput" @focusin="focused" type="text" @input="textInputEvent($event)" :disabled="readOnly" />
                 <!-- @keydown="keyDownEvent($event)" @keyup="keyUpEvent($event)"  -->
             </div>
@@ -295,6 +296,7 @@ export default {
       } catch(err) {
           // this can run into an error when populating an empty complexValue field
           // It mostly doesn't seem to matter, but might as well catch
+          console.error("Error getting complex lookup value from profile: ", err)
           return []
       }
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -6,8 +6,8 @@ export const useConfigStore = defineStore('config', {
   state: () => ({
 
     versionMajor: 1,
-    versionMinor: 3,
-    versionPatch: 0,
+    versionMinor: 4,
+    versionPatch: 7,
 
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -6,8 +6,8 @@ export const useConfigStore = defineStore('config', {
   state: () => ({
 
     versionMajor: 1,
-    versionMinor: 4,
-    versionPatch: 7,
+    versionMinor: 3,
+    versionPatch: 0,
 
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2412,6 +2412,7 @@ export const useProfileStore = defineStore('profile', {
       let pt = utilsProfile.returnPt(this.activeProfile,componentGuid)
       let valueLocation = utilsProfile.returnValueFromPropertyPath(pt,propertyPath)
       let deepestLevelURI = propertyPath[propertyPath.length-1].propertyURI
+
       // console.log(pt.propertyURI)
       // console.log("propertyPath=",propertyPath)
 
@@ -2458,7 +2459,7 @@ export const useProfileStore = defineStore('profile', {
               if (!label){
                 for (let lP1 of LABEL_PREDICATES){
                   for (let lP2 of LABEL_PREDICATES){
-                    if (v[lP1][0][lP2] && v[lP1][0][lP2][0][lP2]){
+                    if (v[lP1] && v[lP1][0][lP2] && v[lP1][0][lP2][0][lP2]){
                       label = v[lP1][0][lP2][0][lP2]
                       break
                     }


### PR DESCRIPTION
Fix issue related to relationships.

Marva could fail to get the label from a complex relationship. There's an added check so it doesn't fail. This fixes 2 things:
- The label for the related hub not appearing
- The XML being a copy of the component with the issue

I'm not sure why fixing the first one fixed the second, but it appears to be the case.

The issue could be seen in this record (2025010797) for the Hub `Houser, Jody. Stranger things and Dungeons & dragons`