### PR TITLE
Adjustment to parsing hub subjects and XML creation

### DIFF
--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -142,6 +142,7 @@ const utilsExport = {
   * @return {boolean}
   */
 	createBnode: function(userValue,property){
+		console
 		// some special cases here
 		if (property == 'http://id.loc.gov/ontologies/bibframe/agent'){
 			// if it is an agent create the Agent bnode and just add the type to it as rdf:type
@@ -861,11 +862,13 @@ const utilsExport = {
 
 
                                                 for (let key3 of Object.keys(value2).filter(k => (!k.includes('@') ? true : false ) )){
-                                                    let pLvl4 = this.createElByBestNS(key2)
+                                                    let pLvl4 = this.createElByBestNS(key3) // this was key2, was that a typo or is this going to break stuff?
+
                                                     for (let value3 of value2[key3]){
                                                         if (this.isBnode(value3)){
                                                             // one more level
                                                             let bnodeLvl4 = this.createBnode(value3,key3)
+
                                                             pLvl4.appendChild(bnodeLvl4)
                                                             bnodeLvl3.appendChild(pLvl4)
                                                             xmlLog.push(`Creating lvl 4 bnode: ${bnodeLvl4.tagName} for ${key3}`)

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1074,7 +1074,6 @@ const utilsParse = {
                         //   </bf:GenreForm>
                         // </bf:genreForm>
 
-
                         gChildData['@type'] = this.UriNamespace(ggChild.tagName)
 
                         // check for URI
@@ -1093,6 +1092,11 @@ const utilsParse = {
 
                           // not a bnode, just a one liner property of the bnode
                           if (this.UriNamespace(gggChild.tagName) == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
+
+                            // expception for bf:Hubs, so it sticks
+                            if (gChildData['@type'] == 'http://id.loc.gov/ontologies/bibframe/Hub'){
+                              continue
+                            }
 
                             if (gggChild.attributes && gggChild.attributes['rdf:about']){
                               gChildData['@type'] = gggChild.attributes['rdf:about'].value
@@ -1242,7 +1246,6 @@ const utilsParse = {
 
 
                                   }else if (gggggChild.children.length ==0){
-
                                       let gggggChildProperty = this.UriNamespace(gggggChild.tagName)
 
                                       if (!gggData[gggggChildProperty]){
@@ -1281,7 +1284,6 @@ const utilsParse = {
 
 
                                   }else{
-
                                     let g5ChildProperty = this.UriNamespace(gggggChild.tagName)
                                     // console.log("g5ChildProperty",g5ChildProperty)
 
@@ -1317,7 +1319,6 @@ const utilsParse = {
                                         for (let g7Child of g6Child.children){
 
                                           if (this.UriNamespace(g7Child.tagName) == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'){
-
 
                                             if (g7Child.attributes && g7Child.attributes['rdf:about']){
                                               g5ChildData['@type'] = g7Child.attributes['rdf:about'].value


### PR DESCRIPTION
Parsing: The Hub subjects was being overwritten by the `rdf:about` for the hub. There's an exception that will prevent this.

XML: There appears to have been a typo(?) in the creation of the `pLvl4` that was using `key2` instead of `key3` this was causing some weird XML `bf:contribution` > `bf:Contribution` > `bf:contribution` when the last piece should have been `bf:agent`

These are very minor code changes, but might have some kind of side effect.