### PR TITLE
[BFP 337] Load from BFDB when Opening a Published Record

### DIFF
--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -714,12 +714,17 @@ export default {
     reloadRecord: function(record){
       let url
       let profile
-      try { // Load page
+
+      if (Object.keys(record).includes('externalid')){
         url = record.externalid.filter((item) => item.includes("/instances/"))[0]
         profile = record.rstused[0]
-      } catch { //Dashboard page
+      } else if (Object.keys(record).includes('Urls')){
         url = record.Urls.filter((item) => item.includes("/instances/"))[0]
         profile = record['RTs'][0]
+      } else {
+        alert("Couldn't load the record")
+        console.error("Failed to load record: ", record)
+        return false
       }
 
       this.lccnLoadSelected = {

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -57,7 +57,7 @@
 
                   <td>
                     <a v-if="row.Status=='unposted'" :href="'/bfe2/quartz/edit/' + row.Id" @click.prevent="loadFromAllRecord(row.Id)">{{ row.Id }}</a>
-                    <a v-else href="#" @click="reloadRecord(row)">Load from BFDB</a>
+                    <a v-else :href="'#'+row.Id" @click="reloadRecord(row)">Load from BFDB</a>
                   </td>
 
                   <td v-text="(row.RTs) ? row.RTs.join(', ') : row.RTs" />
@@ -714,10 +714,10 @@ export default {
     reloadRecord: function(record){
       let url
       let profile
-      try {
+      try { // Load page
         url = record.externalid.filter((item) => item.includes("/instances/"))[0]
         profile = record.rstused[0]
-      } catch {
+      } catch { //Dashboard page
         url = record.Urls.filter((item) => item.includes("/instances/"))[0]
         profile = record['RTs'][0]
       }


### PR DESCRIPTION
Changes:
- This applies to "Your Records" and "All Records." Instead of using the eNumber to load a record that has been posted, Marva will reload that record from BFDB using the `editor-pkg` XML url.

Should also help with any weirdness that might have happened when someone creates a record from CopyCat completes the record and then tries to open it again in Marva from an eNumber fetch. 

