### PR TITLE
Load Choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.13] - 2025-06-25
+### Added
+- Toggle for `Load.vue` between loading from `convertedit-pkg` or `editor-pkg`
+
 ## [1.3.12] - 2025-06-23
 ### Updated
 - IBC profile is loaded with eNumber

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 3,
-    versionPatch: 12,
+    versionPatch: 13,
 
 
 

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -165,6 +165,7 @@
                       <div>Continue Editing BF</div>
                     </label>
                   </div>
+                  <br>
                 </template>
 
                 <h3>Load with profile:</h3>

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -13,7 +13,8 @@
       <div v-if="!copyCatMode">
         <splitpanes>
           <pane class="load" v-if="displayAllRecords">
-            <button style="float: right; z-index: 1000;" @click="displayAllRecords = false; displayDashboard = true">Close</button>
+            <button style="float: right; z-index: 1000;"
+              @click="displayAllRecords = false; displayDashboard = true">Close</button>
             <div v-if="dashBoard && dashBoard.totalDays">
               <h1>
                 <span style="font-size: 1.25em; vertical-align: bottom; margin-right: 3px;"
@@ -44,7 +45,8 @@
 
             <div id="all-records-table">
               <div style="text-align: right;" v-if="dataTableRecords.length == dataTableInitalLimit">
-                <button @click="dataTableRecords = allRecords">Only showing the latest {{ dataTableInitalLimit }} records.
+                <button @click="dataTableRecords = allRecords">Only showing the latest {{ dataTableInitalLimit }}
+                  records.
                   Show all {{ allRecords.length }}?</button>
               </div>
               <DataTable :loading="isLoadingAllRecords" :rows="dataTableRecords" striped hoverable>
@@ -100,7 +102,8 @@
                   <input placeholder="URL to resource or identifier to search" class="url-to-load" type="text"
                     @input="loadSearch" v-model="urlToLoad" ref="urlToLoad">
 
-                    <div v-if="loadingRecord" class="loading-record">L<span class="infinite-spin">O</span>ADING REC<span class="infinite-spin">O</span>RD...</div>
+                  <div v-if="loadingRecord" class="loading-record">L<span class="infinite-spin">O</span>ADING REC<span
+                      class="infinite-spin">O</span>RD...</div>
 
                   <p>Need to search title or author? Use <a href="https://preprod-8230.id.loc.gov/lds/index.xqy"
                       target="_blank">BFDB</a>.</p>
@@ -152,6 +155,18 @@
                   First Enter the URL or identifier for a resource above, then select a profile.
                 </div>
 
+                <template v-if="showLoadTypeSelection()">
+                  <h3>Load Type:</h3>
+                  <div id="container">
+                    <input type="checkbox" id="search-type" class="toggle" name="search-type" value="keyword"
+                      @click="changeLoadType($event)" ref="toggle">
+                    <label for="search-type" class="toggle-container">
+                      <div>Reconvert from Marc</div>
+                      <div>Continue Editing BF</div>
+                    </label>
+                  </div>
+                </template>
+
                 <h3>Load with profile:</h3>
                 <div class="load-buttons">
                   <button class="load-button" @click="loadUrl(s.instance)"
@@ -162,8 +177,10 @@
 
                 <div class="default-profile-container">
                   <span>Default profile to use on [Enter] key</span>
-                  <select v-model="defaultProfile" @change="preferenceStore.setValue('--s-general-default-profile', defaultProfile)">
-                    <option v-for="s in startingPointsFiltered" :value="s.instance" :key="s.instance">{{ s.name }}</option>
+                  <select v-model="defaultProfile"
+                    @change="preferenceStore.setValue('--s-general-default-profile', defaultProfile)">
+                    <option v-for="s in startingPointsFiltered" :value="s.instance" :key="s.instance">{{ s.name }}
+                    </option>
                   </select>
                 </div>
 
@@ -232,9 +249,10 @@
                     these are only for testing input, and cannot be used for posting or in production.</summary>
                   <div :class="{ 'hide-options': hideOptions }">
                     <div class="load-buttons">
-                      <button class="load-button" @click="urlToLoad='new'; loadUrl(s.instance)" v-for="s in startingPointsFiltered">{{
-                        s.name
-                      }}</button>
+                      <button class="load-button" @click="urlToLoad = 'new'; loadUrl(s.instance)"
+                        v-for="s in startingPointsFiltered">{{
+                          s.name
+                        }}</button>
                     </div>
                   </div>
                 </div>
