### PR TITLE
Default component adjustments

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -33,7 +33,7 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
 
-  timeout: 60 * 1000,  // set timeout to 1 minute, default is 30s
+  timeout: 10 * 1000,  // set timeout to 1 minute, default is 30s
 
   /* Configure projects for major browsers */
   projects: [

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -174,17 +174,18 @@
           },
         ]
 
-        if (!this.$route.path.includes('edit')){
-          menuButtonSubMenu.push(
-            {
-              text: "Copy Cat.",
-              click: () => {
-                this.profileStore.copyCatMode = !this.profileStore.copyCatMode
-              },
-              emoji: this.profileStore.copyCatMode ? "heavy_check_mark" : "smile_cat"
-            }
-          )
-        }
+        menuButtonSubMenu.push(
+          {
+            text: "Copy Cat.",
+            click: () => {
+              if (this.$route.path.includes('edit')){
+                this.$router.push('/load')
+              }
+              this.profileStore.copyCatMode = !this.profileStore.copyCatMode
+            },
+            emoji: this.profileStore.copyCatMode ? "heavy_check_mark" : "smile_cat"
+          }
+        )
 
         const config = useConfigStore()
         if (config.returnUrls.displayLCOnlyFeatures){

--- a/src/lib/defaults/default_components.json
+++ b/src/lib/defaults/default_components.json
@@ -222,7 +222,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "p9aBJtEtK8xmmSQD2Wr7a7",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image"
                                             }
                                         ]
                                     }
@@ -276,7 +276,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "tf4kCiRgaBoyzMZ1toeQf7",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations"
                                             }
                                         ]
                                     }
@@ -328,7 +328,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "twigRcScQG1Vw1kWsEpo49",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "color (mul)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "color"
                                             }
                                         ]
                                     }
@@ -571,7 +571,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "7im4k2Mc8ajvA2crzRiDRX",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations"
                                             }
                                         ]
                                     }
@@ -625,7 +625,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "7im4k2Mc8ajvA2crzRiDRX",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations (ill)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "illustrations"
                                             }
                                         ]
                                     },
@@ -635,7 +635,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "kqX2rkDfLYFenRerG5q8JU",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps"
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Illustration"
@@ -742,7 +742,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "opYvbRLVQbFgU7m7YGm34a",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps"
                                             }
                                         ]
                                     }
@@ -864,7 +864,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "srLcpXUjoCpefAV4LGD1U4",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image"
                                             }
                                         ]
                                     }
@@ -923,7 +923,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "srLcpXUjoCpefAV4LGD1U4",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image (cri)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "cartographic image"
                                             }
                                         ]
                                     }
@@ -977,7 +977,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "opYvbRLVQbFgU7m7YGm34a",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps (map)"
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "maps"
                                             }
                                         ]
                                     }
@@ -1098,7 +1098,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "t94yFoZdB8mVeBy9pYQnsA",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "language (lang)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "language"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -1779,7 +1779,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "7EgLYVh5v5jk925H3bnY6t",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -1841,7 +1841,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "pMHWBV9aRMsWaVbvB8Ms2E",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography (biblio)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "bibliography"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -2148,7 +2148,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "jFeMwZq42vCmU3xxQ4uMdr",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "additional physical form (addphys)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "additional physical form"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -2259,7 +2259,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "aaCQgTDGtdhNki7ijc837a",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -2370,7 +2370,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "7TgqRM744nvSCsVANQhwKz",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -2432,7 +2432,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "7TgqRM744nvSCsVANQhwKz",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details (physical)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "physical details"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -2592,7 +2592,7 @@
                                                 "http://www.w3.org/2000/01/rdf-schema#label": [
                                                     {
                                                         "@guid": "3ottSxjy5LpZGRsHYfrU2c",
-                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material (accmat)"
+                                                        "http://www.w3.org/2000/01/rdf-schema#label": "accompanying material"
                                                     }
                                                 ],
                                                 "@type": "http://www.w3.org/2000/01/rdf-schema#Resource"
@@ -2839,7 +2839,7 @@
                                         "http://www.w3.org/2000/01/rdf-schema#label": [
                                             {
                                                 "@guid": "woB3HZpHQnvBNawJQhPgV9",
-                                                "http://www.w3.org/2000/01/rdf-schema#label": "Titles from separate title pates."
+                                                "http://www.w3.org/2000/01/rdf-schema#label": "Titles from separate title pages."
                                             }
                                         ],
                                         "@type": "http://id.loc.gov/ontologies/bibframe/Note"

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -419,7 +419,7 @@ const utilsNetwork = {
         url = "https://preprod-8080.id.loc.gov/resources/instances/identifier/"
       }
 
-      url = url + lccn + "&blastdacache=" + Date.now()
+      url = url + lccn.trim() + "&blastdacache=" + Date.now()
 
       let result = await fetch(
         url,
@@ -3621,7 +3621,7 @@ const utilsNetwork = {
 
     async linkedDataLCSHContributors(contributorsUris){
 
-        
+
       let url = useConfigStore().returnUrls.util + 'related/works/contributor'
 
       const rawResponse = await fetch(url, {
@@ -3637,7 +3637,7 @@ const utilsNetwork = {
       const content = await rawResponse.json();
 
       return content
-      
+
     },
 
     async linkedDataLCSHContributorsExtract(data){
@@ -3646,9 +3646,9 @@ const utilsNetwork = {
         console.log("linkedDataLCSHContributorsExtract data:",data)
 
         for (let lccnUri of Object.keys(data)){
-          
+
           let workUrls = data[lccnUri].results.map(work => work.uri + '.json');
-          
+
             let workPromises = workUrls.map(url => fetch(url).then(response => response.json()));
 
             try {
@@ -3674,19 +3674,19 @@ const utilsNetwork = {
                     }else{
                       if (g['http://www.w3.org/2000/01/rdf-schema#label'] && g['http://www.w3.org/2000/01/rdf-schema#label'].length > 0){
                       lookup[g['@id']]['label'] = g['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value']
-                      }                      
-                    }      
-                    
+                      }
+                    }
+
                     if (g['http://id.loc.gov/ontologies/bflc/marcKey'] && g['http://id.loc.gov/ontologies/bflc/marcKey'].length > 0){
                       lookup[g['@id']]['marcKey'] = g['http://id.loc.gov/ontologies/bflc/marcKey'][0]['@value']
                     }
-                    
+
                   }
 
                   if (g['@id'].startsWith('http://id.loc.gov/resources/works')){
                     lcshList.push(g)
                   }
-                  
+
 
                 }
 
@@ -3808,7 +3808,7 @@ const utilsNetwork = {
 
 
 
-                  }                  
+                  }
 
 
                 }


### PR DESCRIPTION
- Remove the `codes` from the labels in the default library.
- Fix typo in default library
- CopyCat trims whitespace around lccn