### PR TITLE
Nar 046 fix complex label dereference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 
-## [1.3.17] - 2025-01-01
+## [1.3.19] - 2025-01-03
+### Fixed
+- NAR: Hyphanted names in basic mode was not generating correct MARC
+### Updated
+- NAR: 046 is no longer is visible in the advanced marc mode, it will add it there and not try to sneak it in during MARC export
+- Will dereference labels for genres, adds a new exception to keep top level resources without bnodes
+
+## [1.3.17] - 2025-07-01
 ### Updated
 - Load screen updates to prompt to resync from LCAP if no LCCN found
 - Adds dates loaded from METS records in BFDB/ID to show when a record was last edited 

--- a/public/test_files/2023548475.xml
+++ b/public/test_files/2023548475.xml
@@ -51,6 +51,25 @@
                 </bf:role>
             </bf:Contribution>
         </bf:contribution>
+        <bf:contribution>
+            <bf:Contribution>
+                <bf:agent>
+                    <bf:Agent>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Person"/>
+                        <rdfs:label>Robinson-Burns, Xandra</rdfs:label>
+                        <bflc:marcKey>1001 $aRobinson-Burns, Xandra.$d1900-2000</bflc:marcKey>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/aut">
+                        <rdfs:label>author</rdfs:label>
+                        <bf:code>aut</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+
+        
         <bf:title>
             <bf:Title>
                 <bf:mainTitle>Discursul public</bf:mainTitle>

--- a/public/test_files/2023548475.xml
+++ b/public/test_files/2023548475.xml
@@ -73,6 +73,26 @@
                 </bf:role>
             </bf:Contribution>
         </bf:contribution>
+        <bf:contribution>
+            <bf:Contribution>
+                <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/PrimaryContribution"/>
+                <bf:agent>
+                    <bf:Agent>
+                        <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Organization"/>
+                        <rdfs:label>Association of Women Librarians in Nigeria. Annual workshop (3rd : 2013 : Agudama-Epie, Nigeria).</rdfs:label>
+                        <bflc:marcKey>1102 $aAssociation of Women Librarians in Nigeria.$bAnnual workshop$n(3rd :$d2013 :$cAgudama-Epie, Nigeria).</bflc:marcKey>
+                    </bf:Agent>
+                </bf:agent>
+                <bf:role>
+                    <bf:Role rdf:about="http://id.loc.gov/vocabulary/relators/aut">
+                        <rdfs:label>author</rdfs:label>
+                        <bf:code>aut</bf:code>
+                    </bf:Role>
+                </bf:role>
+            </bf:Contribution>
+        </bf:contribution>
+        <bf:genreForm rdf:resource="https://id.loc.gov/authorities/genreForms/gf2014026049"/>
+        
         <dcterms:isPartOf rdf:resource="http://id.loc.gov/resources/works"/>
         <bf:hasInstance rdf:resource="http://id.loc.gov/resources/instances/24184525"/>
         <bf:adminMetadata>

--- a/src/components/panels/edit/fields/LookupComplex.vue
+++ b/src/components/panels/edit/fields/LookupComplex.vue
@@ -55,7 +55,7 @@
             <div v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-show-field-labels') && complexLookupValues.length==0"  class="lookup-fake-input-label" :class="{'label-bold': preferenceStore.returnValue('--b-edit-main-splitpane-edit-show-field-labels-bold')}">{{structure.propertyLabel}}</div>
           </template>
 
-
+          <!-- SHORT CODE DISPLAY MODE -->
           <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == true">
             <div class="lookup-fake-input-text">
                 <div class="bfcode-display-mode-holder">
@@ -87,33 +87,22 @@
 
 
 
-
+          <!-- NORMAL DISPLAY MODE -->
           <template v-if="preferenceStore.returnValue('--b-edit-main-splitpane-edit-shortcode-display-mode') == false">
             <div class="lookup-fake-input-entities" v-if="marcDeliminatedLCSHMode == false">
 
-
+              
               <div v-for="(avl,idx) in complexLookupValues" :class="['selected-value-container']">
                 <div class="selected-value-container-auth">
-                  <!-- <br>
-                  !!{{ avl.type }}
-                  <br>
-                  {{ preferenceStore.returnValue('--b-edit-complex-use-value-icons') }} -->
                   <AuthTypeIcon passClass="complex-lookup-inline" v-if="avl.type && preferenceStore.returnValue('--b-edit-complex-use-value-icons')"  :type="avl.type"/>
                 </div>
-
+                
                 <div class="selected-value-container-title">
