### PR TITLE
Add resync toggle icon to load screen to show resync lcap buttons

### DIFF
--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -3848,7 +3848,7 @@ const utilsNetwork = {
 
       let basePath = url.split('id.loc.gov/')[1];
 
-      let bfdbUrl = useConfigStore().returnUrls.bfdb + basePath + '.doc.xml';
+      let bfdbUrl = useConfigStore().returnUrls.bfdb + basePath + '.doc.xml' + "?blastdacache=" + Date.now();
 
       let results
       try {
@@ -3857,7 +3857,7 @@ const utilsNetwork = {
 
         // try ID
         let id = basePath.split('/').pop()
-        let idUrl = useConfigStore().returnUrls.id + 'data/bibs/' + id + '.mets.xml';
+        let idUrl = useConfigStore().returnUrls.id + 'data/bibs/' + id + '.mets.xml' + "?blastdacache=" + Date.now();
         try {
           results = await fetch(idUrl);
         } catch (error) {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 3,
-    versionPatch: 17,
+    versionPatch: 18,
 
 
 

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -111,12 +111,15 @@
 
                 <ol>
 
-                  <li v-if="searchByLccnResults && searchByLccnResults.length === 0">
-                    <div>No results...</div>
+
+                  <div v-if="searchByLccnResults && searchByLccnResults.length === 0">No results...</div>
+
+                  <li v-if="(searchByLccnResults && searchByLccnResults.length === 0) || showSyncOptions">
+                    
 
                     <div><button @click="openLCAPSyncURL()">Click to Request LCAP Sync for this LCCN</button></div>
                     <div>and then</div>
-                    <div><button @click="loadSearch()">Click to Run Search Again</button></div>
+                    <div><button @click="loadSearch(); showSyncOptions=false">Click to Run Search Again</button></div>
                   </li>
 
                   <template v-if="searchByLccnResults && typeof searchByLccnResults === 'string'">
@@ -129,6 +132,7 @@
                     <table>
                         <thead>
                           <tr>
+                            <th></th>
                             <th></th>
                             <th></th>
                             <th></th>
@@ -158,6 +162,13 @@
                                   </ul>
 
 
+                              </span>
+                            </td>
+                            <td>
+                              <span data-tooltip="Show LCAP Resync Buttons" class="simptip-position-left">
+
+                              
+                                <a href="#" style="cursor: pointer; color:inherit; text-decoration: none;" @click.prevent="showSyncOptions = true" class="material-icons"  title="Show Resync Options">loop</a>
                               </span>
                             </td>
                           </tr>
@@ -372,6 +383,8 @@ export default {
       lccnLoadSelected: false,
 
       dataTableInitalLimit: 1000,
+
+      showSyncOptions: false,
 
       defaultProfile: '',
 


### PR DESCRIPTION
Adds a resync icon to the Lccn Load search results that can be clicked to toggle the force resync buttons.