### PR TITLE
enable iframes

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -20,10 +20,10 @@
   height: 100vh;
 
 }
-
+/* 
 iframe{
   display: none;
-}
+} */
 
 /* the Edit page */
 


### PR DESCRIPTION
iframes were disabled by setting their css display to none, not sure why I did that, but it is breaking tools like Google Input Tools that uses iframes and is used by overseas office.