### PR TITLE
Marva-Folio Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Toggle for `Load.vue` between loading from `convertedit-pkg` or `editor-pkg`
 
+### Updated
+- More prep for OrigBF records
+
+
 ## [1.3.12] - 2025-06-23
 ### Updated
 - IBC profile is loaded with eNumber

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -606,6 +606,32 @@
             }
           )
 
+          menu.push(
+            {
+              text: "Open in Folio",
+              id:"send-folio",
+              ref:"folio",
+              icon: "🇫",
+              click: () => {
+                let url = "https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
+                let bibId = null
+
+                console.info("profile: ", this.activeProfile)
+                // get the bibID
+                for (let rt in this.activeProfile.rt){
+                  let type = rt.split(':').slice(-1)[0]
+                  let url = this.activeProfile.rt[rt].URI
+                  if (type=='Instance'){
+                    bibId =  url.split("/")[url.split('/').length - 1]
+                  }
+                }
+                window.open(url + bibId)
+              },
+              class: (this.activeProfilePosted) ? "record-posted-folio-ok" : "record-unposted-folio-no",
+            }
+          )
+
+
 
           if (this.preferenceStore.copyMode){
               menu.push({ is: "separator" })
@@ -1175,6 +1201,13 @@
       margin-left: 100px;
     }
 
+    .record-unposted-folio-ok{
+      pointer-events: all;
+    }
+    .record-unposted-folio-no{
+      pointer-events: none;
+      opacity: .5;
+    }
 
     .record-posted .icon{
       color: green !important;

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -748,7 +748,7 @@ export default {
 
         //For IBCs add the admin metadata
         for (let rt in this.activeProfile.rt) {
-          if (rt.includes(":Ibc:Instance")) {
+          if (rt.includes(":Instance")) {  // :Ibc:Instance
             let pt = this.activeProfile.rt[rt].pt
             let parent
             let parentId

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -231,23 +231,17 @@
               </div>
 
               <div>
-                <h1 style="margin-bottom: 10px;">
+                <h2 style="margin-bottom: 10px;">
                   <span style="font-size: 1.25em; vertical-align: bottom; margin-right: 3px;"
                     class="material-icons">edit_document</span>
-                  <span>Create Blank Record</span>
-                </h1>
+                  <span>Create Original BIBFRAME (origbf) Descriptions</span>
+                </h2>
                 <div style="padding:5px;">
-                  Use these blank templates to test, but any record that you want to post to Voyager must originate in
-                  Voyager.
-                  Marva cannot currently assign Voyager bib numbers, so you need to create a stub record in Voyager
-                  and
-                  then load
-                  it into Marva.
+                  Use these templates for original BIBFRAME descriptions in Marva and then sent to Folio as Modern MARC records.
                 </div>
                 <div @click="hideOptions = !hideOptions">
                   <summary><span style="text-decoration: underline;">Click Here</span> to access blank record
-                    templates. Currently
-                    these are only for testing input, and cannot be used for posting or in production.</summary>
+                    templates.</summary>
                   <div :class="{ 'hide-options': hideOptions }">
                     <div class="load-buttons">
                       <button class="load-button" @click="urlToLoad = 'new'; loadUrl(s.instance)"


### PR DESCRIPTION
Updates for Folio workflow.

Adds:
- "Open in Folio" button to nav bar
Button just opens a url to the Toolkit but inserts the records bibid. The bibId is based on the URL for the instance. The button is not active until the record is posted to BFDB.

Changes:
- All blank records can be used for `origbf` records because they will have the eNumber added to them
- Wording on Loading page updated to reflect changes for folio