### PR TITLE
Reset `deepHierarchy` with new component creation

### DIFF
--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -825,7 +825,6 @@ const utilsExport = {
 
 									//carve out an exception for associated resource is a series
 									if (bnodeLvl1.tagName == 'bf:Relation' && bnodeLvl2.tagName == 'bf:Series' && pLvl2.tagName == 'bf:associatedResource'){
-										console.info("exception?")
 										let rdftype = this.createElByBestNS('rdf:type')
 										rdftype.setAttributeNS(this.namespace.rdf, 'rdf:resource', 'http://id.loc.gov/ontologies/bflc/Uncontrolled')
 										bnodeLvl2.appendChild(rdftype)

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4417,7 +4417,8 @@ export const useProfileStore = defineStore('profile', {
         this.activeProfile.rt[profile].pt[newPropertyId] = JSON.parse(JSON.stringify(newPt))
         this.activeProfile.rt[profile].ptOrder.splice(propertyPosition+1, 0, newPropertyId);
 
-
+        // reset this, otherwise it can cause unwanted behavior in the XML
+        this.activeProfile.rt[profile].pt[newPropertyId].deepHierarchy = false
         if (structure){
           this.insertDefaultValuesComponent(newPt['@guid'], structure)
         }


### PR DESCRIPTION
Was causing some issues with the XML. The new component would have the XML from the component that the "add additional component" option was selected from.

I suspect this was only happening when a component had `(uneditable)` in it.