### PR TITLE
Popout Marc Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [1.3.7   ] - 2025-06-05
+### Added
+- Ability to open Marc preview in a separate window
+
 ## [1.3.7   ] - 2025-06-04
 ### Updated
 - Advanced NAR: Don't build auto-046 if 046 is present in advanced mode statements. And add more presets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.3.7   ] - 2025-06-05
+## [1.3.7] - 2025-06-05
 ### Added
 - Ability to open Marc preview in a separate window
 

--- a/src/components/panels/sidebar_preview_marc/Marc.vue
+++ b/src/components/panels/sidebar_preview_marc/Marc.vue
@@ -20,6 +20,7 @@ export default {
       selected: null,
       open: false,
       content: {},
+      sourceDoc: {},
     }
   },
   computed: {
@@ -43,7 +44,10 @@ export default {
   },
 
   methods: {
-
+    closeWindow: function () {
+      console.info("close the thing")
+      this.open = false
+    },
     async refreshMarc() {
       this.previewData = await this.profileStore.marcPreview()
     },
@@ -78,6 +82,8 @@ export default {
 
       }, 1000)
     })
+
+    this.sourceDoc = window.document
   },
 
   updated() { }
@@ -90,13 +96,12 @@ export default {
 <template>
 
   <div class="marc-preview-content">
-    <input @click="open = !open" type="checkbox" />
+    <input @click="open = !open" type="checkbox" :checked="open" />
 
-    <WindowPortal :open="open" :content="previewData" :type="marc">
+    <WindowPortal @close="closeWindow" :open="open" :content="previewData" type="marc" :sourceDoc="sourceDoc">
       <!-- <MarcDisplay :previewData="previewData" :selected="selected" /> this doesn't work? -->
     </WindowPortal>
     Popout this Panel?
-    {{ open }}
 
     <!-- TODO: -->
     <!-- resize the panel when the window opens/closes -->

--- a/src/components/panels/sidebar_preview_marc/Marc.vue
+++ b/src/components/panels/sidebar_preview_marc/Marc.vue
@@ -95,7 +95,6 @@ export default {
 <template>
 
   <div class="marc-preview-content">
-    <!-- <input @click="open = !open" type="checkbox" :checked="open" /> -->
      <button class="popout-button">
       <span class="material-icons" @click="open = !open" style="font-size: 14px;">open_in_new</span>
     </button>

--- a/src/components/panels/sidebar_preview_marc/Marc.vue
+++ b/src/components/panels/sidebar_preview_marc/Marc.vue
@@ -92,11 +92,15 @@ export default {
   <div class="marc-preview-content">
     <input @click="open = !open" type="checkbox" />
 
-    <WindowPortal :open="open" :content="previewData">
-      <MarcDisplay :previewData="content" :selected="selected" />
+    <WindowPortal :open="open" :content="previewData" :type="marc">
+      <!-- <MarcDisplay :previewData="previewData" :selected="selected" /> this doesn't work? -->
     </WindowPortal>
     Popout this Panel?
     {{ open }}
+
+    <!-- TODO: -->
+    <!-- resize the panel when the window opens/closes -->
+    <!-- when the window is "x"ed to close, make sure the source knows and add -->
 
     <ul>
       <li v-for="ver in previewData.versions">

--- a/src/components/panels/sidebar_preview_marc/Marc.vue
+++ b/src/components/panels/sidebar_preview_marc/Marc.vue
@@ -129,8 +129,7 @@ li {
 .marc-preview-content {
   padding: 0.25em;
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
-
-
+  font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size')");
 }
 
 .version-number {

--- a/src/components/panels/sidebar_preview_marc/Marc.vue
+++ b/src/components/panels/sidebar_preview_marc/Marc.vue
@@ -1,81 +1,87 @@
 <script>
-  import { useProfileStore } from '@/stores/profile'
-  import { usePreferenceStore } from '@/stores/preference'
+import { useProfileStore } from '@/stores/profile'
+import { usePreferenceStore } from '@/stores/preference'
 
-  import { mapStores, mapState, mapWritableState } from 'pinia'
+import { mapStores, mapState, mapWritableState } from 'pinia'
+import WindowPortal from './WindowPortal.vue'
+import MarcDisplay from './MarcDisplay.vue'
 
-  export default {
-    components: {
+export default {
+  components: {
+    WindowPortal,
+    MarcDisplay
+  },
+
+  data() {
+    return {
+      previewData: { default: null, versions: [] },
+      timeout: null,
+      firstLoad: true,
+      selected: null,
+      open: false,
+      content: {},
+    }
+  },
+  computed: {
+    // other computed properties
+    // ...
+    // gives access to this.counterStore and this.userStore
+    ...mapStores(useProfileStore, usePreferenceStore),
+    // // gives read access to this.count and this.double
+    ...mapState(useProfileStore, ['activeProfile', 'dataChangedTimestamp']),
+    ...mapState(usePreferenceStore, ['styleDefault']),
+
+    ...mapWritableState(useProfileStore, ['activeComponent']),
+
+
+  },
+  watch: {
+    // if this flips from false to true it means they are landing on this page so ask for the record from the backend
+    dataChangedTimestamp(newDataChangedTimestamp, oldDataChangedTimestamp) {
+      this.refreshMarc()
+    }
+  },
+
+  methods: {
+
+    async refreshMarc() {
+      this.previewData = await this.profileStore.marcPreview()
     },
 
-    data() {
-      return {
-        previewData : {default:null, versions:[]},
-        timeout: null,
-        firstLoad: true,
-        selected: null,
-      }
-    },
-    computed: {
-      // other computed properties
-      // ...
-      // gives access to this.counterStore and this.userStore
-      ...mapStores(useProfileStore,usePreferenceStore),
-      // // gives read access to this.count and this.double
-      ...mapState(useProfileStore, ['activeProfile','dataChangedTimestamp']),
-      ...mapState(usePreferenceStore, ['styleDefault']),
+  },
 
-      ...mapWritableState(useProfileStore, ['activeComponent']),
+  created() {
+
+    // this.profileStore.$subscribe(async (mutation, state)=>{
+
+    //   if (mutation && mutation.events && mutation.events.target && mutation.events.target['@guid'] ){
+
+    //     window.clearTimeout(this.timeout)
+    //     this.timeout = window.setTimeout(()=>{
+
+    //       this.refreshMarc()
+
+    //     },500)
 
 
-    },
-    watch: {
-      // if this flips from false to true it means they are landing on this page so ask for the record from the backend
-      dataChangedTimestamp(newDataChangedTimestamp, oldDataChangedTimestamp) {
+
+    //   }
+
+
+    // }, { detached: true })
+
+    // build the XML on first load
+    this.$nextTick(() => {
+      window.setTimeout(() => {
+
         this.refreshMarc()
-      }
-    },
 
-    methods: {
+      }, 1000)
+    })
+  },
 
-      async refreshMarc() {
-        this.previewData = await this.profileStore.marcPreview()
-      },
-
-    },
-
-    created() {
-
-      // this.profileStore.$subscribe(async (mutation, state)=>{
-
-      //   if (mutation && mutation.events && mutation.events.target && mutation.events.target['@guid'] ){
-
-      //     window.clearTimeout(this.timeout)
-      //     this.timeout = window.setTimeout(()=>{
-
-      //       this.refreshMarc()
-
-      //     },500)
-
-
-
-      //   }
-
-
-      // }, { detached: true })
-
-      // build the XML on first load
-      this.$nextTick(()=>{
-        window.setTimeout(()=>{
-
-          this.refreshMarc()
-
-         },1000)
-      })
-    },
-
-    updated() {}
-  }
+  updated() { }
+}
 
 
 
@@ -84,6 +90,13 @@
 <template>
 
   <div class="marc-preview-content">
+    <input @click="open = !open" type="checkbox" />
+
+    <WindowPortal :open="open" :content="previewData">
+      <MarcDisplay :previewData="content" :selected="selected" />
+    </WindowPortal>
+    Popout this Panel?
+    {{ open }}
 
     <ul>
       <li v-for="ver in previewData.versions">
@@ -91,91 +104,41 @@
       </li>
     </ul>
 
-    <template v-if="!selected">
-      <template v-for="ver in previewData.versions">
-        <div v-if="ver.default">
-          <div class="version-number">{{ ver.version  }}</div>
-          <div v-if="preferenceStore.returnValue('--b-edit-main-splitpane-opac-marc-html')" v-html="ver.marcRecord"></div>
-          <pre v-else>
-            <code>
-{{ ver.marcRecord }}
-            </code>
-          </pre>
-          <hr>
-          <pre>
-            <code>
-{{ ver.results.stdout.trim() }}
-            </code>
-          </pre>
-        </div>
-      </template>
-
-    </template>
-    <template v-else>
-      <template v-for="ver in previewData.versions">
-        <div v-if="selected == ver.version">
-          <div class="version-number">{{ ver.version  }}</div>
-          <template v-if="ver.error">
-
-            <pre>
-              <code>
-{{ ver.results }}
-              </code>
-            </pre>
-          </template>
-          <template v-else>
-            <pre>
-              <code>
-{{ ver.marcRecord }}
-              </code>
-            </pre>
-            <hr>
-            <pre>
-              <code>
-{{ ver.results.stdout.trim() }}
-              </code>
-            </pre>
-          </template>
-        </div>
-      </template>
-
-
-
-    </template>
-
+    <MarcDisplay :previewData="previewData" :selected="selected" />
   </div>
 </template>
 
 <style scoped>
-
-ul{
+ul {
   padding: 0;
 }
-li{
+
+li {
   display: inline-block;
 }
 
-.marc-preview-content{
+.marc-preview-content {
   padding: 0.25em;
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
 
 
 }
-.version-number{
+
+.version-number {
   font-size: 1.25em;
   font-weight: bold;
 }
 
 
-.sidebar-header-text{
-  font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size', true) + 0.25  + 'em'");
+.sidebar-header-text {
+  font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size', true) + 0.25 + 'em'");
   font-family: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-family')");
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
 
 }
 
 
-.sidebar-spacer{
+.sidebar-spacer {
   padding-top: 1em;
   margin-top: 1em;
   padding-bottom: 1em;
@@ -184,14 +147,14 @@ li{
 }
 
 
-.item-icon{
-  fill:v-bind("preferenceStore.returnValue('--c-general-icon-item-color')");
-  stroke-width:0.5;
-  stroke:rgb(0,0,0)
+.item-icon {
+  fill: v-bind("preferenceStore.returnValue('--c-general-icon-item-color')");
+  stroke-width: 0.5;
+  stroke: rgb(0, 0, 0)
 }
 
 /** MARC preview formatting */
-:deep() .marc.record{
+:deep() .marc.record {
   font-family: monospace;
 }
 
@@ -201,7 +164,7 @@ li{
 
 
 :deep() .marc.subfield.subfield-0 .subfield-value,
-:deep() .marc.subfield.subfield-1 .subfield-value{
+:deep() .marc.subfield.subfield-1 .subfield-value {
   width: 4.5em;
   display: inline-block;
   text-overflow: ellipsis;
@@ -211,13 +174,11 @@ li{
   vertical-align: bottom;
 }
 
-:deep() div.marc.field{
+:deep() div.marc.field {
   text-indent: 4em hanging;
 }
 
-:deep() span.marc.subfield:hover{
+:deep() span.marc.subfield:hover {
   background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-marc-html-highlight-color')");
 }
-
-
 </style>

--- a/src/components/panels/sidebar_preview_marc/Marc.vue
+++ b/src/components/panels/sidebar_preview_marc/Marc.vue
@@ -45,7 +45,6 @@ export default {
 
   methods: {
     closeWindow: function () {
-      console.info("close the thing")
       this.open = false
     },
     async refreshMarc() {
@@ -96,16 +95,14 @@ export default {
 <template>
 
   <div class="marc-preview-content">
-    <input @click="open = !open" type="checkbox" :checked="open" />
+    <!-- <input @click="open = !open" type="checkbox" :checked="open" /> -->
+     <button class="popout-button">
+      <span class="material-icons" @click="open = !open" style="font-size: 14px;">open_in_new</span>
+    </button>
 
     <WindowPortal @close="closeWindow" :open="open" :content="previewData" type="marc" :sourceDoc="sourceDoc">
-      <!-- <MarcDisplay :previewData="previewData" :selected="selected" /> this doesn't work? -->
+      <!-- <MarcDisplay :previewData="previewData" :selected="selected" /> why this doesn't work? -->
     </WindowPortal>
-    Popout this Panel?
-
-    <!-- TODO: -->
-    <!-- resize the panel when the window opens/closes -->
-    <!-- when the window is "x"ed to close, make sure the source knows and add -->
 
     <ul>
       <li v-for="ver in previewData.versions">
@@ -130,6 +127,7 @@ li {
   padding: 0.25em;
   color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
   font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size')");
+  font-family: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-family')");
 }
 
 .version-number {
@@ -188,5 +186,10 @@ li {
 
 :deep() span.marc.subfield:hover {
   background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-marc-html-highlight-color')");
+}
+
+.popout-button{
+  float: right;
+  z-index: 999;
 }
 </style>

--- a/src/components/panels/sidebar_preview_marc/MarcDisplay.vue
+++ b/src/components/panels/sidebar_preview_marc/MarcDisplay.vue
@@ -1,0 +1,167 @@
+<script>
+import { usePreferenceStore } from '@/stores/preference'
+import { useProfileStore } from '@/stores/profile'
+
+import { mapStores, mapState, mapWritableState } from 'pinia'
+
+export default {
+    components: {},
+    data() {
+        return {
+        }
+    },
+    props: {
+        previewData: {
+            type: Object,
+            default: {}
+        },
+        selected: String
+    },
+    computed: {
+        ...mapStores(useProfileStore, usePreferenceStore),
+        ...mapState(useProfileStore, ['activeProfile', 'dataChangedTimestamp']),
+        ...mapState(usePreferenceStore, ['styleDefault']),
+        ...mapWritableState(useProfileStore, ['activeComponent']),
+    },
+    watch: {},
+    methods: {},
+    created() {},
+    updated() { }
+}
+
+
+
+</script>
+
+
+<template>
+    <template v-if="!selected">
+        <template v-for="ver in previewData.versions">
+            <div v-if="ver.default">
+                <div class="version-number">{{ ver.version }}</div>
+                <div v-if="preferenceStore.returnValue('--b-edit-main-splitpane-opac-marc-html')"
+                    v-html="ver.marcRecord"></div>
+                <pre v-else>
+            <code>
+              {{ ver.marcRecord }}
+            </code>
+          </pre>
+                <hr>
+                <pre>
+            <code>
+              {{ ver.results.stdout.trim() }}
+            </code>
+          </pre>
+            </div>
+        </template>
+
+    </template>
+    <template v-else>
+        <template v-for="ver in previewData.versions">
+            <div v-if="selected == ver.version">
+                <div class="version-number">{{ ver.version }}</div>
+                <template v-if="ver.error">
+
+                    <pre>
+              <code>
+{{ ver.results }}
+              </code>
+            </pre>
+                </template>
+                <template v-else>
+                    <pre>
+              <code>
+{{ ver.marcRecord }}
+              </code>
+            </pre>
+                    <hr>
+                    <pre>
+              <code>
+{{ ver.results.stdout.trim() }}
+              </code>
+            </pre>
+                </template>
+            </div>
+        </template>
+
+
+
+    </template>
+</template>
+
+
+
+<style scoped>
+ul {
+    padding: 0;
+}
+
+li {
+    display: inline-block;
+}
+
+.marc-preview-content {
+    padding: 0.25em;
+    color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
+
+
+}
+
+.version-number {
+    font-size: 1.25em;
+    font-weight: bold;
+}
+
+
+.sidebar-header-text {
+    font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size', true) + 0.25 + 'em'");
+    font-family: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-family')");
+    color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
+
+}
+
+
+.sidebar-spacer {
+    padding-top: 1em;
+    margin-top: 1em;
+    padding-bottom: 1em;
+    border-top: solid 1px v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')");
+
+}
+
+
+.item-icon {
+    fill: v-bind("preferenceStore.returnValue('--c-general-icon-item-color')");
+    stroke-width: 0.5;
+    stroke: rgb(0, 0, 0)
+}
+
+/** MARC preview formatting */
+:deep() .marc.record {
+    font-family: monospace;
+}
+
+:deep() .marc.indicators {
+    white-space: pre;
+}
+
+
+:deep() .marc.subfield.subfield-0 .subfield-value,
+:deep() .marc.subfield.subfield-1 .subfield-value {
+    width: 4.5em;
+    display: inline-block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    color: rgba(0, 0, 0, 0.5);
+    vertical-align: bottom;
+}
+
+:deep() div.marc.field {
+    text-indent: 4em hanging;
+}
+
+:deep() span.marc.subfield:hover {
+    background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-marc-html-highlight-color')");
+}
+</style>

--- a/src/components/panels/sidebar_preview_marc/WindowPortal.vue
+++ b/src/components/panels/sidebar_preview_marc/WindowPortal.vue
@@ -1,9 +1,8 @@
 <!-- https://stackoverflow.com/questions/49657462/open-a-vuejs-component-on-a-new-window -->
 <template>
-    <template v-if="open">
-        {{ styles }}
-         <MarcDisplay :previewData="content" selected="" v-if="type == 'marc'"/>
-    </template>
+        <template v-if="open">
+            <MarcDisplay :previewData="content" selected="" v-if="type == 'marc'"/>
+        </template>
 </template>
 
 <script>
@@ -38,11 +37,12 @@ export default {
     data() {
         return {
             windowRef: null,
+            currentPanels: null,
         }
     },
     computed: {
         ...mapStores(usePreferenceStore),
-        ...mapState(usePreferenceStore, ['styleDefault']),
+        ...mapState(usePreferenceStore, ['styleDefault', 'panelSizePresets']),
     },
     watch: {
         open(newOpen) {
@@ -59,6 +59,9 @@ export default {
             console.info('source: ', this.sourceDoc)
             console.info('styleSheets: ', this.sourceDoc.styleSheets)
             console.info("targetDoc: ", targetDoc)
+            console.info("this: ", window.document)
+
+            // Copy the style from the component we are duplicating
             Array.from(this.sourceDoc.styleSheets).forEach(styleSheet => {
                 if (styleSheet.cssRules){
                     const newStyleEl = this.sourceDoc.createElement('style')
@@ -67,11 +70,18 @@ export default {
                     })
 
                     targetDoc.head.appendChild(newStyleEl)
-                } else if (styleSheet.href){
-                    const newLinkEl = this.sourceDoc.createElement('link')
-                    newLinkEl.rel = 'stylesheet'
-                    newLinkEl.href = styleSheet.href
-                    targetDoc.head.appendChild(newLinkEl)
+                }
+            })
+
+            //Copy the style from there
+            Array.from(window.document.styleSheets).forEach(styleSheet => {
+                if (styleSheet.cssRules){
+                    const newStyleEl = window.document.createElement('style')
+                    Array.from(styleSheet.cssRules).forEach(cssRule => {
+                        newStyleEl.appendChild(window.document.createTextNode(cssRule.cssText))
+                    })
+
+                    targetDoc.head.appendChild(newStyleEl)
                 }
             })
         },
@@ -82,9 +92,54 @@ export default {
             // magic!
             this.windowRef.document.body.appendChild(this.$el);
             this.copyStyles(this.windowRef.document)
+
+            //adjust the panel sizes
+            //get the current info and store it
+            this.currentPanels = this.preferenceStore.getPanelData()
+
+            // adjust the sizes to hide the one being popped out
+            let newPanels = JSON.parse(JSON.stringify(this.currentPanels))
+            let previewPanelSizes = Object.keys(newPanels.percents).filter((panel) => !panel.includes('-edit-') && !panel.includes('properties'))
+            let previewEditSizes = Object.keys(newPanels.percents).filter((panel) => panel.includes('-edit-'))
+            let previewSize = 0
+            let nullPanels = []
+            let adjustedPanels = []
+
+            // get the size of the panel we're going to dup
+            for (let panel of previewPanelSizes){
+                if (panel.includes(this.type) && newPanels.percents[panel]){
+                    previewSize += Number(newPanels.percents[panel].slice(0,2))
+                }
+            }
+
+            // find the edit panels that have a size (in dual edit or not)
+            for (let panel of previewEditSizes){
+                if (newPanels.percents[panel]){
+                    adjustedPanels.push(panel)
+                } else {
+                    nullPanels.push(panel)
+                }
+            }
+
+            for (let key in newPanels.percents){
+                if (key.includes(this.type)){
+                    newPanels.percents[key] = "1%" // shrink the panel we are duping in a new window
+                } else if (adjustedPanels.includes(key)){ // add the space to the form panels
+                    let size = Number(newPanels.percents[key].slice(0,2))
+                    if (adjustedPanels.length == 1){
+                        newPanels.percents[key] = size + previewSize + "%"
+                    } else {
+                        newPanels.percents[key] = size + (previewSize/2) + "%"
+                    }
+                }
+            }
+
+            // move to adjusted panels
+            this.preferenceStore.setPanelData(newPanels)
         },
         closePortal() {
             console.info("closing")
+            this.preferenceStore.setPanelData(this.currentPanels)
             if (this.windowRef) {
                 this.windowRef.close();
                 this.windowRef = null;
@@ -96,6 +151,9 @@ export default {
         if (this.open) {
             this.openPortal();
         }
+
+        this.panelSizePresets = this.preferenceStore.returnValue('--o-edit-main-splitpane-edit-panel-size-presets')
+        console.info("panelSizePresets: ", this.panelSizePresets)
     },
     beforeDestroy() {
         console.info("destroy")
@@ -105,3 +163,12 @@ export default {
     }
 }
 </script>
+
+<!--  -->
+
+<style scoped>
+body {
+    background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-background-color')") !important;
+    color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
+}
+</style>

--- a/src/components/panels/sidebar_preview_marc/WindowPortal.vue
+++ b/src/components/panels/sidebar_preview_marc/WindowPortal.vue
@@ -1,7 +1,8 @@
 <!-- https://stackoverflow.com/questions/49657462/open-a-vuejs-component-on-a-new-window -->
 <template>
     <template v-if="open">
-         <MarcDisplay :previewData="content" selected="2.10.0" v-if="type == 'marc'"/>
+        {{ styles }}
+         <MarcDisplay :previewData="content" selected="" v-if="type == 'marc'"/>
     </template>
 </template>
 
@@ -28,6 +29,10 @@ export default {
         type: {
             type: String,
             default: ''
+        },
+        sourceDoc: {
+            type: Object,
+            default: {}
         }
     },
     data() {
@@ -50,14 +55,36 @@ export default {
         }
     },
     methods: {
+        copyStyles(targetDoc) {
+            console.info('source: ', this.sourceDoc)
+            console.info('styleSheets: ', this.sourceDoc.styleSheets)
+            console.info("targetDoc: ", targetDoc)
+            Array.from(this.sourceDoc.styleSheets).forEach(styleSheet => {
+                if (styleSheet.cssRules){
+                    const newStyleEl = this.sourceDoc.createElement('style')
+                    Array.from(styleSheet.cssRules).forEach(cssRule => {
+                        newStyleEl.appendChild(this.sourceDoc.createTextNode(cssRule.cssText))
+                    })
+
+                    targetDoc.head.appendChild(newStyleEl)
+                } else if (styleSheet.href){
+                    const newLinkEl = this.sourceDoc.createElement('link')
+                    newLinkEl.rel = 'stylesheet'
+                    newLinkEl.href = styleSheet.href
+                    targetDoc.head.appendChild(newLinkEl)
+                }
+            })
+        },
         openPortal() {
             console.info("open portal: ", this.content)
-            this.windowRef = window.open("", "", "width=600,height=400,left=200,top=200");
+            this.windowRef = window.open("", "", "width=700,height=600,left=200,top=200");
             this.windowRef.addEventListener('beforeunload', this.closePortal);
             // magic!
             this.windowRef.document.body.appendChild(this.$el);
+            this.copyStyles(this.windowRef.document)
         },
         closePortal() {
+            console.info("closing")
             if (this.windowRef) {
                 this.windowRef.close();
                 this.windowRef = null;

--- a/src/components/panels/sidebar_preview_marc/WindowPortal.vue
+++ b/src/components/panels/sidebar_preview_marc/WindowPortal.vue
@@ -16,6 +16,7 @@ export default {
       MarcDisplay
     },
     name: 'window-portal',
+    emits: ['close'],
     props: {
         open: {
             type: Boolean,
@@ -56,11 +57,6 @@ export default {
     },
     methods: {
         copyStyles(targetDoc) {
-            console.info('source: ', this.sourceDoc)
-            console.info('styleSheets: ', this.sourceDoc.styleSheets)
-            console.info("targetDoc: ", targetDoc)
-            console.info("this: ", window.document)
-
             // Copy the style from the component we are duplicating
             Array.from(this.sourceDoc.styleSheets).forEach(styleSheet => {
                 if (styleSheet.cssRules){
@@ -86,7 +82,7 @@ export default {
             })
         },
         openPortal() {
-            this.windowRef = window.open("", "", "width=700,height=600,left=200,top=200");
+            this.windowRef = window.open("", "", "width=700,height=900,left=200,top=200");
             this.windowRef.addEventListener('beforeunload', this.closePortal);
             // magic!
             this.windowRef.document.body.appendChild(this.$el);

--- a/src/components/panels/sidebar_preview_marc/WindowPortal.vue
+++ b/src/components/panels/sidebar_preview_marc/WindowPortal.vue
@@ -153,10 +153,8 @@ export default {
         }
 
         this.panelSizePresets = this.preferenceStore.returnValue('--o-edit-main-splitpane-edit-panel-size-presets')
-        console.info("panelSizePresets: ", this.panelSizePresets)
     },
     beforeDestroy() {
-        console.info("destroy")
         if (this.windowRef) {
             this.closePortal();
         }

--- a/src/components/panels/sidebar_preview_marc/WindowPortal.vue
+++ b/src/components/panels/sidebar_preview_marc/WindowPortal.vue
@@ -1,0 +1,78 @@
+<!-- https://stackoverflow.com/questions/49657462/open-a-vuejs-component-on-a-new-window -->
+<template>
+    <template v-if="open">
+        <!-- <MarcDisplay :previewData="content" /> -->
+         hello?
+         <slot></slot>
+    </template>
+</template>
+
+<script>
+import { usePreferenceStore } from '@/stores/preference'
+import { mapStores, mapState } from 'pinia'
+
+import MarcDisplay from './MarcDisplay.vue'
+
+export default {
+    components: {
+      MarcDisplay
+    },
+    name: 'window-portal',
+    props: {
+        open: {
+            type: Boolean,
+            default: true,
+        },
+        content: {
+            type: Object,
+            default: {}
+        }
+    },
+    data() {
+        return {
+            windowRef: null,
+        }
+    },
+    computed: {
+        ...mapStores(usePreferenceStore),
+        ...mapState(usePreferenceStore, ['styleDefault']),
+    },
+    watch: {
+        open(newOpen) {
+            console.info("???")
+            if (newOpen) {
+                this.openPortal();
+            } else {
+                this.closePortal();
+            }
+        }
+    },
+    methods: {
+        openPortal() {
+            console.info("open portal: ", this.content)
+            this.windowRef = window.open("", "", "width=600,height=400,left=200,top=200");
+            this.windowRef.addEventListener('beforeunload', this.closePortal);
+            // magic!
+            this.windowRef.document.body.appendChild(this.$el);
+        },
+        closePortal() {
+            if (this.windowRef) {
+                this.windowRef.close();
+                this.windowRef = null;
+                this.$emit('close');
+            }
+        }
+    },
+    mounted() {
+        if (this.open) {
+            this.openPortal();
+        }
+    },
+    beforeDestroy() {
+        console.info("destroy")
+        if (this.windowRef) {
+            this.closePortal();
+        }
+    }
+}
+</script>

--- a/src/components/panels/sidebar_preview_marc/WindowPortal.vue
+++ b/src/components/panels/sidebar_preview_marc/WindowPortal.vue
@@ -1,9 +1,7 @@
 <!-- https://stackoverflow.com/questions/49657462/open-a-vuejs-component-on-a-new-window -->
 <template>
     <template v-if="open">
-        <!-- <MarcDisplay :previewData="content" /> -->
-         hello?
-         <slot></slot>
+         <MarcDisplay :previewData="content" selected="2.10.0" v-if="type == 'marc'"/>
     </template>
 </template>
 
@@ -26,6 +24,10 @@ export default {
         content: {
             type: Object,
             default: {}
+        },
+        type: {
+            type: String,
+            default: ''
         }
     },
     data() {

--- a/src/components/panels/sidebar_preview_marc/WindowPortal.vue
+++ b/src/components/panels/sidebar_preview_marc/WindowPortal.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { usePreferenceStore } from '@/stores/preference'
-import { mapStores, mapState } from 'pinia'
+import { mapStores, mapState, mapWritableState } from 'pinia'
 
 import MarcDisplay from './MarcDisplay.vue'
 
@@ -42,11 +42,11 @@ export default {
     },
     computed: {
         ...mapStores(usePreferenceStore),
-        ...mapState(usePreferenceStore, ['styleDefault', 'panelSizePresets']),
+        ...mapState(usePreferenceStore, ['styleDefault']),
+        ...mapWritableState(usePreferenceStore, ['panelSizePresets']),
     },
     watch: {
         open(newOpen) {
-            console.info("???")
             if (newOpen) {
                 this.openPortal();
             } else {
@@ -86,7 +86,6 @@ export default {
             })
         },
         openPortal() {
-            console.info("open portal: ", this.content)
             this.windowRef = window.open("", "", "width=700,height=600,left=200,top=200");
             this.windowRef.addEventListener('beforeunload', this.closePortal);
             // magic!
@@ -138,7 +137,6 @@ export default {
             this.preferenceStore.setPanelData(newPanels)
         },
         closePortal() {
-            console.info("closing")
             this.preferenceStore.setPanelData(this.currentPanels)
             if (this.windowRef) {
                 this.windowRef.close();
@@ -164,9 +162,12 @@ export default {
 
 <!--  -->
 
-<style scoped>
-body {
-    background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-background-color')") !important;
-    color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')") !important;
+<style>
+
+div:has(div.marc.record) {
+    background-color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-background-color')");
+    color: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-color')");
+    font-size: v-bind("preferenceStore.returnValue('--n-edit-main-splitpane-opac-font-size')");
+    font-family: v-bind("preferenceStore.returnValue('--c-edit-main-splitpane-opac-font-family')");
 }
 </style>

--- a/src/components/panels/sidebar_preview_xml/Xml.vue
+++ b/src/components/panels/sidebar_preview_xml/Xml.vue
@@ -116,7 +116,6 @@
 
 <template>
   <div>
-    <span>???</span>
     <XmlViewer ref="xmlviewer" :xml="xml" />
 
 

--- a/src/components/panels/sidebar_preview_xml/Xml.vue
+++ b/src/components/panels/sidebar_preview_xml/Xml.vue
@@ -115,9 +115,8 @@
 </script>
 
 <template>
-
   <div>
-
+    <span>???</span>
     <XmlViewer ref="xmlviewer" :xml="xml" />
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 3,
-    versionPatch: 7,
+    versionPatch: 8,
 
 
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1858,7 +1858,6 @@ export const usePreferenceStore = defineStore('preference', {
     },
 
     setPanelData(data){
-      console.info("loading: ", data)
       for (let key of Object.keys(data.view)){
         this.panelDisplay[key] = data.view[key]
       }

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1858,7 +1858,7 @@ export const usePreferenceStore = defineStore('preference', {
     },
 
     setPanelData(data){
-
+      console.info("loading: ", data)
       for (let key of Object.keys(data.view)){
         this.panelDisplay[key] = data.view[key]
       }


### PR DESCRIPTION
Add: Ability to popout the marc preview panel.

It will continue to update as the changes are made to the record. Button appears on the right of the panel. The new window should have the same styling as the preview. The preview panel is hidden, reduced to 1% width. If it is taken out the marc in the new window won't update. When the preview gets hidden the space is given the Marva form.

There's also some fixes to preferences that working working in the Marc preview like `font-size` and `font-family`.

There's some refactoring in `Marc.vue` so that the creation is separate from it to be able to duplicate it in the new window. The code has been moved to `MarcDisplay.vue` and this new component is called in `Marc.vue` and `WindowPortal.vue`.