### PR TITLE
Sort complex lookup

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1243,9 +1243,11 @@
                         <template v-if="key != 'sources'">
                           <ul class="details-list">
                             <li class="details-details" v-if="key=='lcclasss'" v-for="v in activeContext.extra['lcclasss']">
-                              <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
-                              <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
-                              <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
+                              <template v-if="typeof v === 'string'">
+                                <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
+                                <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
+                                <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
+                              </template>
                             </li>
                             <li class="details-details" v-if='["identifiers","broaders",].includes(key)'>
                               <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -53,7 +53,7 @@
 
         // These help paging the results when needed
         offsetStart: 0,
-        offsetStep: 25,
+        offsetStep: 30,
         currentPage: 1,
         maxPage: 0,
         activeContext: null,
@@ -1063,7 +1063,7 @@
                 <div class="toggle-btn-grp cssonly">
                   <div v-for="opt in modalSelectOptions"><input type="radio" :value="opt.label" class="search-mode-radio" v-model="modeSelect" name="searchMode"/><label onclick="" class="toggle-btn">{{opt.label}}</label></div>
 				  </div>
-                  <div v-if="(activeComplexSearch && activeComplexSearch[0] && ((activeComplexSearch[0].total % 25 ) > 0 || activeComplexSearch.length > 0))" class="complex-lookup-paging">
+                  <div v-if="(activeComplexSearch && activeComplexSearch[0] && ((activeComplexSearch[0].total % 30) > 0 || activeComplexSearch.length > 0))" class="complex-lookup-paging">
                     <span :style="`${this.preferenceStore.styleModalTextColor()}`">
                       <a href="#" title="first page" class="first" :class="{off: this.currentPage == 1}" @click="firstPage()">
                         <span class="material-icons pagination" :style="`${this.preferenceStore.styleModalTextColor()}`">keyboard_double_arrow_left</span>
@@ -1082,7 +1082,7 @@
                   </div>
                   <div v-else style="min-height: 27px;"></div>
 
-                  
+
 
 				  <div id="container" v-if="modalSelectOptions.length == 10 && modalSelectOptions[8].label == 'NAF Geo SubDiv'">
 					<input type="checkbox" id="search-type" class="toggle" name="search-type" value="keyword" @click="changeSearchType($event)" ref="toggle">

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -316,8 +316,10 @@
                             <ul  class="details-list">
                               <template v-for="v in contextData[key]">
                                 <li class="modal-context-data-li" v-if="key=='lcclasss'">
-                                  <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
-                                  <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
+                                  <template v-if="typeof v === 'string'">
+                                    <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v" target="_blank">{{ v }}</a>
+                                    <button class="material-icons see-search" @click="addClassNumber(v)">add</button>
+                                  </template>
                                 </li>
                                 <li class="modal-context-data-li" v-else-if="key == 'broaders'">
                                   {{v}}

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -113,7 +113,7 @@
                     <div v-if="searchResults && searchResults.names.length>0 && !this.searching" class="subject-section" :class="{'scrollable-subjects': preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'small-container': this.numPopulatedResults()==3 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'medium-container': this.numPopulatedResults()==2 && preferenceStore.returnValue('--b-edit-complex-scroll-independently'), 'large-container': this.numPopulatedResults()==1&&preferenceStore.returnValue('--b-edit-complex-scroll-independently')}">
                       <span class="subject-results-heading">LCNAF</span>
                       <div v-for="(name,idx) in searchResults.names" @click="selectContext((searchResults.names.length - idx)*-1)" @mouseover="loadContext((searchResults.names.length - idx)*-1)" :data-id="(searchResults.names.length - idx)*-1" :key="name.uri" :class="['fake-option', {'unselected':(pickPostion != (searchResults.names.length - idx)*-1 ), 'selected':(pickPostion == (searchResults.names.length - idx)*-1 ),'picked': (pickLookup[(searchResults.names.length - idx)*-1] && pickLookup[(searchResults.names.length - idx)*-1].picked)}]">
