### PR TITLE
Bibframe.org updates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -94,7 +94,8 @@ export default {
 //     const configStore = useConfigStore()
 // const profileStore = useProfileStore()
 
-    this.preferenceStore.initalize()
+
+    this.preferenceStore.initalize(this.configStore.returnUrls)
     // this.profileStore.buildProfiles()
     //window.setTimeout(async ()=>{
 

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -575,7 +575,10 @@
             click: () => { this.profileStore.saveRecord() }
           }
           )
-          menu.push(
+          
+
+          if (config.returnUrls.displayLCOnlyFeatures){
+menu.push(
             {
               text: "Validate",
               icon: "check",
@@ -613,7 +616,6 @@
             }
           )
 
-          if (config.returnUrls.displayLCOnlyFeatures){
             menu.push(
               {
                 text: "Open in LCAP",
@@ -705,7 +707,27 @@
         // anything after this point will  be on the right of nav menu
         menu.push({ is: "spacer" })
 
+        if (useConfigStore().returnUrls.isBibframeDotOrg && this.$route.path.startsWith('/edit/')){
+          menu.push(
+          {
+              text: 'Download MARC',
+              click: () => { 
+                this.profileStore.downloadBFDotOrg('marc')
 
+               }
+          }
+          )
+          menu.push(
+          {
+              text: 'Download BF',
+              click: () => { 
+                this.profileStore.downloadBFDotOrg('bf')
+
+               }
+          }
+          )          
+          
+        }
 
         menu.push(
         {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -86,11 +86,12 @@ export const useConfigStore = defineStore('config', {
         id: 'https://id.loc.gov/',
         env : 'staging',
         dev: true,
-        displayLCOnlyFeatures: true,
+        displayLCOnlyFeatures: false,
         simpleLookupLang: 'en',
         publicEndpoints:true,
         lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
         bfdb : 'https://preprod-8230.id.loc.gov/',
+        isBibframeDotOrg: true,
 
       },
 
@@ -165,6 +166,7 @@ export const useConfigStore = defineStore('config', {
         publicEndpoints:true,
         displayLCOnlyFeatures: false,
         simpleLookupLang: 'en',
+        isBibframeDotOrg: true,
       },
 
       playwrightTestConfig:{

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -86,12 +86,12 @@ export const useConfigStore = defineStore('config', {
         id: 'https://id.loc.gov/',
         env : 'staging',
         dev: true,
-        displayLCOnlyFeatures: false,
+        displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
         publicEndpoints:true,
         lcap: 'https://c2vwscf01.loc.gov/cflsops/toolkit-training-lcsg/lcap-productivity/marva/bibId/',
         bfdb : 'https://preprod-8230.id.loc.gov/',
-        isBibframeDotOrg: true,
+        isBibframeDotOrg: false,
 
       },
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1491,7 +1491,7 @@ export const usePreferenceStore = defineStore('preference', {
     * Setup the preference store, access settings stored in localstorage, etc.
     * @return {void} -
     */
-    initalize: function(){
+    initalize: function(configUrls=null){
 
       // check to see if we have the settings locally we can populate
       if (window.localStorage.getItem('marva-catInitals')){
@@ -1512,7 +1512,78 @@ export const usePreferenceStore = defineStore('preference', {
 
       this.styleDefaultOrginal = JSON.parse(JSON.stringify(this.styleDefault))
       this.panelDisplayOrginal = JSON.parse(JSON.stringify(this.panelDisplay))
+
+      let setInitalBibframeDotOrgPrefs = false
+      if (configUrls && configUrls.isBibframeDotOrg && !this.catInitals){
+        console.log("Setting initial prefs for bibframe.org")
+        // take the last 5 digits of the timestamp
+        let ts = Date.now().toString()
+        let rand = Math.floor(Math.random() * 100).toString().padStart(2,'0')
+        let useRandom = ts.substring(ts.length - 3) + rand
+        this.catInitals = "Guest-" + useRandom
+        this.catCode = "G" + useRandom
+        setInitalBibframeDotOrgPrefs = true
+      }
+
       this.loadPreferences()
+
+      // write some basic defaults if they are a new user on bibframe.org
+      if (setInitalBibframeDotOrgPrefs){
+
+        console.log("added default prefs for bibframe.org")
+        let quickViewDefaults = [
+                    {
+                        "view": {
+                            "properties": true,
+                            "dualEdit": true,
+                            "opac": false,
+                            "xml": false,
+                            "marc": true,
+                            "linkedData": false
+                        },
+                        "percents": {
+                            "edit-main-splitpane-opac": null,
+                            "edit-main-splitpane-marc": "29.1005%",
+                            "edit-main-splitpane-xml": null,
+                            "edit-main-splitpane-edit-combined": null,
+                            "edit-main-splitpane-edit-work": "29.828%",
+                            "edit-main-splitpane-edit-instance": "30.8201%",
+                            "edit-main-splitpane-properties": "10.2513%"
+                        },
+                        "default": true,
+                        "icon": "edit",
+                        "color": "#000000",
+                        "id": "uUoRfG8ZAJQ7dCBToPDMV2"
+                    },
+                    {
+                        "view": {
+                            "properties": false,
+                            "dualEdit": true,
+                            "opac": false,
+                            "xml": true,
+                            "marc": true,
+                            "linkedData": false
+                        },
+                        "percents": {
+                            "edit-main-splitpane-opac": null,
+                            "edit-main-splitpane-marc": "24.8677%",
+                            "edit-main-splitpane-xml": "27.381%",
+                            "edit-main-splitpane-edit-combined": null,
+                            "edit-main-splitpane-edit-work": "23.082%",
+                            "edit-main-splitpane-edit-instance": "24.6693%",
+                            "edit-main-splitpane-properties": null
+                        },
+                        "default": false,
+                        "icon": "preview",
+                        "color": "#000000",
+                        "id": "rhJgQTRXuvJKabjYQtHgcc"
+                    }
+                ]
+        this.setValue('--o-edit-main-splitpane-edit-panel-size-presets', quickViewDefaults)
+
+
+        
+      }
 
       this.buildDiacriticSettings()
 
@@ -1520,7 +1591,6 @@ export const usePreferenceStore = defineStore('preference', {
       this.copyMode = this.styleDefault['--c-general-copy-mode'].value
 
       this.panelSizePresets = this.styleDefault['--o-edit-main-splitpane-edit-panel-size-presets'].value
-
 
 
         // fetch(this.configStore.returnUrls.scriptshifter + 'languages', {

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -3196,6 +3196,40 @@ export const useProfileStore = defineStore('profile', {
       return utilsExport.buildXML(this.activeProfile)
     },
 
+
+    downloadBFDotOrg: async function(format='marc'){
+
+      let xml = await utilsExport.buildXML(this.activeProfile)
+      let marc = await utilsNetwork.marcPreview(xml.bf2Marc, false)
+      
+      xml = xml.xmlStringFormatted
+      marc =marc[0].results.stdout
+      let use = marc
+      let filename = `${this.activeProfile.eId}.marcxml.xml`
+      if (format=='marc'){
+        use = marc
+      }else{
+        use = xml
+        filename = `${this.activeProfile.eId}.rdfxml.xml`
+      }
+
+      const blob = new Blob([use], { type: "text/xml" });
+      const url = URL.createObjectURL(blob);
+
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+
+      // Append to body and trigger click (some browsers might require this for reliable click event)
+      document.body.appendChild(a); 
+      a.click();
+      document.body.removeChild(a); // Clean up
+
+      URL.revokeObjectURL(url);
+
+
+    },
+
     /**
     * return the MARC transformation from the back end
     *


### PR DESCRIPTION
Adds new buttons to the nav bar for Bibframe.org marva. 
Adds new isBibframeDotOrg flag in config. 
Moves the Validate and Post Nav buttons into the displayLCOnlyFeatures block to remove them on bibframe.org
New logic that checks to see if the user has catInitals yet and isBibframeDotOrg and if not then it assumes they are a new user on bibframe.org so it makes up a "Guest-XXXXX" username for them so it doesn't prompt them.
It also sets a Quick view as the default view that shows duel edit and MARC view