### PR TITLE
Simplify intended audience

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -459,7 +459,7 @@ export const useConfigStore = defineStore('config', {
       "processor" : 'lcAuthorities',
       "modes":[
         {
-          'LCGFT All':{"url":"https://id.loc.gov/authorities/genreForms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},          
+          'LCGFT All':{"url":"https://id.loc.gov/authorities/genreForms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>", "all":true},
           'RBMS':{"url":"https://id.loc.gov/vocabulary/rbmscv/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 
         }
@@ -551,7 +551,7 @@ export const useConfigStore = defineStore('config', {
 			"processor" : 'lcAuthorities',
 			"modes":[
 				{
-					'MARC Audience':{"url": "https://id.loc.gov/vocabulary/maudience.html"},
+          'MARC Audience':{"url": "https://id.loc.gov/vocabulary/maudience/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 					'LCDGT':{"url": "https://id.loc.gov/authorities/demographicTerms/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
           // 'LCSH':{"url": "https://id.loc.gov/authorities/subjects/suggest2/?q=<QUERY>&count=25&offset=<OFFSET>"},
 				}

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2774,6 +2774,8 @@ export const useProfileStore = defineStore('profile', {
           //   ]
           // }
 
+          console.info("!propertypath: ", propertyPath)
+          console.info("?nodeMape collections: ", nodeMap.collections)
           // add the source for Genre/Form
           if (propertyPath.map((obj) => obj.propertyURI).includes("http://id.loc.gov/ontologies/bibframe/genreForm")){
             let objId = blankNode['@id']
@@ -2787,6 +2789,21 @@ export const useProfileStore = defineStore('profile', {
                           {
                               "@guid": short.generate(),
                               "http://www.w3.org/2000/01/rdf-schema#label": "Library of Congress genre/form terms for library and archival materials"
+                          }
+                      ]
+                  }
+              ]
+            } if (nodeMap.collections.includes('http://id.loc.gov/vocabulary/rbms/collection_rbmscv')){
+              console.info("nodeMape collections: ", nodeMap.collections)
+              blankNode['http://id.loc.gov/ontologies/bibframe/source'] =  [
+                {
+                      "@guid": short.generate(),
+                      "@type": "http://id.loc.gov/ontologies/bibframe/Source",
+                      "@id": "http://id.loc.gov/vocabulary/genreFormSchemes/rbmscv",
+                      "http://www.w3.org/2000/01/rdf-schema#label": [
+                          {
+                              "@guid": short.generate(),
+                              "http://www.w3.org/2000/01/rdf-schema#label": "RBMS Controlled Vocabularies"
                           }
                       ]
                   }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2774,8 +2774,6 @@ export const useProfileStore = defineStore('profile', {
           //   ]
           // }
 
-          console.info("!propertypath: ", propertyPath)
-          console.info("?nodeMape collections: ", nodeMap.collections)
           // add the source for Genre/Form
           if (propertyPath.map((obj) => obj.propertyURI).includes("http://id.loc.gov/ontologies/bibframe/genreForm")){
             let objId = blankNode['@id']
@@ -2794,7 +2792,6 @@ export const useProfileStore = defineStore('profile', {
                   }
               ]
             } if (nodeMap.collections.includes('http://id.loc.gov/vocabulary/rbms/collection_rbmscv')){
-              console.info("nodeMape collections: ", nodeMap.collections)
               blankNode['http://id.loc.gov/ontologies/bibframe/source'] =  [
                 {
                       "@guid": short.generate(),


### PR DESCRIPTION
Instead of the dual simple/complex lookup, we just use the suggest service for the Marc Audience terms. Didn't realize that was a possibility at the time of the first implementation.

Also adds source to RBMS lookup to fix second indicator and add `$2`