### PR TITLE
CopyCat Update ISBN Search

### DIFF
--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -67,10 +67,12 @@
             <label for="matchPoint">Match on: </label>
             <input name="matchPoint" id="matchPoint" type="text" v-model="isbn" @input="checkLccn" />
           </template>
+          <template v-else>
+            <br><br>
+          </template>
 
 
           <template v-if="existingLCCN || existingISBN">
-            <br>
             <Badge v-if="existingLCCN"
               text="A record with this LCCN might exist. If you continue, the copy cat record will be merged with the existing record."
               badgeType="warning" :noHover="true" />
@@ -441,6 +443,8 @@ export default {
           this.existingRecordUrl = ""
         }
       }
+
+      console.info("this.existingRecordUrl: ", this.existingRecordUrl)
     },
 
     encodingLevel: function (value) {


### PR DESCRIPTION
Adjustments to ISBN search:

- Allow ISBN/Other search when there is no LCCN
- Make Other search more explicit
- Allow cataloger to adjust the search

The LCCN check works the same: it uses the value in the LCCN input field. But now there's an option for "Other Identifier." When selected it'll populate the field with the value of the search query. It can be adjusted to check something else and can be done at anytime.

This does 2 things:
1) It makes explicit something that was happening under the hood, the search against the search field value
2) Allows the cataloger to make adjustments incase there's something else they would like to search on

Populating it with the `wcQuery` is a convenience.