### PR TITLE
Update Subject search order, remove dupes

### DIFF
--- a/src/components/panels/edit/modals/helpers/ComplexSearchResultsDisplay.vue
+++ b/src/components/panels/edit/modals/helpers/ComplexSearchResultsDisplay.vue
@@ -31,7 +31,15 @@
                 </div>
             </div>
 
-
+            <SearchResultOption
+                searchType="subjectsSimple"
+                :label="searchMode == 'HUBS' ? 'Left Anchored' : 'Simple'"
+                index="searchResults.subjectsComplex.length + ix"
+                :searchResults="searchResults"
+                :pickLookup="pickLookup"
+                @selectContext="selectContext"
+                @emitLoadContext="loadContext"
+            />
             <SearchResultOption
                 searchType="names"
                 label="LCNAF"
@@ -45,15 +53,6 @@
                 searchType="subjectsComplex"
                 :label="searchMode == 'HUBS' ? 'Keyword' : 'Complex'"
                 index="ix"
-                :searchResults="searchResults"
-                :pickLookup="pickLookup"
-                @selectContext="selectContext"
-                @emitLoadContext="loadContext"
-            />
-            <SearchResultOption
-                searchType="subjectsSimple"
-                :label="searchMode == 'HUBS' ? 'Left Anchored' : 'Simple'"
-                index="searchResults.subjectsComplex.length + ix"
                 :searchResults="searchResults"
                 :pickLookup="pickLookup"
                 @selectContext="selectContext"

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2800,8 +2800,13 @@ const utilsNetwork = {
         complexHeadings = resultsSubjectsComplex.concat(resultsSubjectsComplexSubdivision1)
       }
 
+      if (complexVal.includes("--")){
+        resultsSubjectsSimple = resultsSubjectsSimpleComplex.concat(resultsSubjectsSimple)
+        resultsPayloadSubjectsSimpleSubdivision = resultsSubjectsSimpleComplex.concat(resultsPayloadSubjectsSimpleSubdivision)
+      }
+
       let results = {
-        'subjectsSimple': pos == 0 ? resultsSubjectsSimpleComplex.concat(resultsSubjectsSimple) : resultsSubjectsSimpleComplex.concat(resultsPayloadSubjectsSimpleSubdivision),
+        'subjectsSimple': pos == 0 ? resultsSubjectsSimple : resultsPayloadSubjectsSimpleSubdivision,
         'subjectsComplex': complexHeadings,
         'names': pos == 0 ? resultsNames.concat(resultsNamesGeo).sort((a,b) => a.suggestLabel > b.suggestLabel ? 1 : a.suggestLabel < b.suggestLabel ? -1 : 1) : resultsNamesSubdivision,
         'hierarchicalGeographic': pos == 0 ? [] : resultsHierarchicalGeographic,

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -489,7 +489,7 @@ const utilsNetwork = {
               url = url.replace('https://preprod-8080.id.loc.gov','https://id.loc.gov')
               url = url.replace('https://preprod-8288.id.loc.gov','https://id.loc.gov')
             } else { // if it's not dev or public make sure we're using 8080
-              url = url.replace('https://id.loc.gov', 'https://preprod-8080.id.loc.gov')
+              url = url.replace('https://id.loc.gov', 'https://preprod-8287.id.loc.gov')  // temp change to 8287
             }
 
             if (usePreferenceStore().returnValue('--b-edit-complex-include-usage')){

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -65,7 +65,7 @@ export const useConfigStore = defineStore('config', {
 
         id: 'https://preprod-8080.id.loc.gov/',
         env : 'production',
-        dev: true,
+        dev: false,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
         lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',


### PR DESCRIPTION
Changes:
- Move `Simple` subject results to the top

Fix:
- Remove duplicates from `Simple` subject results