-                        <span v-if="name.suggestLabel && name.suggestLabel.length>41">{{name.suggestLabel.substring(0,41)}}...</span>
+                        <span v-if="name.suggestLabel && name.suggestLabel.length>100">{{name.suggestLabel.substring(0,100)}}...</span>
                           <span v-else>{{name.suggestLabel}}</span>
                           <span> [LCNAF]</span>
                           <span v-if="name.collections">

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -487,7 +487,7 @@ const utilsNetwork = {
 
             url = url + "&blastdacache=" + Date.now()
 
-            url = url + "&sortfield=label"
+            url = url + "&sortfield=label" // enforce sorting on the label
 
             console.info("url: ", url)
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -487,6 +487,10 @@ const utilsNetwork = {
 
             url = url + "&blastdacache=" + Date.now()
 
+            url = url + "&sortfield=label"
+
+            console.info("url: ", url)
+
             // don't allow a ? in the keyword if it is already marked as keyword search
             if (url.includes('searchtype=keyword') && url.includes('q=?')){
               url = url.replace('q=?','q=')

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2615,10 +2615,12 @@ const utilsNetwork = {
       let resultsExactName = []
       let resultsExactSubject = []
 
-
+      // this.searchExact(exactPayloadName),
+      // this.searchExact(exactPayloadSubject),
+      // resultsExactName, resultsExactSubject,
 
       if (mode == "LCSHNAF"){
-        [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic, resultsExactName, resultsExactSubject, resultsSubjectsComplexSearchVal, resultsSubjectsComplexSubdivision1, resultsSubjectsComplexSubdivision2, resultsSubjectsComplexSubdivision3] = await Promise.all([
+        [resultsNames, resultsNamesGeo, resultsNamesSubdivision, resultsSubjectsSimple, resultsPayloadSubjectsSimpleSubdivision, resultsSubjectsComplex, resultsHierarchicalGeographic, resultsSubjectsComplexSearchVal, resultsSubjectsComplexSubdivision1, resultsSubjectsComplexSubdivision2, resultsSubjectsComplexSubdivision3] = await Promise.all([
             this.searchComplex(searchPayloadNames),
             this.searchComplex( searchPayloadNamesGeo),
             this.searchComplex(searchPayloadNamesSubdivision),
@@ -2626,8 +2628,6 @@ const utilsNetwork = {
             this.searchComplex(searchPayloadSubjectsSimpleSubdivision),
             this.searchComplex(searchPayloadSubjectsComplex),
             this.searchComplex(searchPayloadHierarchicalGeographic),
-            this.searchExact(exactPayloadName),
-            this.searchExact(exactPayloadSubject),
             this.searchComplex(searchPayloadSubjectsComplexSearchVal),
             this.searchComplex(searchPayloadSubjectsComplexSubdivision1),
             this.searchComplex(searchPayloadSubjectsComplexSubdivision2),

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -487,7 +487,7 @@ const utilsNetwork = {
 
             url = url + "&blastdacache=" + Date.now()
 
-            url = url + "&sortfield=label" // enforce sorting on the label
+            // url = url + "&sortfield=label"
 
             console.info("url: ", url)
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -489,12 +489,12 @@ export const useConfigStore = defineStore('config', {
       "processor" : 'lcAuthorities',
       "modes":[
         {
-          'NAF Auth Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Name&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Personal Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Corporate Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF Geographic':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&count=25&offset=<OFFSET>&searchtype=<TYPE>"},
-          'NAF All':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
+          'NAF Auth Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=Name&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+          'NAF Personal Names':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=PersonalName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+          'NAF Corporate Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=CorporateName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+          'NAF Conference Name':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&rdftype=ConferenceName&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+          'NAF Geographic':{"url":"http://preprod.id.loc.gov/authorities/names/suggest2/?q=<QUERY>&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&count=30&offset=<OFFSET>&searchtype=<TYPE>"},
+          'NAF All':{"url":"https://id.loc.gov/authorities/names/suggest2/?q=<QUERY>&count=30&offset=<OFFSET>"},
         }
       ]
     },


### PR DESCRIPTION
Changes:
- Remove `known label` search for subjects
- Truncate at `100` characters instead of `41`
- ComplexLookup returns `30` results, was `25`
- In details panel, check that `lcclasss` class values are strings

This was about adding `&sortfields=label` to the searches, but it would appear that `suggest2` is already doing that.