-                  <!-- <span class="material-icons check-mark">check_circle_outline</span> -->
                   <span v-if="!avl.needsDereference && !avl.uneditable " style="padding-right: 0.3em; font-weight: bold">
                     <a href="#" :class="['entity-link']" @click="openAuthority()" ref="el">{{avl.label}}</a>
                     <ValidationIcon :value="avl" />
-                    <!-- <span class="uncontrolled" v-if="avl.isLiteral">
-                      (uncontrolled)
-                    </span>
-                    <span v-if="!avl.isLiteral" title="Controlled Term" class="selected-value-icon" style="">
-                    </span> -->
-
                   </span>
-                  <span v-else-if="avl.needsDereference" style="padding-right: 0.3em; font-weight: bold"><LabelDereference :URI="avl.URI"/><span v-if="!avl.isLiteral" title="Controlled Term" class="selected-value-icon"><span class="material-icons check-mark">check_circle_outline</span></span></span>
+                  <span v-else-if="avl.needsDereference" style="padding-right: 0.3em; font-weight: bold"><LabelDereference :URI="avl.URI"/></span>
                   <span v-else-if="avl.uneditable" style="padding-right: 0.3em; font-weight: bold">{{ avl.label }} (Uneditable)</span>
                 </div>
                 <div class="selected-value-container-action" v-if="!avl.uneditable">
@@ -137,6 +126,7 @@
         </div>
 
 
+        <!-- SUBJECT MODE -->
         <template v-if="configStore.useSubjectEditor.includes(structure.propertyURI)">
 
           <div class="marc-deliminated-lcsh-mode-container" v-if="marcDeliminatedLCSHModeResults && marcDeliminatedLCSHModeResults.hit && Array.isArray(marcDeliminatedLCSHModeResults.hit)">

--- a/src/components/panels/edit/fields/helpers/LabelDereference.vue
+++ b/src/components/panels/edit/fields/helpers/LabelDereference.vue
@@ -42,7 +42,7 @@ export default {
     fetchLabel: function(){
       if (this.URI){
         if (this.URI.startsWith('http://') || this.URI.startsWith('https://') ){
-
+          // console.log('fetching label for URI: ' + this.URI)
           if (this.URI.includes('id.loc.gov')){
 
             // if its a instance/work/hub getthe x-pref label from the head request
@@ -52,6 +52,8 @@ export default {
                 this.URI.includes('/resources/hubs/') ||
                 this.URI.includes('/ontologies/bibframe/') ||
 
+
+                this.URI.includes('/authorities/genreForms/') ||
 
                 this.URI.includes('/vocabulary/')
               ){
@@ -64,8 +66,10 @@ export default {
               URL = URL.replace('http://','https://')
 
               let cache = sessionStorage.getItem(URL);
-
               if (cache){
+
+                // console.log('using cached label for URI: ' + this.URI)
+                // console.log('cached label: ' + cache)
 
                 this.displayLabel = cache
 
@@ -74,11 +78,9 @@ export default {
                 if (returnUrls.env == "production"){
                   URL = URL.replace("//id.", "//preprod-8080.id.")
                 }
-
-                let self = this
                 fetch(URL, {method: 'HEAD' }).then(
-                  function(response)
-                    {
+                  (response) => {
+                      // console.log('fetching label for URI: ' + this.URI)
 
                       // an id upgrade enables a ecoded pref-label to be exposed
                       // since the old x-preflabel is not encoded and header vars are not unicode supporting
@@ -87,16 +89,16 @@ export default {
                       if (response.headers.get("x-preflabel-encoded")){
                         preflabel = decodeURIComponent(response.headers.get("x-preflabel-encoded"));
                       }
-
+                      // console.log('x-preflabel: ' + preflabel)
                       if (preflabel){
-                        self.displayLabel = preflabel
+                        this.displayLabel = preflabel
                         sessionStorage.setItem(URL, preflabel);
                       }
                     }
-                  ).catch(function() {
+                  ).catch((e) => {
 
                         // there was something with the request, ignore
-
+                        console.error('Error fetching label for URI: ' + this.URI);
 
                   });
 
@@ -112,6 +114,9 @@ export default {
               // some common hardcoded values
               if (this.URI == 'http://id.loc.gov/authorities/subjects'){
                 this.displayLabel = 'Library of Congress subject headings'
+              }else{
+                // just return the URI
+                this.displayLabel = this.URI
               }
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -7,7 +7,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 3,
-    versionPatch: 18,
+    versionPatch: 19,
 
 
 


### PR DESCRIPTION
### Fixed
- NAR: Hyphenated names in basic mode was not generating correct MARC
### Updated
- NAR: 046 is visible in the advanced marc mode, it will add it there and not try to sneak it in during MARC export
- Will dereference labels for genres, adds a new exception to keep top level resources without bnodes
