### PR TITLE
Complex Lookup Classification Fallback

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -89,7 +89,7 @@
         },
         panelDetailOrder: [
             "birthdates","deathdates", "notes", "gacs", "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds",
-            "sources", "lcclasses", "birthplaces",  "locales",
+            "sources", "lcclasses", "lcclasss", "birthplaces",  "locales",
             "activityfields","occupations","languages", "sees",
             "identifiers","broaders",
             "collections", "genres", "subjects", "marcKeys", "rdftypes"
@@ -1201,6 +1201,25 @@
                               </li>
                             </ul>
                           </template>
+
+                          <template v-else-if="key == 'lcclasss' && activeContext.extra['lcclasses'].length < 1">
+                            <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
+                                this.labelMap[key] : key }}:</span>
+                            <ul class="">
+                                <li class="" v-if="key == 'lcclasss'" v-for="v in activeContext.extra[key]">
+                                    <template v-if="typeof v == 'string'">
+                                        <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm=' + v"
+                                            target="_blank">{{ v }}</a>
+                                        <button class="material-icons see-search"
+                                            @click="addClassNumber(v)">add</button>
+                                    </template>
+                                    <template v-else>
+                                        {{ v }}
+                                    </template>
+                                </li>
+                            </ul>
+                        </template>
+
                           <template v-else>
                             <ul>
                             <li class="details-details" v-if='["identifiers","broaders",].includes(key)'>
@@ -1223,7 +1242,7 @@
                               <div>Extra Details</div>
                             </template>
                             <template v-for="key in panelDetailOrder">
-                              <template v-if='activeContext.extra[key] && activeContext.extra[key].length>0 && ["notes", "collections", "marcKeys", "rdftypes"].includes(key)'>
+                              <template v-if='activeContext.extra[key] && activeContext.extra[key].length>0 && ["notes", "collections", "marcKeys", "rdftypes", "lcclasss"].includes(key)'>
                                 <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>
                                 <ul>
                                   <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -171,7 +171,7 @@
                             <ul class="">
                                 <li class="" v-if="key == 'lcclasss'" v-for="v in contextData[key]">
                                     <template v-if="typeof v == 'string'">
-                                        <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm=' + v.code"
+                                        <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm=' + v"
                                             target="_blank">{{ v }}</a>
                                         <button class="material-icons see-search"
                                             @click="addClassNumber(v)">add</button>
@@ -216,7 +216,7 @@
                         </template>
                         <template v-for="key in panelDetailOrder">
                             <template
-                                v-if='contextData[key] && contextData[key].length > 0 && ["notes", "collections", "subjects", "marcKeys"].includes(key)'>
+                                v-if='contextData[key] && contextData[key].length > 0 && ["notes", "collections", "subjects", "marcKeys", "lcclasss"].includes(key)'>
                                 <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
                                     this.labelMap[key] : key }}:</div>
                                 <ul>

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -165,6 +165,24 @@
                             </ul>
                         </template>
 
+                        <template v-else-if="key == 'lcclasss' && contextData['lcclasses'].length < 1">
+                            <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
+                                this.labelMap[key] : key }}:</span>
+                            <ul class="">
+                                <li class="" v-if="key == 'lcclasss'" v-for="v in contextData[key]">
+                                    <template v-if="typeof v == 'string'">
+                                        <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm=' + v.code"
+                                            target="_blank">{{ v }}</a>
+                                        <button class="material-icons see-search"
+                                            @click="addClassNumber(v)">add</button>
+                                    </template>
+                                    <template v-else>
+                                        {{ v }}
+                                    </template>
+                                </li>
+                            </ul>
+                        </template>
+
                         <template v-else-if="['broaders', 'identifiers'].includes(key)">
                             <div class="modal-context-data-title" v-if="key != 'identifiers'">{{
                                 Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</div>

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -606,29 +606,31 @@
             }
           )
 
