### PR TITLE
Open in folio fix

### DIFF
--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -613,9 +613,9 @@
               ref:"lcap",
               icon: "open_in_new",
               click: () => {
-                let url = "https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
+                let url =  useConfigStore().returnUrls.lcap // "https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
                 let bibId = null
-
+                console.log("url",url)
                 // get the bibID
                 for (let rt in this.activeProfile.rt){
                   let type = rt.split(':').slice(-1)[0]
@@ -626,7 +626,7 @@
                 }
                 window.open(url + bibId)
               },
-              class: (this.activeProfilePosted || this.isStaging()) ? "record-posted-folio-ok" : "record-unposted-folio-no",
+              class: (this.activeProfilePosted || this.isStaging() || (this.activeProfile && this.activeProfile.status && this.activeProfile.status == 'posted' )) ? "record-posted-folio-ok" : "record-unposted-folio-no",
             }
           )
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 3,
-    versionPatch: 14,
+    versionPatch: 15,
 
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -68,6 +68,7 @@ export const useConfigStore = defineStore('config', {
         dev: true,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
+        lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
       },
 
       externalDev:{
@@ -86,6 +87,7 @@ export const useConfigStore = defineStore('config', {
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
         publicEndpoints:true,
+        lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
 
       },
 
@@ -108,6 +110,7 @@ export const useConfigStore = defineStore('config', {
 
         worldCat: 'https://preprod-3001.id.loc.gov/bfe2/util/worldcat/',
         copyCatUpload: 'https://preprod-3001.id.loc.gov/bfe2/util/copycat/upload/stag', // change ports for production
+        lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
 
         id: 'https://preprod-8080.id.loc.gov/',
         env : 'staging',
@@ -131,6 +134,8 @@ export const useConfigStore = defineStore('config', {
         // starting : 'https://editor.id.loc.gov/api/listconfigs?where=index.resourceType:startingPoints&where=index.label:config',
         profiles : '/bfe2/util/profiles/profile/prod',
         starting : '/bfe2/util/profiles/starting/prod',
+
+        lcap: 'https://lcsg.toolkit.lcap.loc.gov/lcap-productivity/marva/bibId/',
 
         worldCat: 'https://editor.id.loc.gov/bfe2/util/worldcat/',
         copyCatUpload: 'https://editor.id.loc.gov/bfe2/util/copycat/upload/prod',


### PR DESCRIPTION
Adds LCAP Marva loader URL to config. 
Adds the correct url for Production. 
Enables the button if the status of the profile is published.

 