### PR TITLE
Fix `Save` flipping to not saved when there were not changes

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -101,7 +101,7 @@
                   v-on:keydown.enter.prevent="submitField"
                   autocomplete="off"
                   @focusin="focused"
-                  @focus="valueChanged"
+                  @focus="expandHeightToContent"
                   @blur="blured"
                   @input="valueChanged"
                   @keyup="navKey"
@@ -443,13 +443,16 @@ export default {
     },
 
     expandHeightToContent: function(){
-      for (let key of Object.keys(this.$refs)){
-        if (key.startsWith('input_')){
-          if (this.$refs[key] && this.$refs[key][0]){
-            this.$refs[key][0].style.height =  this.$refs[key][0].scrollHeight + "px"
+      console.info("expand")
+      window.setTimeout(()=>{
+        for (let key of Object.keys(this.$refs)){
+          if (key.startsWith('input_')){
+            if (this.$refs[key] && this.$refs[key][0]){
+              this.$refs[key][0].style.height =  this.$refs[key][0].scrollHeight + "px"
+            }
           }
         }
-      }
+      }, 50)
 
     },
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -18,10 +18,10 @@ export const useConfigStore = defineStore('config', {
 
         ldpjs : 'http://localhost:9401/api-staging/',
 
-        // util  : 'http://localhost:9401/util/',
+        util  : 'http://localhost:9401/util/',
         // util  : 'http://localhost:5200/',
         // util  :  'https://preprod-3001.id.loc.gov/bfe2/util/',
-        util  :  'https://editor.id.loc.gov/bfe2/util/',
+        // util  :  'https://editor.id.loc.gov/bfe2/util/',
 
         utilLang: 'http://localhost:9401/util-lang/',
         scriptshifter: 'http://localhost:9401/scriptshifter/',


### PR DESCRIPTION
The cause was a recent change to address expanding the height of componenets with lots of text. That envoked `valueChanged()` when the field was focused and unset the `saved` "flag"