-          menu.push(
-            {
-              text: "Open in LCAP",
-              id:"send-lcap",
-              ref:"lcap",
-              icon: "open_in_new",
-              click: () => {
-                let url =  useConfigStore().returnUrls.lcap // "https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
-                let bibId = null
-                console.log("url",url)
-                // get the bibID
-                for (let rt in this.activeProfile.rt){
-                  let type = rt.split(':').slice(-1)[0]
-                  let url = this.activeProfile.rt[rt].URI
-                  if (type=='Instance'){
-                    bibId =  url.split("/")[url.split('/').length - 1]
+          if (config.returnUrls.displayLCOnlyFeatures){
+            menu.push(
+              {
+                text: "Open in LCAP",
+                id:"send-lcap",
+                ref:"lcap",
+                icon: "open_in_new",
+                click: () => {
+                  let url =  useConfigStore().returnUrls.lcap // "https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/"
+                  let bibId = null
+                  console.log("url",url)
+                  // get the bibID
+                  for (let rt in this.activeProfile.rt){
+                    let type = rt.split(':').slice(-1)[0]
+                    let url = this.activeProfile.rt[rt].URI
+                    if (type=='Instance'){
+                      bibId =  url.split("/")[url.split('/').length - 1]
+                    }
                   }
-                }
-                window.open(url + bibId)
-              },
-              class: (this.activeProfilePosted || this.isStaging() || (this.activeProfile && this.activeProfile.status && this.activeProfile.status == 'published' )) ? "record-posted-folio-ok" : "record-unposted-folio-no",
+                  window.open(url + bibId)
+                },
+                class: (this.activeProfilePosted || this.isStaging() || (this.activeProfile && this.activeProfile.status && this.activeProfile.status == 'published' )) ? "record-posted-folio-ok" : "record-unposted-folio-no",
+              }
+            )
             }
-          )
 
 
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2400,7 +2400,7 @@ const utilsNetwork = {
       this.subjectSearchActive = true
       let namesUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Auth Names'].url.replace('<QUERY>',searchVal).replace('&count=30','&count='+numResultsNames).replace("<OFFSET>", "1")+'&keepdiacritics=true'
       let namesGeoUrl = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF Geographic'].url.replace('<QUERY>',searchVal).replace('&count=30','&count='+numResultsNames).replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/names/collection_NamesAuthorizedHeadings&rdftype=Geographic&keepdiacritics=true'
-      let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=30','&count=5').replace("<OFFSET>", "1")+'&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions&keepdiacritics=true'
+      let namesUrlSubdivision = useConfigStore().lookupConfig['http://preprod.id.loc.gov/authorities/names'].modes[0]['NAF All'].url.replace('<QUERY>',searchVal).replace('&count=30','&count=5').replace("<OFFSET>", "1")+'&keepdiacritics=true' //&memberOf=http://id.loc.gov/authorities/subjects/collection_Subdivisions
 
       let subjectUrlComplexSearchVal = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',searchVal).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
       let subjectUrlComplex = useConfigStore().lookupConfig['http://id.loc.gov/authorities/subjects'].modes[0]['LCSH All'].url.replace('<QUERY>',complexVal).replace('&count=25','&count='+numResultsComplex).replace("<OFFSET>", "1")+'&rdftype=ComplexType'+'&memberOf=http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings'
@@ -2804,6 +2804,8 @@ const utilsNetwork = {
         resultsSubjectsSimple = resultsSubjectsSimpleComplex.concat(resultsSubjectsSimple)
         resultsPayloadSubjectsSimpleSubdivision = resultsSubjectsSimpleComplex.concat(resultsPayloadSubjectsSimpleSubdivision)
       }
+
+      console.info("")
 
       let results = {
         'subjectsSimple': pos == 0 ? resultsSubjectsSimple : resultsPayloadSubjectsSimpleSubdivision,

--- a/tests-playwright/components/complex_lookup/subject_builder.spec.js
+++ b/tests-playwright/components/complex_lookup/subject_builder.spec.js
@@ -10,6 +10,7 @@ import { preferences } from '../../configs/subjectBuilderConfig.json'
  * marc html: true
  */
 
+
 test('Find simple heading "Dogs" with correct XML and MARC', async ({ page }) => {
     await page.goto('http://localhost:5555/bfe2/quartz/');
 
@@ -735,7 +736,12 @@ test('Able to add an edited subject', async ({ page }) => {
     await expect(page.getByRole('dialog')).toContainText('Add [SHIFT+Enter]');
     await page.getByRole('button', { name: 'Add [SHIFT+Enter]' }).click();
     await page.getByText('bf:Work').click();
-    await expect(page.locator('#app')).toContainText('<madsrdf:ComplexSubjectxmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#"><bf:source><bf:Sourcerdf:about="http://id.loc.gov/authorities/subjects"><rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"xml:lang="en">Library of Congress Subject Headings</rdfs:label></bf:Source></bf:source><madsrdf:isMemberOfMADSSchemerdf:resource="http://id.loc.gov/authorities/subjects"></madsrdf:isMemberOfMADSScheme><madsrdf:authoritativeLabel>Public schools--Austria--History--18th century--Congresses</madsrdf:authoritativeLabel><rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">Public schools--Austria--History--18th century--Congresses</rdfs:label><madsrdf:componentListrdf:parseType="Collection"><madsrdf:Topicrdf:about="http://id.loc.gov/authorities/subjects/sh85108801"><madsrdf:authoritativeLabel>Public schools</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">150 $aPublic schools</bflc:marcKey></madsrdf:Topic><madsrdf:Geographicrdf:about="http://id.loc.gov/rwo/agents/n79040121-781"><madsrdf:authoritativeLabel>Austria</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">181 $zAustria</bflc:marcKey></madsrdf:Geographic><madsrdf:Topicrdf:about="http://id.loc.gov/authorities/subjects/sh99005024"><madsrdf:authoritativeLabel>History</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">180 $xHistory</bflc:marcKey></madsrdf:Topic><madsrdf:Temporalrdf:about="http://id.loc.gov/authorities/subjects/sh2002012474"><madsrdf:authoritativeLabel>18th century</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">182 $y18th century</bflc:marcKey></madsrdf:Temporal><madsrdf:GenreFormrdf:about="http://id.loc.gov/authorities/subjects/sh99001533"><madsrdf:authoritativeLabel>Congresses</madsrdf:authoritativeLabel><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">185 $vCongresses</bflc:marcKey></madsrdf:GenreForm></madsrdf:componentList></madsrdf:ComplexSubject>');
+    await expect(page.locator('#app')).toContainText('<madsrdf:authoritativeLabel>Public schools--Austria--History--18th century--Congresses</madsrdf:authoritativeLabel>');
+    await expect(page.locator('#app')).toContainText('<madsrdf:Topicrdf:about="http://id.loc.gov/authorities/subjects/sh85108801">');
+    await expect(page.locator('#app')).toContainText('<bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">150  $aPublic schools</bflc:marcKey>');
+    await expect(page.locator('#app')).toContainText('<madsrdf:GenreFormrdf:about="http://id.loc.gov/authorities/subjects/sh99001533">');
+    await expect(page.locator('#app')).toContainText('<madsrdf:authoritativeLabel>Congresses</madsrdf:authoritativeLabel>');
+    await expect(page.locator('#app')).toContainText('bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">185  $vCongresses</bflc:marcKey>');
 });
 
 

--- a/tests-playwright/components/complex_lookup/subject_builder.spec.js
+++ b/tests-playwright/components/complex_lookup/subject_builder.spec.js
@@ -760,7 +760,7 @@ test('Correct USE appears for a Complex Heading', async ({ page }) => {
     await expect(page.getByRole('dialog')).toContainText('Agriculture--Technological innovations (USE Agricultural innovations)', {timeout: 60000});
     await page.getByText('Agriculture--Technological innovations (USE Agricultural innovations)').click();
     await page.getByRole('button', { name: 'Add [SHIFT+Enter]' }).click();
-    await page.locator('.child-elements > div > div > div > .caret').first().click();
+    await page.getByText('bf:Work').click();
     await expect(page.locator('#app')).toContainText('Agricultural innovations');
     await expect(page.locator('#app')).toContainText('150 $aAgricultural innovations');
     await expect(page.locator('#app')).toContainText('rdf:about="http://id.loc.gov/authorities/subjects/sh85002334"');


### PR DESCRIPTION
Add a fallback for the classification information in the complex lookup.

Marva is expecting `lcclasses` for the full classification number. In cases when that is empty, there will be nothing. If it is empty, fallback on `lcclasss` to populate something.