### PR TITLE
Empty Shelf List from Load Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Scratch Monograph and IBC records come in with empty fields of LCCN and ISBN
 - MARC XML preview is collapsable
 - Change AdminMetadata template used in scratch records to allow 040 changes
+- When the shelflist search will use the activeProfile to populate the fields
 
 ### Fixed
 - "Add all defaults" not populating AdminMetadata in Scratch records

--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -399,10 +399,12 @@
 
     async mounted() {
       // If they launched the shefllist from the tools menu then it does not have the
-      // context of launching from the component, so fake it via the profile
-      if (Object.keys(this.activeShelfListData)==0){
+      // context of launching from the component, so fake it via the profile.
+      // Unless, it's being loaded from the loading screen
+      if (Object.keys(this.activeShelfListData)==0 && this.$route.path.includes("/edit/")){
         this.profileStore.buildActiveShelfListDataFromProfile()
       }
+
       this.classNumber = this.activeShelfListData.class
       this.cutterNumber = this.activeShelfListData.cutter
       this.contributor = this.activeShelfListData.contributor

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -6491,7 +6491,6 @@ export const useProfileStore = defineStore('profile', {
      * @return {void} Updates the activeShelfListData state directly
      */
     buildActiveShelfListDataFromProfile(){
-
       // look through the active profile for the LCC data
       for (let rt in this.activeProfile.rt){
         for (let pt in this.activeProfile.rt[rt].pt){


### PR DESCRIPTION
If you opened a record, opened the shelf list search, `saved`, and then went to the load screen and opened the shelf list search from there it would be populated with the `saved` values. This shouldn't happen anymore.