### PR TITLE
Non-Latin Agent Adjust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.1] - 2025-0+-05
+
+## [1.4.2] - 2025-09-15
+### Fixed
+- `returnAllNonLatinAgentOptions` sometimes haveng `undefined` in the scripts
+
+## [1.4.1] - 2025-09-05
 ### Changed
 - `Add Classification` adds to LC Class Component, instead of first class component
 - `Add Classification` creates LC Class component, if there isn't one

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -219,13 +219,10 @@
         let newClass
         // If no match, need to add component
         if (!targetComponent){
-          console.info("adding new")
           let structure = this.returnComponentByPropertyLabel('Classification numbers')
           newClass = await this.duplicateComponentGetId(structure['@guid'], structure, "lc:RT:bf2:Monograph:Work", lastClassifiction)
           targetComponent = profile.rt["lc:RT:bf2:Monograph:Work"].pt[newClass[0]]
         }
-
-        console.info("targetComponent: ", targetComponent)
 
         let propertyPath = [
           { level: 0, propertyURI: "http://id.loc.gov/ontologies/bibframe/classification" },

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -506,8 +506,12 @@
 
            const customLayouts = this.preferenceStore.returnValue("--l-custom-layouts")
            if (customLayouts != {}){
+
             layoutsMenu.push({ is: "separator" })
             const layoutList = Object.keys(customLayouts)
+
+            if (this.activeProfile == null){ return }
+
             for (let idx in layoutList){
               let layout = customLayouts[layoutList[idx]]
               layoutsMenu.push({

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5076,7 +5076,10 @@ export const useProfileStore = defineStore('profile', {
               }
            }
           if (nl && nl.node  && nl.node['@language']){
-            nonLatinMap[ptFound['@guid']].scripts.push(nl.node['@language'].split("-")[1])
+            let script = nl.node['@language'].split("-")[1]
+            if (script){
+              nonLatinMap[ptFound['@guid']].scripts.push(script)
+            }
           }
 
 


### PR DESCRIPTION
In some situations this could leave a "script" value as `undefined`. 

For example, if the language is only `en` and it tried to split and return `[1]` it would be `undefined`. This could cause issues downstream.