### PR TITLE
Add Icon when Alt Version is Posted

### DIFF
--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -18,10 +18,10 @@ export const useConfigStore = defineStore('config', {
 
         ldpjs : 'http://localhost:9401/api-staging/',
 
-        util  : 'http://localhost:9401/util/',
+        // util  : 'http://localhost:9401/util/',
         // util  : 'http://localhost:5200/',
         // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
-        // util  :  'https://editor.id.loc.gov/bfe2/util/',
+        util  :  'https://editor.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',
@@ -66,7 +66,7 @@ export const useConfigStore = defineStore('config', {
         copyCatUpload: 'http://localhost:9401/copycat/upload/stag',
 
         id: 'https://preprod-8080.id.loc.gov/',
-        env : 'staging',
+        env : 'production',
         dev: false,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -315,6 +315,8 @@
                         </template>
                         <div class="material-icons" v-if="record.status == 'published'" title="Posted record">check_box
                         </div>
+                        <div class="alt-posted material-icons" v-if="record.status != 'published' && continueRecordsPreviousVersions[record.lccn] && continueRecordsPreviousVersions[record.lccn].filter((rec) => rec.status == 'published').length > 0" title="Alt Version Posted">check_box
+                        </div>
                       </div>
                       <template v-if="continueRecordsPreviousVersions[record.lccn]">
                         <details class="continue-record-previous-versions-details">
@@ -324,7 +326,7 @@
                               <li v-for="prev in continueRecordsPreviousVersions[record.lccn]">
                                 <router-link :to="{ name: 'Edit', params: { recordId: prev.eid } }">
                                   <span style="opacity: 0.55;">({{ prev.eid }})</span> {{ prev.title }} ({{
-                                    returnTimeAgo(prev.timestamp) }}) {{ prev.status }}
+                                    returnTimeAgo(prev.timestamp) }}) <div class="material-icons" v-if="prev.status == 'published'" title="Posted record">check_box</div>
                                 </router-link>
                               </li>
                             </ul>
@@ -1638,6 +1640,11 @@ summary {
 
 .fake-link{
   cursor: pointer;
+}
+
+.alt-posted {
+  color: rgb(250, 202, 50) !important;
+  cursor: help;
 }
 
 </style>


### PR DESCRIPTION
There can be situations when someone posts a record and then opens it again which creates a new record in Marva. This shouldn't happen often, but has caused confusion in the past.

This update gives an indication that an older, alternate version of the record was been posted.