### PR TITLE
Fix incorrect type for Geo Subjects

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2527,10 +2527,15 @@ methods: {
 
       this.pickLookup[this.pickPostion].picked=true
 
+      let type = null
       try {
-        let marcKey = this.pickLookup[this.pickPostion].marcKey
-        let type = marcKey.match(/\$[axyzv]{1}/g)
-        type = this.getTypeFromSubfield(type[0])
+        if (this.pickLookup[this.pickPostion].extra.rdftypes.length > 0){
+          type = "madsrdf:" + this.pickLookup[this.pickPostion].extra.rdftypes[0]
+        } else {
+          let marcKey = this.pickLookup[this.pickPostion].marcKey
+          type = marcKey.match(/\$[axyzv]{1}/g)
+          type = this.getTypeFromSubfield(type[0])
+        }
         this.setTypeClick(null, type)
       } catch(err) {
         console.error("Error getting the type. ", err)

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1594,8 +1594,6 @@ const utilsNetwork = {
       }
 
       for (let heading of headings){
-        console.info("heading: ", heading)
-
         let foundHeading = false
         // console.log("---------------------\n",heading,"\n------------------------\n")
 
@@ -2215,8 +2213,6 @@ const utilsNetwork = {
       // console.log("result",result)
 
       this.subjectSearchActive = false
-
-      console.info("result: ", result)
 
       return result
     },

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -1594,6 +1594,7 @@ const utilsNetwork = {
       }
 
       for (let heading of headings){
+        console.info("heading: ", heading)
 
         let foundHeading = false
         // console.log("---------------------\n",heading,"\n------------------------\n")
@@ -2192,10 +2193,11 @@ const utilsNetwork = {
       }
 
       // we want to double check the rdfType heading to make sure if we need to ask id to get more clarity about the rdfType
+
       if (Array.isArray(result.hit)){
         // it wont be an array if its a complex heading
         for (let r of result.hit){
-          if (!r.literal && r.uri.indexOf('id.loc.gov/authorities/names/') > 0){
+          if (!r.literal){  //&& r.uri.indexOf('id.loc.gov/authorities/names/') > 0
             r.heading.rdfType = "http://www.loc.gov/mads/rdf/v1#" + r.extra.rdftypes[0] //responseUri
           }
         }
@@ -2213,6 +2215,8 @@ const utilsNetwork = {
       // console.log("result",result)
 
       this.subjectSearchActive = false
+
+      console.info("result: ", result)
 
       return result
     },


### PR DESCRIPTION
The subject builder and Marc entry would both say that a geographic heading was a `Topic` because it was relying on the `$a` to set the type. Now they will make use of `extra.rdftypes[0]` when available to set the type.