### PR TITLE
Expand `deleteComponent()` to work better with "uneditable" data

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -67,7 +67,7 @@ export const useConfigStore = defineStore('config', {
 
         id: 'https://preprod-8080.id.loc.gov/',
         env : 'staging',
-        dev: true,
+        dev: false,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
         lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
@@ -425,7 +425,7 @@ export const useConfigStore = defineStore('config', {
     {lccn:'2023478519',label:"bf:relation test", idUrl:'https://id.loc.gov/resources/instances/2023478519.html', profile:'Monograph',profileId:'lc:RT:bf2:Monograph:Instance'},
 
 
-    
+
 
   ],
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4641,6 +4641,15 @@ export const useProfileStore = defineStore('profile', {
           for (let key in this.activeProfile.rt[pt.parentId].pt[pt.id].userValue){
               if (!key.startsWith('@')){
                 delete this.activeProfile.rt[pt.parentId].pt[pt.id].userValue[key]
+
+                // Cleanup for components that are uneditable
+                if (Object.keys(this.activeProfile.rt[pt.parentId].pt[pt.id]).includes("xmlSource")){
+                  delete this.activeProfile.rt[pt.parentId].pt[pt.id].xmlSource
+                  this.activeProfile.rt[pt.parentId].pt[pt.id].hasData = false
+                  this.activeProfile.rt[pt.parentId].pt[pt.id].deepHierarchy = false
+                  this.activeProfile.rt[pt.parentId].pt[pt.id].dataLoaded = false
+                  this.activeProfile.rt[pt.parentId].pt[pt.id].xmlHash = ""
+                }
               }
             }
         }


### PR DESCRIPTION
For "expression of," trying to delete the uneditable component would leave pieces of the component in place and it wouldn't be editable. Even putting in a different Hub would show the information when the record was loaed into Marva.