### PR TITLE
Shelf list preserve space

### DIFF
--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -449,7 +449,7 @@
                 <input v-model="cutterNumber" class="number-input" @input="search()" placeholder="Cutter" type="text" />
                 <button class="number-input" @click="save" :disabled="(!activeShelfListData.componentGuid)">Save</button>
                 <input name="preserveSpace" type="checkbox" v-model="preserveSpace" @click="search()" />
-                <label for="preserveSpace">Preserve Cutter Spaces</label>
+                <label for="preserveSpace" class="number-input">Preserve Cutter Spaces</label>
 
                 <div class="menu-buttons">
                   <button class="close-button"   @pointerup="showShelfListingModal=false">X</button>

--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -449,7 +449,7 @@
                 <input v-model="cutterNumber" class="number-input" @input="search()" placeholder="Cutter" type="text" />
                 <button class="number-input" @click="save" :disabled="(!activeShelfListData.componentGuid)">Save</button>
                 <input name="preserveSpace" type="checkbox" v-model="preserveSpace" @click="search()" />
-                <label for="preserveSpace">Preserve Spaces</label>
+                <label for="preserveSpace">Preserve Cutter Spaces</label>
 
                 <div class="menu-buttons">
                   <button class="close-button"   @pointerup="showShelfListingModal=false">X</button>

--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -147,7 +147,7 @@
             let date = this.date ? "&sp-date="+this.date : ""
             let countParam = "&count=201"
 
-            let cutter = this.preserveSpace ? this.cutterNumber : this.cutterNumber.trim()
+            let cutter = this.preserveSpace ? this.cutterNumber : this.cutterNumber.trimEnd()
             let initalResult =  await utilsNetwork.searchShelfList(
               this.classNumber.trim() + '' + cutter,
               contributor + title + subj + date + countParam
@@ -236,7 +236,7 @@
             await this.profileStore.setValueLiteral(this.activeShelfListData.componentGuid,this.activeShelfListData.classGuid,classPropertyPath,this.classNumber)
           }
 
-          if (this.cutterNumber && this.cutterNumber != ''){  //.trim()
+          if (this.cutterNumber && this.cutterNumber.trim() != ''){
             if (!this.activeShelfListData.cutterGuid){
               this.activeShelfListData.cutterGuid = short.generate()
             }
@@ -263,7 +263,7 @@
 
           this.results = []
           this.searching=true
-          let cutter = this.preserveSpace ? this.cutterNumber : this.cutterNumber.trim()
+          let cutter = this.preserveSpace ? this.cutterNumber : this.cutterNumber.trimEnd()
           this.results =  await utilsNetwork.searchShelfList(
             this.classNumber.trim() + '' + cutter,
             contributor + title + subj + date + countParam

--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -57,7 +57,8 @@
 
         oldInterface: false,
 
-        idbase: useConfigStore().returnUrls.id
+        idbase: useConfigStore().returnUrls.id,
+        preserveSpace: false,
 
 
       }
@@ -146,9 +147,9 @@
             let date = this.date ? "&sp-date="+this.date : ""
             let countParam = "&count=201"
 
-
+            let cutter = this.preserveSpace ? this.cutterNumber : this.cutterNumber.trim()
             let initalResult =  await utilsNetwork.searchShelfList(
-              this.classNumber.trim() + '' + this.cutterNumber.trim(),
+              this.classNumber.trim() + '' + cutter,
               contributor + title + subj + date + countParam
             )
             let initalFirstClass = initalResult[0].term
@@ -235,7 +236,7 @@
             await this.profileStore.setValueLiteral(this.activeShelfListData.componentGuid,this.activeShelfListData.classGuid,classPropertyPath,this.classNumber)
           }
 
-          if (this.cutterNumber && this.cutterNumber.trim() != ''){
+          if (this.cutterNumber && this.cutterNumber != ''){  //.trim()
             if (!this.activeShelfListData.cutterGuid){
               this.activeShelfListData.cutterGuid = short.generate()
             }
@@ -262,8 +263,9 @@
 
           this.results = []
           this.searching=true
+          let cutter = this.preserveSpace ? this.cutterNumber : this.cutterNumber.trim()
           this.results =  await utilsNetwork.searchShelfList(
-            this.classNumber.trim() + '' + this.cutterNumber.trim(),
+            this.classNumber.trim() + '' + cutter,
             contributor + title + subj + date + countParam
           )
           this.searching=false
@@ -446,6 +448,8 @@
                 <input v-model="classNumber" class="number-input" placeholder="Class" @input="search()" type="text" />
                 <input v-model="cutterNumber" class="number-input" @input="search()" placeholder="Cutter" type="text" />
                 <button class="number-input" @click="save" :disabled="(!activeShelfListData.componentGuid)">Save</button>
+                <input name="preserveSpace" type="checkbox" v-model="preserveSpace" @click="search()" />
+                <label for="preserveSpace">Preserve Spaces</label>
 
                 <div class="menu-buttons">
                   <button class="close-button"   @pointerup="showShelfListingModal=false">X</button>


### PR DESCRIPTION
Add ability to preserve the space in the cutter portion of a class number at the start of the number.

Sometimes the spaces matter and need to be preserved. This adds a checkbox that will not perform `trimEnd()` on the Cutter Portion.