@@ -316,6 +334,7 @@ export default {
       hideOptions: true,
 
       loadingRecord: false,
+      loadType: "loadMarc",
 
     }
   },
@@ -352,7 +371,18 @@ export default {
   },
 
   methods: {
+    showLoadTypeSelection: function () {
+      let config = useConfigStore()
+      return config.returnUrls.displayLCOnlyFeatures
+    },
 
+    changeLoadType: function (event) {
+      if (event.target.checked) {
+        this.loadType = "loadBf"
+      } else {
+        this.loadType = "loadMarc"
+      }
+    },
 
     loadFromAllRecord: function (eId) {
 
@@ -497,12 +527,12 @@ export default {
     loadSearch: function () {
       this.lccnLoadSelected = null
       console.log("this.urlToLoad", this.urlToLoad)
-      console.log("this.urlToLoad.indexOf('BFDB URI')",this.urlToLoad.indexOf('BFDB URI'))
-      console.log("this.urlToLoad.indexOf('Status')",this.urlToLoad.indexOf('Status'))
+      console.log("this.urlToLoad.indexOf('BFDB URI')", this.urlToLoad.indexOf('BFDB URI'))
+      console.log("this.urlToLoad.indexOf('Status')", this.urlToLoad.indexOf('Status'))
       if (this.urlToLoad.startsWith("http://") || this.urlToLoad.startsWith("https://")) {
         this.urlToLoadIsHttp = true
         return false
-      }else if(this.urlToLoad.indexOf('BFDB URI') > -1 && this.urlToLoad.indexOf('Status') > -1  ){
+      } else if (this.urlToLoad.indexOf('BFDB URI') > -1 && this.urlToLoad.indexOf('Status') > -1) {
 
         let urlMatch = this.urlToLoad.match(/:\/\/[^\s\/]+\/.*?\/instances\/[^\s]+/g);
         if (urlMatch && urlMatch.length > 0) {
@@ -515,7 +545,7 @@ export default {
           this.loadUrl(new Event('click'), null)
 
           return false;
-        }else{
+        } else {
           this.urlToLoadIsHttp = false
         }
 
@@ -543,22 +573,24 @@ export default {
     },
 
     loadUrl: async function (useInstanceProfile, multiTestFlag) {
-      console.log("useInstanceProfile",useInstanceProfile)
+      console.log("useInstanceProfile", useInstanceProfile)
       let useLoadUrl = ''
       if (this.lccnLoadSelected) {
         useLoadUrl = this.lccnLoadSelected.bfdbPackageURL
-      }else if (this.urlToLoad.startsWith("http://") || this.urlToLoad.startsWith("https://") || this.urlToLoad.startsWith("/")) {
+        if (this.loadType == 'loadBf') {
+          useLoadUrl = useLoadUrl.replace("convertedit-pkg", "editor-pkg")
+        }
+      } else if (this.urlToLoad.startsWith("http://") || this.urlToLoad.startsWith("https://") || this.urlToLoad.startsWith("/")) {
         useLoadUrl = this.urlToLoad
-      }else if (this.urlToLoad=='new') {
+      } else if (this.urlToLoad == 'new') {
         // continue on with a empty profile
-      }else{
+      } else {
         alert("Please enter a valid URL or identifier to load.")
       }
 
-
       // did they just hit enter and the record is loading, and not ready to go yet
       if (useLoadUrl.trim() === '' && this.searchByLccnResults && typeof this.searchByLccnResults === 'string') {
-        if (this.urlToLoadTimer){
+        if (this.urlToLoadTimer) {
           return false
         }
         this.urlToLoadTimer = window.setTimeout(() => {
@@ -569,11 +601,11 @@ export default {
       }
 
       if (useLoadUrl.trim() !== '') {
-        this.loadingRecord=true
+        this.loadingRecord = true
         let xml = await utilsNetwork.fetchBfdbXML(useLoadUrl)
         if (!xml) {
           alert("There was an error retrieving that URL. Are you sure it is correct: " + this.urlToLoad)
-          this.loadingRecord=false
+          this.loadingRecord = false
           return false
         }
         // if (xml.indexOf('<rdf:RDF'))
@@ -587,13 +619,13 @@ export default {
       // console.log("useInstanceProfile", useInstanceProfile)
 
       // if it is an event it means they did not click the profile button but pressed ENTER
-      if (useInstanceProfile instanceof Event){
+      if (useInstanceProfile instanceof Event) {
         // check to see if there is a default profile set
         if (this.defaultProfile && this.defaultProfile != '') {
           useInstanceProfile = this.defaultProfile
         }
         // don't keep going if there was no search result
-        if (this.searchByLccnResults && this.searchByLccnResults.length === 0){
+        if (this.searchByLccnResults && this.searchByLccnResults.length === 0) {
           return false
         }
       }
@@ -609,13 +641,13 @@ export default {
 
       // check if the input field is empty
       if (useLoadUrl == "" && useProfile === null) {
-        this.loadingRecord=false
+        this.loadingRecord = false
         alert("Please enter the URL or Identifier of the record you want to load.")
         return false
       }
 
       if (useProfile === null) {
-        this.loadingRecord=false
+        this.loadingRecord = false
         alert('No profile selected. Select a profile under "Load with profile."')
         return false
       }
@@ -761,56 +793,56 @@ export default {
               '@guid': short.generate(),
               "type": "resource",
               "userValue": {
-                    "@root": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
-                    "http://id.loc.gov/ontologies/bibframe/adminMetadata": [
-                        {
+                "@root": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
+                "http://id.loc.gov/ontologies/bibframe/adminMetadata": [
+                  {
+                    "@guid": short.generate(),
+                    "@type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
+                    "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
+                      {
+                        "@guid": short.generate(),
+                        "@type": "http://id.loc.gov/ontologies/bibframe/Local",
+                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
+                          {
+                            "@guid": "8wJoYGrC8ut67SxhnXMEQp",
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": useProfile.eId
+                          }
+                        ],
+                        "http://id.loc.gov/ontologies/bibframe/assigner": [
+                          {
                             "@guid": short.generate(),
-                            "@type": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
-                            "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
-                                {
-                                    "@guid": short.generate(),
-                                    "@type": "http://id.loc.gov/ontologies/bibframe/Local",
-                                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": [
-                                        {
-                                            "@guid": "8wJoYGrC8ut67SxhnXMEQp",
-                                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#value": useProfile.eId
-                                        }
-                                    ],
-                                    "http://id.loc.gov/ontologies/bibframe/assigner": [
-                                        {
-                                            "@guid": short.generate(),
-                                            "@type": "http://id.loc.gov/ontologies/bibframe/Organization",
-                                            "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc",
-                                            "http://www.w3.org/2000/01/rdf-schema#label": [
-                                                {
-                                                    "@guid": short.generate(),
-                                                    "http://www.w3.org/2000/01/rdf-schema#label": "LC, NDMSO"
-                                                }
-                                            ],
-                                            "http://id.loc.gov/ontologies/bibframe/code": [
-                                                {
-                                                    "@guid": short.generate(),
-                                                    "http://id.loc.gov/ontologies/bibframe/code": "DLC-MRC",
-                                                    "@datatype": "http://id.loc.gov/datatypes/orgs/code"
-                                                },
-                                                {
-                                                    "@guid": short.generate(),
-                                                    "http://id.loc.gov/ontologies/bibframe/code": "dlcmrc",
-                                                    "@datatype": "http://id.loc.gov/datatypes/orgs/normalized"
-                                                },
-                                                {
-                                                    "@guid": short.generate(),
-                                                    "http://id.loc.gov/ontologies/bibframe/code": "US-dlcmrc",
-                                                    "@datatype": "http://id.loc.gov/datatypes/orgs/iso15511"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
+                            "@type": "http://id.loc.gov/ontologies/bibframe/Organization",
+                            "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc",
+                            "http://www.w3.org/2000/01/rdf-schema#label": [
+                              {
+                                "@guid": short.generate(),
+                                "http://www.w3.org/2000/01/rdf-schema#label": "LC, NDMSO"
+                              }
+                            ],
+                            "http://id.loc.gov/ontologies/bibframe/code": [
+                              {
+                                "@guid": short.generate(),
+                                "http://id.loc.gov/ontologies/bibframe/code": "DLC-MRC",
+                                "@datatype": "http://id.loc.gov/datatypes/orgs/code"
+                              },
+                              {
+                                "@guid": short.generate(),
+                                "http://id.loc.gov/ontologies/bibframe/code": "dlcmrc",
+                                "@datatype": "http://id.loc.gov/datatypes/orgs/normalized"
+                              },
+                              {
+                                "@guid": short.generate(),
+                                "http://id.loc.gov/ontologies/bibframe/code": "US-dlcmrc",
+                                "@datatype": "http://id.loc.gov/datatypes/orgs/iso15511"
+                              }
                             ]
-                        }
+                          }
+                        ]
+                      }
                     ]
-                },
+                  }
+                ]
+              },
               "valueConstraint": {
                 "defaults": [],
                 "useValuesFrom": [],
@@ -820,7 +852,7 @@ export default {
             }
 
             // Add the eNumber to the instance identifier
-            if (Object.keys(pt).includes("id_loc_gov_ontologies_bibframe_identifiedBy__identifiers")){
+            if (Object.keys(pt).includes("id_loc_gov_ontologies_bibframe_identifiedBy__identifiers")) {
               pt['id_loc_gov_ontologies_bibframe_identifiedBy__identifiers'].userValue = {
                 "http://id.loc.gov/ontologies/bibframe/identifiedBy": [
                   {
@@ -850,7 +882,7 @@ export default {
           }
         }
       }
-      this.loadingRecord=false
+      this.loadingRecord = false
       if (multiTestFlag) {
         this.$router.push(`/multiedit/`)
         return true
@@ -900,7 +932,7 @@ export default {
   },
 
   mounted: async function () {
-    this.loadingRecord=false
+    this.loadingRecord = false
     this.refreshSavedRecords()
     if (window.location.hash && window.location.hash == '#stats') {
       // console.log("showing stats")
@@ -952,12 +984,12 @@ export default {
 </script>
 
 <style>
-
-.loading-record{
+.loading-record {
   text-align: center;
   font-size: 1.5em;
   margin-bottom: 1em;
 }
+
 .dt-bg-gray-50 {
   background-color: v-bind("preferenceStore.returnValue('--c-edit-modals-background-color-accent')") !important;
   color: v-bind("preferenceStore.returnValue('--c-edit-modals-text-color')") !important;
@@ -1148,22 +1180,93 @@ summary {
 
 }
 
-.default-profile-container{
-  padding:0.25em;
-  margin-top:1em
+.default-profile-container {
+  padding: 0.25em;
+  margin-top: 1em
 }
-.default-profile-container select{
+
+.default-profile-container select {
   margin-left: 1em;
   font-size: 1em;
 }
+
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .infinite-spin {
   display: inline-block;
   /* don't do it :( */
   /* animation: spin 2s linear infinite; */
+}
+
+/* toggle */
+/* https://hudecz.medium.com/how-to-create-a-pure-css-toggle-button-2fcc955a8984 */
+#container {
+  margin-left: 5px;
+}
+
+.toggle {
+  display: none;
+}
+
+.toggle-container {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  width: fit-content;
+  border: 3px solid v-bind("preferenceStore.returnValue('--c-edit-copy-cat-card-color-selected')");
+  border-radius: 20px;
+  background: v-bind("preferenceStore.returnValue('--c-edit-copy-cat-card-color-selected')");
+  font-weight: bold;
+  color: v-bind("preferenceStore.returnValue('--c-edit-copy-cat-card-color-selected')");
+  cursor: pointer;
+}
+
+.toggle-container::before {
+  content: '';
+  position: absolute;
+  width: 50%;
+  height: 100%;
+  left: 0%;
+  border-radius: 20px;
+  background: black;
+  transition: all 0.3s;
+}
+
+.toggle-container div {
+  padding: 6px;
+  text-align: center;
+  z-index: 1;
+}
+
+.toggle:checked+.toggle-container::before {
+  left: 50%;
+}
+
+.toggle:checked+.toggle-container div:first-child {
+  color: black;
+  transition: color 0.3s;
+}
+
+.toggle:checked+.toggle-container div:last-child {
+  color: v-bind("preferenceStore.returnValue('--c-edit-copy-cat-card-color-selected')");
+  transition: color 0.3s;
+}
+
+.toggle+.toggle-container div:first-child {
+  color: v-bind("preferenceStore.returnValue('--c-edit-copy-cat-card-color-selected')");
+  transition: color 0.3s;
+}
+
+.toggle+.toggle-container div:last-child {
+  color: black;
+  transition: color 0.3s;
 }
 </style>


### PR DESCRIPTION
Add a choice to the Load page either load as `Reconvert from Marc` or `Continue Editing BF`
- `Reconvert` uses "editconvert-pkg"
- `Continue` uses "editor-pkg"

These match the options available in BFDB. 

This is an `LCOnlyFeature`. Cataloger where having issues with loading a record they had worked on and getting the Reconverted MARC, which made the record appear as if it hadn't been touched.