### PR TITLE
[BFP 316] `Your Records` Sometimes Missing LCCN 

### DIFF
--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1535,21 +1535,37 @@ const utilsExport = {
 			}
 		}
 
+		console.info("rdfBasic: ", rdfBasic)
+
 		if (rdfBasic.getElementsByTagName("bf:Instance").length>0){
-			let i = rdfBasic.getElementsByTagName("bf:Instance")[0]
+			let i = rdfBasic.getElementsByTagName("bf:Instance")[0] // If there's an associatedResource this can find that instead of the instance of this record
+			// Only look at the top `bf:Instance`
+			for (let inst of rdfBasic.getElementsByTagName("bf:Instance")){
+				let parentNode = inst.parentNode.tagName
+				if (parentNode == 'RDF'){
+					i = inst
+					break
+				}
+			}
+
+			console.info("i: ", i)
 
 			// then find all the lccns and living in the bf:identifiedBy
 			for (let c of i.children){
 				if (c.tagName === 'bf:identifiedBy'){
-
+					console.info(c.tagName, ": ", c)
+					console.info(">>>", c.getElementsByTagName("bf:Lccn"))
 					// grab the lccn bnode
 					if (c.getElementsByTagName("bf:Lccn").length>0){
 						let lccnEl = c.getElementsByTagName("bf:Lccn")[0]
+
+						console.info("lccnEl: ", lccnEl)
 
 						// does it have a status
 						if (lccnEl.getElementsByTagName("bf:Status").length==0){
 							// no status element, so this is it
 							xmlVoidDataLccn = lccnEl.innerText || lccnEl.textContent
+							console.info("set lccn 1: ", xmlVoidDataLccn)
 							//break
 						}else if (lccnEl.getElementsByTagName("bf:Status").length>0){
 							// it does have a status, if it is canceled then we dont wnat to use it
@@ -1561,6 +1577,7 @@ const utilsExport = {
 							for (let cc of lccnEl.children){
 								if (cc.tagName == 'rdf:value'){
 									xmlVoidDataLccn = cc.innerText || cc.textContent
+									console.info("set lccn 2: ", xmlVoidDataLccn)
 								}
 							}
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1539,12 +1539,15 @@ const utilsExport = {
 
 		if (rdfBasic.getElementsByTagName("bf:Instance").length>0){
 			let i = rdfBasic.getElementsByTagName("bf:Instance")[0] // If there's an associatedResource this can find that instead of the instance of this record
-			// Only look at the top `bf:Instance`
-			for (let inst of rdfBasic.getElementsByTagName("bf:Instance")){
-				let parentNode = inst.parentNode.tagName
-				if (parentNode == 'RDF'){
-					i = inst
-					break
+
+			if (i.parentNode.tagName != 'RDF'){
+				// Only look at the top `bf:Instance`
+				for (let inst of rdfBasic.getElementsByTagName("bf:Instance")){
+					let parentNode = inst.parentNode.tagName
+					if (parentNode == 'RDF'){
+						i = inst
+						break
+					}
 				}
 			}
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -438,8 +438,6 @@ const utilsExport = {
   * @return {object} multiple XML strings
   */
   buildXMLProcess: async function(profile){
-    // console.info("buildXML: ", JSON.stringify(profile))
-
     // keep track of the proces for later
 	// let debugHistory = []
 	let xmlLog = []
@@ -1535,8 +1533,6 @@ const utilsExport = {
 			}
 		}
 
-		console.info("rdfBasic: ", rdfBasic)
-
 		if (rdfBasic.getElementsByTagName("bf:Instance").length>0){
 			let i = rdfBasic.getElementsByTagName("bf:Instance")[0] // If there's an associatedResource this can find that instead of the instance of this record
 
@@ -1551,24 +1547,17 @@ const utilsExport = {
 				}
 			}
 
-			console.info("i: ", i)
-
 			// then find all the lccns and living in the bf:identifiedBy
 			for (let c of i.children){
 				if (c.tagName === 'bf:identifiedBy'){
-					console.info(c.tagName, ": ", c)
-					console.info(">>>", c.getElementsByTagName("bf:Lccn"))
 					// grab the lccn bnode
 					if (c.getElementsByTagName("bf:Lccn").length>0){
 						let lccnEl = c.getElementsByTagName("bf:Lccn")[0]
-
-						console.info("lccnEl: ", lccnEl)
 
 						// does it have a status
 						if (lccnEl.getElementsByTagName("bf:Status").length==0){
 							// no status element, so this is it
 							xmlVoidDataLccn = lccnEl.innerText || lccnEl.textContent
-							console.info("set lccn 1: ", xmlVoidDataLccn)
 							//break
 						}else if (lccnEl.getElementsByTagName("bf:Status").length>0){
 							// it does have a status, if it is canceled then we dont wnat to use it
@@ -1745,9 +1734,6 @@ const utilsExport = {
 	let strBf2MarcXmlElBib = (new XMLSerializer()).serializeToString(bf2MarcXmlElRdf)
 
 	// console.info("strXmlBasic: ", strXmlBasic)
-	// for (let item of xmlLog){
-	// 	console.info(item)
-	// }
 
 	return {
 		xmlDom: rdf,

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1569,7 +1569,6 @@ const utilsExport = {
 							for (let cc of lccnEl.children){
 								if (cc.tagName == 'rdf:value'){
 									xmlVoidDataLccn = cc.innerText || cc.textContent
-									console.info("set lccn 2: ", xmlVoidDataLccn)
 								}
 							}
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2829,6 +2829,7 @@ const utilsNetwork = {
     */
 
     saveRecord: async function(xml, eId){
+      console.info("saveRecord: ", xml)
       const putMethod = {
         method: 'PUT', // Method itself
         headers: {
@@ -2883,6 +2884,8 @@ const utilsNetwork = {
      },
 
      searchSavedRecords: async function(user,search){
+
+      console.info("searchSavedRecords: ", search)
 
       let utilUrl = useConfigStore().returnUrls.util
       let utilPath = useConfigStore().returnUrls.env

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -2829,7 +2829,6 @@ const utilsNetwork = {
     */
 
     saveRecord: async function(xml, eId){
-      console.info("saveRecord: ", xml)
       const putMethod = {
         method: 'PUT', // Method itself
         headers: {
@@ -2884,9 +2883,6 @@ const utilsNetwork = {
      },
 
      searchSavedRecords: async function(user,search){
-
-      console.info("searchSavedRecords: ", search)
-
       let utilUrl = useConfigStore().returnUrls.util
       let utilPath = useConfigStore().returnUrls.env
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -66,7 +66,7 @@ export const useConfigStore = defineStore('config', {
         copyCatUpload: 'http://localhost:9401/copycat/upload/stag',
 
         id: 'https://preprod-8080.id.loc.gov/',
-        env : 'production',
+        env : 'staging',
         dev: false,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4370,9 +4370,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     duplicateComponent: async function(componentGuid, structure){
-      console.info("\nduplicateComponent")
-      console.info("componentGuid: ", componentGuid)
-      console.info("structure: ", structure)
       let createEmpty = true
 
       // locate the correct pt to work on in the activeProfile
@@ -7100,9 +7097,6 @@ export const useProfileStore = defineStore('profile', {
         }
       }
 
-      // console.info("last: ", subjectLast)
-      // console.info("structure: ", this.returnStructureByGUID(subjectLast["@guid"]))
-
       let showing = subjectCount - subjectHidden
       if (showing == 0){
         // add an empty subject component
@@ -7114,8 +7108,6 @@ export const useProfileStore = defineStore('profile', {
       }
 
       let results = {'subjects': subjectCount, 'hidden': subjectHidden, 'showing': showing}
-
-      // console.info("profile: ", profile)
 
       return results
     },

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -7089,7 +7089,6 @@ export const useProfileStore = defineStore('profile', {
         for (let pt in profile.rt[rt].pt){
           if (pt.includes("id_loc_gov_ontologies_bibframe_subject__subjects")){
             let comp =  profile.rt[rt].pt[pt]
-            console.info("comp: ", comp, "--", comp.deleted)
             if (comp.deleted === undefined || (Object.keys(comp).includes('deleted') && comp.deleted != true)){
               subjectCount++
             }
@@ -7116,7 +7115,6 @@ export const useProfileStore = defineStore('profile', {
 
       let results = {'subjects': subjectCount, 'hidden': subjectHidden, 'showing': showing}
 
-      console.info("results: ", results)
       // console.info("profile: ", profile)
 
       return results

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1188,7 +1188,7 @@ export default {
     async refreshSavedRecords() {
 
       console.log("refreshSavedRecords")
-
+      console.info("refreshSavedRecords")
 
       let records = await utilsNetwork.searchSavedRecords(this.preferenceStore.returnUserNameForSaving)
 

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1186,9 +1186,7 @@ export default {
 
 
     async refreshSavedRecords() {
-
       console.log("refreshSavedRecords")
-      console.info("refreshSavedRecords")
 
       let records = await utilsNetwork.searchSavedRecords(this.preferenceStore.returnUserNameForSaving)
 


### PR DESCRIPTION
Fixes missing LCCNs.

When the LCCN was being located in the record, it could find an identifier for an associated resource in the bf:Work. Now there's a check to make sure that it's getting a value from a top level bf:Instance.

Existing records need to be resaved for the the LCCN to appear, but new records shouldn't have the issue.