### PR TITLE
Adjust Subject Builder for better `USE` Matching

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -2046,6 +2046,15 @@ export default {
         // take the subject string and split
         let splitString = this.subjectString.split('--')
 
+        // if the incoming subject can replace the whole subject string, do that
+        if (this.pickLookup[this.pickPostion].suggestLabel.includes(this.subjectString + " (USE ")){
+          console.info("1")
+          if(splitString.length > 1 ){
+            this.activeComponentIndex = 0
+            splitString.pop()
+          }
+        }
+
         // replace the string with what we selected
         splitString[this.activeComponentIndex] = this.pickLookup[this.pickPostion].label.replaceAll('-', '‑')
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -910,6 +910,7 @@ export default {
 
     //parse complex headings so we can have complete and broken up headings
     parseComplexSubject: async function (uri) {
+      console.info("parse")
       let returnUrls = useConfigStore().returnUrls
       let url = uri
       if (returnUrls.env == 'production') {
@@ -1157,7 +1158,11 @@ export default {
       if (event.key === 'Enter' && event.shiftKey === false) {
         this.linkModeResults = false
         this.linkModeSearching = true
-        this.linkModeResults = await utilsNetwork.subjectLinkModeResolveLCSH(this.linkModeString)
+        if (this.linkModeString.length > 2){
+          this.linkModeResults = await utilsNetwork.subjectLinkModeResolveLCSH(this.linkModeString)
+        } else {
+          return
+        }
         this.linkModeSearching = false
 
       } else if (event.key === 'Enter' && event.shiftKey === true) {
@@ -1522,7 +1527,13 @@ export default {
         searchStringFull = searchStringFull.replace("---", "‑--")
       }
 
-      that.searchResults = await utilsNetwork.subjectSearch(searchString, searchStringFull, complexSub, that.searchMode)
+      console.info("search?")
+      if (searchString.length > 2){
+        console.info("yes")
+        that.searchResults = await utilsNetwork.subjectSearch(searchString, searchStringFull, complexSub, that.searchMode)
+      } else {
+        return
+      }
       // that.searchResults = await utilsNetwork.subjectSearch(searchString, searchStringFull, that.searchMode)
 
       // if they clicked around while it was doing this lookup bail out
@@ -2048,9 +2059,8 @@ export default {
 
         // if the incoming subject can replace the whole subject string, do that
         if (this.pickLookup[this.pickPostion].suggestLabel.includes(this.subjectString + " (USE ")){
-          console.info("1")
-          if(splitString.length > 1 ){
-            this.activeComponentIndex = 0
+          if(splitString.length == 2 ){
+            this.activeComponentIndex = 0  // is this reliable?
             splitString.pop()
           }
         }

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -910,7 +910,6 @@ export default {
 
     //parse complex headings so we can have complete and broken up headings
     parseComplexSubject: async function (uri) {
-      console.info("parse")
       let returnUrls = useConfigStore().returnUrls
       let url = uri
       if (returnUrls.env == 'production') {
@@ -1478,8 +1477,6 @@ export default {
 
     // some context messing here, pass the debounce func a ref to the vue "this" as that to ref in the function callback
     searchApis: debounce(async (searchString, searchStringFull, that) => {
-      console.info("searchString: ", searchString)
-      console.info("searchStringFull: ", searchStringFull)
       that.pickCurrent = null //reset the current selection when the search changes
 
       that.searchResults = null
@@ -1529,9 +1526,7 @@ export default {
         searchStringFull = searchStringFull.replace("---", "‑--")
       }
 
-      console.info("search?")
       if (searchString.length > 2){
-        console.info("yes")
         that.searchResults = await utilsNetwork.subjectSearch(searchString, searchStringFull, complexSub, that.searchMode)
       } else {
         return

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1478,6 +1478,8 @@ export default {
 
     // some context messing here, pass the debounce func a ref to the vue "this" as that to ref in the function callback
     searchApis: debounce(async (searchString, searchStringFull, that) => {
+      console.info("searchString: ", searchString)
+      console.info("searchStringFull: ", searchStringFull)
       that.pickCurrent = null //reset the current selection when the search changes
 
       that.searchResults = null

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -314,6 +314,7 @@ const utilsNetwork = {
       // console.log("url:",url)
       // console.log('options:',options)
       try{
+        throw Error("???")
         let response = await fetch(url,options);
         let data = null
         if (response.status == 404){
@@ -2378,6 +2379,7 @@ const utilsNetwork = {
     * @return {} -
     */
     subjectSearch: async function(searchVal, complexVal, complexSub, mode){
+      console.info("subjectSearch: ", searchVal)
       // subjectSearch: async function(searchVal, complexVal, mode){
       //encode the URLs
       searchVal = encodeURIComponent(searchVal)
@@ -2425,6 +2427,8 @@ const utilsNetwork = {
       let childrenSubjectSubdivision = useConfigStore().lookupConfig['http://id.loc.gov/authorities/childrensSubjects'].modes[0]['LCSHAC All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count=4').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions'
 
       let searchValHierarchicalGeographic = searchVal.replaceAll('‑','-') //.split(' ').join('--')
+
+      console.info("namesUrl: ", namesUrl)
 
       let subjectUrlHierarchicalGeographic = useConfigStore().lookupConfig['HierarchicalGeographic'].modes[0]['All'].url.replace('<QUERY>',searchValHierarchicalGeographic).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2715,6 +2715,7 @@ const utilsNetwork = {
         resultsSubjectsSimple.push(resultsSubjectsSimple.pop())
         // resultsSubjectsSimple.reverse()
       }
+      resultsSubjectsSimpleComplex = resultsSubjectsSimpleComplex.filter((r) => {return (!r.literal)})
       if (resultsSubjectsSimpleComplex.length>0){
         resultsSubjectsSimpleComplex.push(resultsSubjectsSimpleComplex.pop())
       }

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -314,7 +314,6 @@ const utilsNetwork = {
       // console.log("url:",url)
       // console.log('options:',options)
       try{
-        throw Error("???")
         let response = await fetch(url,options);
         let data = null
         if (response.status == 404){

--- a/tests-playwright/components/complex_lookup/subject_builder.spec.js
+++ b/tests-playwright/components/complex_lookup/subject_builder.spec.js
@@ -740,7 +740,6 @@ test('Able to add an edited subject', async ({ page }) => {
 
 
 test('Correct USE appears for a Complex Heading', async ({ page }) => {
-    test.slow()// triple the timeout
     await page.goto('http://localhost:5555/bfe2/quartz/');
 
     // Update the preferences for this test
@@ -752,7 +751,7 @@ test('Correct USE appears for a Complex Heading', async ({ page }) => {
     await page.getByRole('button', { name: 'Monograph', exact: true }).nth(1).click();
     await page.locator('form').filter({ hasText: 'Search LCSH/LCNAF' }).getByRole('textbox').click();
     await page.locator('form').filter({ hasText: 'Search LCSH/LCNAFbolt' }).getByRole('textbox').fill('Agriculture--Technological innovations');
-    await expect(page.getByRole('dialog')).toContainText('Agriculture--Technological innovations (USE Agricultural innovations)');
+    await expect(page.getByRole('dialog')).toContainText('Agriculture--Technological innovations (USE Agricultural innovations)', {timeout: 60000});
     await page.getByText('Agriculture--Technological innovations (USE Agricultural innovations)').click();
     await page.getByRole('button', { name: 'Add [SHIFT+Enter]' }).click();
     await page.locator('.child-elements > div > div > div > .caret').first().click();

--- a/tests-playwright/components/complex_lookup/subject_builder.spec.js
+++ b/tests-playwright/components/complex_lookup/subject_builder.spec.js
@@ -737,3 +737,26 @@ test('Able to add an edited subject', async ({ page }) => {
     await page.getByText('bf:Work').click();
     await expect(page.locator('#app')).toContainText('<madsrdf:ComplexSubjectxmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"><bf:source><bf:Sourcerdf:about="http://id.loc.gov/authorities/subjects"><rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"xml:lang="en">Library of Congress Subject Headings</rdfs:label></bf:Source></bf:source><madsrdf:isMemberOfMADSSchemerdf:resource="http://id.loc.gov/authorities/subjects"></madsrdf:isMemberOfMADSScheme><madsrdf:authoritativeLabel>Public schools--Austria--History--18th century--Congresses</madsrdf:authoritativeLabel><rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Public schools--Austria--History--18th century--Congresses</rdfs:label><madsrdf:componentListrdf:parseType="Collection"><madsrdf:Topicrdf:about="http://id.loc.gov/authorities/subjects/sh85108801"><madsrdf:authoritativeLabel>Public schools</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">150 $aPublic schools</bflc:marcKey></madsrdf:Topic><madsrdf:Geographicrdf:about="http://id.loc.gov/rwo/agents/n79040121-781"><madsrdf:authoritativeLabel>Austria</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">181 $zAustria</bflc:marcKey></madsrdf:Geographic><madsrdf:Topicrdf:about="http://id.loc.gov/authorities/subjects/sh99005024"><madsrdf:authoritativeLabel>History</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">180 $xHistory</bflc:marcKey></madsrdf:Topic><madsrdf:Temporalrdf:about="http://id.loc.gov/authorities/subjects/sh2002012474"><madsrdf:authoritativeLabel>18th century</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">182 $y18th century</bflc:marcKey></madsrdf:Temporal><madsrdf:GenreFormrdf:about="http://id.loc.gov/authorities/subjects/sh99001533"><madsrdf:authoritativeLabel>Congresses</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">185 $vCongresses</bflc:marcKey></madsrdf:GenreForm></madsrdf:componentList></madsrdf:ComplexSubject>');
 });
+
+
+test('Correct USE appears for a Complex Heading', async ({ page }) => {
+    test.slow()// triple the timeout
+    await page.goto('http://localhost:5555/bfe2/quartz/');
+
+    // Update the preferences for this test
+    let prefs = JSON.stringify(preferences)
+    await page.evaluate(prefs => localStorage.setItem("marva-preferences", prefs), prefs)
+    await page.reload();
+
+    await page.getByText('Click Here').click();
+    await page.getByRole('button', { name: 'Monograph', exact: true }).nth(1).click();
+    await page.locator('form').filter({ hasText: 'Search LCSH/LCNAF' }).getByRole('textbox').click();
+    await page.locator('form').filter({ hasText: 'Search LCSH/LCNAFbolt' }).getByRole('textbox').fill('Agriculture--Technological innovations');
+    await expect(page.getByRole('dialog')).toContainText('Agriculture--Technological innovations (USE Agricultural innovations)');
+    await page.getByText('Agriculture--Technological innovations (USE Agricultural innovations)').click();
+    await page.getByRole('button', { name: 'Add [SHIFT+Enter]' }).click();
+    await page.locator('.child-elements > div > div > div > .caret').first().click();
+    await expect(page.locator('#app')).toContainText('Agricultural innovations');
+    await expect(page.locator('#app')).toContainText('150 $aAgricultural innovations');
+    await expect(page.locator('#app')).toContainText('rdf:about="http://id.loc.gov/authorities/subjects/sh85002334"');
+});


### PR DESCRIPTION
Changed:
- How `subjectSearch()` works to be more inclusive
- Add a character limit of 3 to subject searches

If a complex heading had a `USE` term it wouldn't surface. It will now.
Example:  `Agriculture--Technological innovations` will show `Agricultural innovation` in the results

