### PR TITLE
Fix Class Type Flipping Back to LC

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -889,7 +889,9 @@ export default {
         currentPos = this.getCaretCharOffset(event.target)
       }
       // console.log("3 v:",v)
-      await this.profileStore.setValueLiteral(this.guid,event.target.dataset.guid,this.propertyPath,v,useLang)
+      if (v != ""){
+        await this.profileStore.setValueLiteral(this.guid,event.target.dataset.guid,this.propertyPath,v,useLang)
+      }
 
 
 

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -288,7 +288,6 @@ const utilsProfile = {
           // first we test to see if the type is a literal (the type returned, not the property of the value), if so then we
           // don't need to set the type, as its not a blank node, just a nested property
           if (utilsRDF.isUriALiteral(type) === false){
-
             // for duration set datatype
             if(pt.propertyURI == 'http://id.loc.gov/ontologies/bibframe/duration'){
               pointer[p][0]['@datatype'] = type
@@ -866,14 +865,14 @@ const utilsProfile = {
   },
 
 
-  
+
   returnContributorUris: function(profile){
     let uris = []
     for (let rt in profile["rt"]){
         for (let pt in profile["rt"][rt]["pt"]){
             pt = profile["rt"][rt]["pt"][pt]
             if (pt.propertyURI == 'http://id.loc.gov/ontologies/bibframe/contribution'){
-                if (pt.userValue && 
+                if (pt.userValue &&
                     pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'] &&
                     pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0] &&
                     pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'] &&
@@ -883,7 +882,7 @@ const utilsProfile = {
                     uris.push(pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'][0]['@id'])
                 }
             }
-          
+
         }
     }
 


### PR DESCRIPTION
Previous update to get components with lots of data to resize called `valueChanged()` to do that. That caused an issue because there wouldn't actually be a value and `setValueLiteral()` wouldn't work. Now, we'll check that there is a value before calling `setValueLiteral()`.