### PR TITLE
Clicking in the Field Triggers Height Expansion

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -101,6 +101,7 @@
                   v-on:keydown.enter.prevent="submitField"
                   autocomplete="off"
                   @focusin="focused"
+                  @focus="valueChanged"
                   @blur="blured"
                   @input="valueChanged"
                   @keyup="navKey"
@@ -935,7 +936,10 @@ export default {
 
       }
 
-      this.expandHeightToContent()
+      window.setTimeout(()=>{
+        this.expandHeightToContent()
+      }, 100)
+      // this.expandHeightToContent()
     },
 
 


### PR DESCRIPTION
    There could cases when a field as so much info that when you focus on it
    some of the text would be pushed down by the action button. The hidden
    text would only show again after making an edit to the field.