### PR TITLE
CopyCat UI Changes

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -318,7 +318,7 @@ const utilsNetwork = {
           return false
         }
 
-        if (url.includes('.rdf') || url.includes('.xml')){
+        if (url.includes('.rdf') || url.includes('.xml') || url.includes('.html')){
           data =  await response.text()
         }else{
           data =  await response.json()
@@ -416,7 +416,8 @@ const utilsNetwork = {
     searchLccn: async function name(lccn) {
       let url = "https://id.loc.gov/resources/instances/identifier/"
       if (useConfigStore().returnUrls.displayLCOnlyFeatures){
-        url = "https://preprod-8080.id.loc.gov/resources/instances/identifier/"
+        // url = "https://preprod-8080.id.loc.gov/resources/instances/identifier/"
+        url = "https://preprod-8289.id.loc.gov/resources/instances/identifier/"
       }
 
       url = url + lccn.trim() + "&blastdacache=" + Date.now()

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -43,6 +43,7 @@ const utilsNetwork = {
       "controllerCyak": new AbortController(),
       "exactName": new AbortController(),
       "exactSubject": new AbortController(),
+      "lccnSearchController": new AbortController(),
     },
     subjectSearchActive: false,
 
@@ -414,10 +415,15 @@ const utilsNetwork = {
     },
 
     searchLccn: async function name(lccn) {
+      if (this.subjectSearchActive){
+        this.controllers["lccnSearchController"].abort()
+        this.controllers["lccnSearchController"] = new AbortController()
+      }
+      this.subjectSearchActive = true
+
       let url = "https://id.loc.gov/resources/instances/identifier/"
       if (useConfigStore().returnUrls.displayLCOnlyFeatures){
-        // url = "https://preprod-8080.id.loc.gov/resources/instances/identifier/"
-        url = "https://preprod-8289.id.loc.gov/resources/instances/identifier/"
+        url = "https://preprod-8080.id.loc.gov/resources/instances/identifier/"
       }
 
       url = url + lccn.trim() + "&blastdacache=" + Date.now()
@@ -426,6 +432,7 @@ const utilsNetwork = {
         url,
         {
           method: 'HEAD',
+          signal: this.controllers["lccnSearchController"].signal
           // redirect: 'manual',
           // mode: 'cors',
           // headers: {
@@ -434,6 +441,8 @@ const utilsNetwork = {
           // }
         }
       )
+
+      this.subjectSearchActive = false
 
       return result
     },

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -45,14 +45,8 @@
             </select>
 
           </form>
-          <hr>
-          <label for="lccn">LCCN: </label>
-          <input name="lccn" id="lccn" type="text" v-model="urlToLoad" @input="checkLccn"
-            :disabled="selectedRecordUrl" />
-          <Badge v-if="selectedRecordUrl" text="This LCCN is from the selected record."
-            noHover="true" badgeType="primary" />
-          <br><br>
 
+          <hr style="margin-bottom: 10px;;">
           Check for existing record using:
           <div id="container">
             <input type="checkbox" id="search-type" class="toggle" name="search-type" value="keyword"
@@ -62,14 +56,19 @@
               <div>Other Identifier</div>
             </label>
           </div>
+
           <template v-if="searchType != 'lccn'">
-            <br>
             <label for="matchPoint">Match on: </label>
             <input name="matchPoint" id="matchPoint" type="text" v-model="isbn" @input="checkLccn" />
           </template>
-          <template v-else>
-            <br><br>
-          </template>
+
+          <br>
+          <label for="lccn">LCCN for record: </label>
+          <input name="lccn" id="lccn" type="text" v-model="urlToLoad" @input="checkLccn"
+            :disabled="selectedRecordUrl" />
+          <Badge v-if="selectedRecordUrl" text="This LCCN is from the selected record."
+            noHover="true" badgeType="primary" />
+          <br><br>
 
 
           <template v-if="existingLCCN || existingISBN">

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -283,7 +283,7 @@ export default {
     startingPointsFiltered() {
       let points = []
       for (let k in this.startingPoints) {
-        if (this.startingPoints[k].work && this.startingPoints[k].instance) {
+        if (this.startingPoints[k].work && this.startingPoints[k].instance && k != 'IBC description') {
           points.push(this.startingPoints[k])
         }
       }

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -383,6 +383,7 @@ export default {
       this.existingISBN = false
 
       console.info("urlToLoad: ", this.urlToLoad)
+      if (this.urlToLoad.length < 3){ return }
 
       if (this.searchType == 'lccn') {
         this.checkingLCCN = true
@@ -437,14 +438,11 @@ export default {
         }
       }
 
-      console.info("this.existingRecordUrl: ", this.existingRecordUrl)
       if (this.existingRecordUrl) {
         let data = await utilsNetwork.fetchSimpleLookup(this.existingRecordUrl)
-        console.info("data: ", data)
         const parser = new DOMParser()
         const doc = parser.parseFromString(data, "text/html")
         let title = doc.querySelectorAll('[name="dc.title"]')
-        console.info("title: ", title[0].content.split("(Instance)")[0])
         this.matchTitle = title[0].content.split("(Instance)")[0]
       }
     },

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -74,11 +74,10 @@
               <a class="existing-lccn-note" :href="existingRecordUrl" target="_blank">Existing Record with this {{
                 existingLCCN ? 'LCCN' : 'identifier' }}: "{{ matchTitle }}"</a>
             </h4>
-            <br>
           </template>
           <template v-else>
             <Badge v-if="urlToLoad != '' && !checkingLCCN && !existingLCCN && searchType == 'lccn' && wcIndex == 'sn'"
-              text="No results for this LCCN, try searching for the ISBN." badgeType="warning" :noHover="true" />
+              text="No matches for this LCCN, try searching for on another identifier like the ISBN." badgeType="warning" :noHover="true" />
           </template>
 
           <br>
@@ -91,7 +90,6 @@
 
           <label for="prio">Priority: </label><input name="prio" type="text" v-model="recordPriority"
             :class="{ 'needs-input': !recordPriority }" /><br>
-          <!-- <label for="ibc">Is there an IBC with the same LCCN? : </label><input name="ibc" id="ibc" type="checkbox" v-model="ibcCheck" /><br> -->
           <label for="jackphy">Does this record contain non-Latin script that should be retained? </label>
           <input name="jackphy" id="jackphy" type="checkbox" v-model="jackphyCheck" /><br>
           <br>

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -82,7 +82,7 @@
           </template>
 
           <br>
-          <label for="lccn">LCCN for record: </label>
+          <label for="lccn">LCCN: </label>
           <input name="lccn" id="lccn" type="text" v-model="urlToLoad" @input="checkLccn"
             :disabled="selectedRecordUrl" />
           <Badge v-if="selectedRecordUrl" text="This LCCN is from the selected record." noHover="true"
@@ -447,21 +447,6 @@ export default {
         return 'High'
       }
       return 'Low'
-    },
-
-    catLevelToolTip: function (value) {
-      switch (value) {
-        case "PccAdapt":
-          return "042 contains 'pcc' & Language = English"
-        case "CopyCat":
-          return "Encoding Level is 'high', Not PCC record, Language = English"
-        case "OrigRes":
-          return "Low level record, Not PCC, or not English"
-        case "OrigCop":
-          return "Cataloging Agency and Transcribing Agency are 'DLC'"
-        default:
-          return "You shouldn't be seeing this. Let someone know the value is '" + value + "'"
-      }
     },
 
     getMarcFieldAsString: function (record, target) {

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -76,11 +76,6 @@
             </h4>
             <br>
           </template>
-          <template v-else-if="urlToLoad.length < 10 && urlToLoad.length != 0">
-            <br>
-            <Badge text="LCCNs should be 10 characters long." badgeType="warning" :noHover="true" />
-            <br>
-          </template>
           <template v-else>
             <Badge v-if="urlToLoad != '' && !checkingLCCN && !existingLCCN && searchType == 'lccn' && wcIndex == 'sn'"
               text="No results for this LCCN, try searching for the ISBN." badgeType="warning" :noHover="true" />

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -57,30 +57,22 @@
             </label>
           </div>
 
+          <br>
           <template v-if="searchType != 'lccn'">
             <label for="matchPoint">Match on: </label>
             <input name="matchPoint" id="matchPoint" type="text" v-model="isbn" @input="checkLccn" />
           </template>
-
-          <br>
-          <label for="lccn">LCCN for record: </label>
-          <input name="lccn" id="lccn" type="text" v-model="urlToLoad" @input="checkLccn"
-            :disabled="selectedRecordUrl" />
-          <Badge v-if="selectedRecordUrl" text="This LCCN is from the selected record." noHover="true"
-            badgeType="primary" />
-          <br><br>
-
 
           <template v-if="existingLCCN || existingISBN">
             <Badge v-if="existingLCCN"
               text="A record with this LCCN might exist. If you continue, the copy cat record will be merged with the existing record."
               badgeType="warning" :noHover="true" />
             <Badge v-if="existingISBN"
-              text="A record with this ISBN might exist. If you continue, the copy cat record will be merged with the existing record."
+              text="A record with this identifier might exist. If you continue, the copy cat record will be merged with the existing record."
               badgeType="warning" :noHover="true" />
             <h4>
               <a class="existing-lccn-note" :href="existingRecordUrl" target="_blank">Existing Record with this {{
-                existingLCCN ? 'LCCN' : 'ISBN' }}</a>
+                existingLCCN ? 'LCCN' : 'identifier' }}: "{{ matchTitle }}"</a>
             </h4>
             <br>
           </template>
@@ -93,7 +85,15 @@
             <Badge v-if="urlToLoad != '' && !checkingLCCN && !existingLCCN && searchType == 'lccn' && wcIndex == 'sn'"
               text="No results for this LCCN, try searching for the ISBN." badgeType="warning" :noHover="true" />
           </template>
+
           <br>
+          <label for="lccn">LCCN for record: </label>
+          <input name="lccn" id="lccn" type="text" v-model="urlToLoad" @input="checkLccn"
+            :disabled="selectedRecordUrl" />
+          <Badge v-if="selectedRecordUrl" text="This LCCN is from the selected record." noHover="true"
+            badgeType="primary" />
+          <br><br>
+
           <label for="prio">Priority: </label><input name="prio" type="text" v-model="recordPriority"
             :class="{ 'needs-input': !recordPriority }" /><br>
           <!-- <label for="ibc">Is there an IBC with the same LCCN? : </label><input name="ibc" id="ibc" type="checkbox" v-model="ibcCheck" /><br> -->
@@ -444,7 +444,8 @@ export default {
         const parser = new DOMParser()
         const doc = parser.parseFromString(data, "text/html")
         let title = doc.querySelectorAll('[name="dc.title"]')
-        console.info("title: ", title[0].content)
+        console.info("title: ", title[0].content.split("(Instance)")[0])
+        this.matchTitle = title[0].content.split("(Instance)")[0]
       }
     },
 

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -66,8 +66,8 @@
           <label for="lccn">LCCN for record: </label>
           <input name="lccn" id="lccn" type="text" v-model="urlToLoad" @input="checkLccn"
             :disabled="selectedRecordUrl" />
-          <Badge v-if="selectedRecordUrl" text="This LCCN is from the selected record."
-            noHover="true" badgeType="primary" />
+          <Badge v-if="selectedRecordUrl" text="This LCCN is from the selected record." noHover="true"
+            badgeType="primary" />
           <br><br>
 
 
@@ -91,20 +91,14 @@
           </template>
           <template v-else>
             <Badge v-if="urlToLoad != '' && !checkingLCCN && !existingLCCN && searchType == 'lccn' && wcIndex == 'sn'"
-              text="No results for this LCCN, try searching for the ISBN."
-              badgeType="warning" :noHover="true" />
+              text="No results for this LCCN, try searching for the ISBN." badgeType="warning" :noHover="true" />
           </template>
           <br>
           <label for="prio">Priority: </label><input name="prio" type="text" v-model="recordPriority"
             :class="{ 'needs-input': !recordPriority }" /><br>
           <!-- <label for="ibc">Is there an IBC with the same LCCN? : </label><input name="ibc" id="ibc" type="checkbox" v-model="ibcCheck" /><br> -->
           <label for="jackphy">Does this record contain non-Latin script that should be retained? </label>
-            <input
-              name="jackphy"
-              id="jackphy"
-              type="checkbox"
-              v-model="jackphyCheck"
-              /><br>
+          <input name="jackphy" id="jackphy" type="checkbox" v-model="jackphyCheck" /><br>
           <br>
           <h3>Load with profile:</h3>
           <template v-if="posting">
@@ -444,6 +438,14 @@ export default {
       }
 
       console.info("this.existingRecordUrl: ", this.existingRecordUrl)
+      if (this.existingRecordUrl) {
+        let data = await utilsNetwork.fetchSimpleLookup(this.existingRecordUrl)
+        console.info("data: ", data)
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(data, "text/html")
+        let title = doc.querySelectorAll('[name="dc.title"]')
+        console.info("title: ", title[0].content)
+      }
     },
 
     encodingLevel: function (value) {


### PR DESCRIPTION
Some changes to the UI for copycat to better fit workflow that searches for an existing record before searching for the LCCN. 

If the identifier search finds a match, it'll put the title in the message.

![image](https://github.com/user-attachments/assets/ba85ccc6-1d96-4c44-85a1-e388a3edf302)

There's also support to abort a search as someone continues typing. Should fix the issue with some false positives turning up and sticky results.