### PR TITLE
[BFP-408] Differentiate Shelflist: `Selected` is Open or Occupied

### DIFF
--- a/src/components/panels/edit/modals/ShelfListing.vue
+++ b/src/components/panels/edit/modals/ShelfListing.vue
@@ -515,9 +515,14 @@
                           <td class="shelflist-number" @click="copyToClipboard($event, r.term)" style="cursor: pointer;">
                             <span v-if="!(r.term ==  '' && r.frequency ==  '' && r.creator ==  '' && r.uniformtitle ==  '' && r.title ==  '' && r.pubdate ==  '' && r.subject ==  '' && r.altsubject ==  '' && r.bibid ==  '' && r.sort ==  '') && r.lookup.includes('precision=exact&qname=idx:lcclass')"
                               class="material-icons number-match simptip-position-right"
-                              data-tooltip="EXISTING CLASS NUM"
+                              data-tooltip="OCCUPIED"
                               >
-                              layers
+                              radio_button_checked
+                            </span>
+                            <span v-else-if="!r.lookup.includes('precision=exact&qname=idx:lcclass')"
+                              class="material-icons number-match simptip-position-right"
+                              data-tooltip="AVAILABLE">
+                              radio_button_unchecked
                             </span>
                             {{ r.term }}
                           </td>
@@ -759,6 +764,7 @@
 .number-match {
   font-size: 1em;
   vertical-align: middle;
+  color: unset;
 }
 
 </style>


### PR DESCRIPTION
Update the "selected" element in the shelf list results to indicate if the spot is open or not and add tooltip for the icons.

Open: 
<img width="300" height="31" alt="image" src="https://github.com/user-attachments/assets/b076bc33-eac2-4909-8512-b58e6cc07189" />

Occupied:
<img width="298" height="34" alt="image" src="https://github.com/user-attachments/assets/56811e64-81bb-4576-81d7-1f5cf47f0249" />
