### PR TITLE
Add Script Font Size Preference, Preference Order, Shelflist Links++

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -96,7 +96,7 @@
               </template>
               <template v-else>
                 <textarea
-                  :class="['literal-textarea 1', 'can-select',{'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font'), 'script-text': preferenceStore.returnValue('--n-edit-main-literal-font-size-script') != '1em'}]"
+                  :class="['literal-textarea', 'can-select',{'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font'), 'script-text': preferenceStore.returnValue('--n-edit-main-literal-font-size-script') != '1em'}]"
                   v-model="lValue.value"
                   v-on:keydown.enter.prevent="submitField"
                   autocomplete="off"

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -96,7 +96,7 @@
               </template>
               <template v-else>
                 <textarea
-                  :class="['literal-textarea 1', 'can-select',{'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font')}]"
+                  :class="['literal-textarea 1', 'can-select',{'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font'), 'script-text': preferenceStore.returnValue('--n-edit-main-literal-font-size-script') != '1em'}]"
                   v-model="lValue.value"
                   v-on:keydown.enter.prevent="submitField"
                   autocomplete="off"
@@ -1421,7 +1421,7 @@ fieldset{
   left: 2px;
 }
 
-.literal-field:has( + .lang-display) > form > textarea{
+.literal-field:has( + .lang-display) > form > textarea.script-text{
   font-size: v-bind("preferenceStore.returnValue('--n-edit-main-literal-font-size-script')");
 }
 

--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -96,7 +96,7 @@
               </template>
               <template v-else>
                 <textarea
-                  :class="['literal-textarea', 'can-select',{'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font')}]"
+                  :class="['literal-textarea 1', 'can-select',{'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font')}]"
                   v-model="lValue.value"
                   v-on:keydown.enter.prevent="submitField"
                   autocomplete="off"
@@ -1341,7 +1341,6 @@ fieldset{
   font-size: v-bind("preferenceStore.returnValue('--n-edit-main-literal-font-size')");
   height: v-bind("preferenceStore.returnValue('--n-edit-main-literal-font-size')");
 
-
 }
 .inline-mode-editable-span-input:focus-within {
   background-color: #dfe5f1;
@@ -1356,11 +1355,6 @@ fieldset{
   outline: none;
   margin-right: 15px;
   padding-right: 1em;
-
-
-
-
-
 }
 .inline-mode-editable-span-space-maker{
   display: inline-block;
@@ -1427,7 +1421,9 @@ fieldset{
   left: 2px;
 }
 
-
+.literal-field:has( + .lang-display) > form > textarea{
+  font-size: v-bind("preferenceStore.returnValue('--n-edit-main-literal-font-size-script')");
+}
 
 textarea{
   border: none;

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -2455,6 +2455,11 @@ const utilsParse = {
    */
    reorderAllNonLatinLiterals: function(profile){
 
+    console.info(profile, ": ", profile=={})
+    if (profile == {}) {
+      return profile
+    }
+
     function process (obj, func) {
       if (obj && obj.userValue){
         obj = obj.userValue
@@ -2475,6 +2480,7 @@ const utilsParse = {
         }
       }
     }
+
     for (let rt of profile.rtOrder){
       for (let pt of profile.rt[rt].ptOrder){
         let ptObj = profile.rt[rt].pt[pt]

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -2455,11 +2455,6 @@ const utilsParse = {
    */
    reorderAllNonLatinLiterals: function(profile){
 
-    console.info(profile, ": ", profile=={})
-    if (profile == {}) {
-      return profile
-    }
-
     function process (obj, func) {
       if (obj && obj.userValue){
         obj = obj.userValue

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1679,6 +1679,7 @@ export const usePreferenceStore = defineStore('preference', {
     * @return {void}
     */
     loadPreferences: function(data=null){
+      // How to get the order set
       if (window.localStorage.getItem('marva-preferences') || data){
         let prefs = null
 
@@ -1688,8 +1689,10 @@ export const usePreferenceStore = defineStore('preference', {
           prefs = data
         }
 
+        let order = Object.keys(this.styleDefault)
+
         // TEMP - 10/24 remove eventually
-        for (let k in prefs.styleDefault){
+        for (let k of order){  //in prefs.styleDefault
           if (prefs.styleDefault[k].group == "Sidebars - OPAC"){
             prefs.styleDefault[k].group = "Sidebars - Previews"
           }
@@ -1702,22 +1705,20 @@ export const usePreferenceStore = defineStore('preference', {
             prefs.styleDefault[k].desc = 'Compact Advanced Modular Mode.'
             prefs.styleDefault[k].descShort = 'Use CAMM Mode'
             // prefs.styleDefault[k].value = false
-
-
-
           }
-
-
         }
 
         // if there is a new style in the defaults that is not in their saved prefs.
         for (let k in this.styleDefault){
-          if (!prefs.styleDefault[k]){
+          if (!prefs.styleDefault[k] || prefs.styleDefault[k] != this.styleDefault[k]){
             prefs.styleDefault[k] = this.styleDefault[k]
           }
         }
 
-        this.styleDefault = prefs.styleDefault
+        // this.styleDefault = prefs.styleDefault
+        for (let k of order){
+          this.styleDefault[k] = prefs.styleDefault[k]
+        }
         this.panelDisplay = prefs.panelDisplay
 
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1267,6 +1267,14 @@ export const usePreferenceStore = defineStore('preference', {
         group: 'Shelflisting',
         range: [1,6]
     },
+    '--c-shelflist-line-colors' : {
+          value:'#f1f7ff;', // old val: #a4c3f9ff == #a8c7fc;
+          desc: 'Accent color for the shelf list results.',
+          descShort: 'Shelf List Accent',
+          type: 'color',
+          group: 'Shelflisting',
+          range: null
+       },
       '--b-shelflist-link-1-label' : {
         desc: 'Label for link 1.',
         descShort: 'Link 1 Label',
@@ -1352,15 +1360,56 @@ export const usePreferenceStore = defineStore('preference', {
         index: 4
       },
 
+      '--b-shelflist-link-6-label' : {
+        desc: 'Label for link 6.',
+        descShort: 'Link 6 Label',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
+      '--b-shelflist-link-6' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 6 URL',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
 
-      '--c-shelflist-line-colors' : {
-          value:'#f1f7ff;', // old val: #a4c3f9ff == #a8c7fc;
-          desc: 'Accent color for the shelf list results.',
-          descShort: 'Shelf List Accent',
-          type: 'color',
-          group: 'Shelflisting',
-          range: null
-       },
+      '--b-shelflist-link-7-label' : {
+        desc: 'Label for link 7.',
+        descShort: 'Link 7 Label',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
+      '--b-shelflist-link-7' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 7 URL',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
+
+      '--b-shelflist-link-8-label' : {
+        desc: 'Label for link 8.',
+        descShort: 'Link 8 Label',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
+      '--b-shelflist-link-8' : {
+        desc: 'Link to an outside resource to help with shelf listing.',
+        descShort: 'Link 8 URL',
+        value: "",
+        type: 'string',
+        group: 'Shelflisting',
+        index: 4
+      },
 
     '--b-edit-main-splitpane-edit-inline-mode' : {
       desc: 'Compact Advanced Modular Mode.',
@@ -1693,10 +1742,10 @@ export const usePreferenceStore = defineStore('preference', {
 
         // TEMP - 10/24 remove eventually
         for (let k of order){  //in prefs.styleDefault
-          if (prefs.styleDefault[k].group == "Sidebars - OPAC"){
+          if (prefs.styleDefault[k] && prefs.styleDefault[k].group == "Sidebars - OPAC"){
             prefs.styleDefault[k].group = "Sidebars - Previews"
           }
-          if (prefs.styleDefault[k].group == "Shelflisting"){
+          if (prefs.styleDefault[k] && prefs.styleDefault[k].group == "Shelflisting"){
             prefs.styleDefault[k].group = "Shelflisting"
           }
 
@@ -1710,7 +1759,7 @@ export const usePreferenceStore = defineStore('preference', {
 
         // if there is a new style in the defaults that is not in their saved prefs.
         for (let k in this.styleDefault){
-          if (!prefs.styleDefault[k] || prefs.styleDefault[k] != this.styleDefault[k]){
+          if (!prefs.styleDefault[k]){
             prefs.styleDefault[k] = this.styleDefault[k]
           }
         }

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -654,6 +654,16 @@ export const usePreferenceStore = defineStore('preference', {
           group: 'Literal Field',
           range: [1,2]
       },
+      '--n-edit-main-literal-font-size-script' : {
+          desc: 'The fontsize of the script in the literal field',
+          descShort: 'Font Size Script',
+          value: 1,
+          step: 0.1,
+          type: 'number',
+          unit: 'em',
+          group: 'Literal Field',
+          range: [1,2]
+      },
       '--c-edit-main-literal-font-color' : {
         desc: 'The color of the text',
         descShort: 'Font Color',
@@ -1592,7 +1602,7 @@ export const usePreferenceStore = defineStore('preference', {
         this.setValue('--o-edit-main-splitpane-edit-panel-size-presets', quickViewDefaults)
 
 
-        
+
       }
 
       this.buildDiacriticSettings()

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -1366,7 +1366,7 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
-        index: 4
+        index: 5
       },
       '--b-shelflist-link-6' : {
         desc: 'Link to an outside resource to help with shelf listing.',
@@ -1374,7 +1374,7 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
-        index: 4
+        index: 5
       },
 
       '--b-shelflist-link-7-label' : {
@@ -1383,7 +1383,7 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
-        index: 4
+        index: 6
       },
       '--b-shelflist-link-7' : {
         desc: 'Link to an outside resource to help with shelf listing.',
@@ -1391,7 +1391,7 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
-        index: 4
+        index: 6
       },
 
       '--b-shelflist-link-8-label' : {
@@ -1400,7 +1400,7 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
-        index: 4
+        index: 7
       },
       '--b-shelflist-link-8' : {
         desc: 'Link to an outside resource to help with shelf listing.',
@@ -1408,7 +1408,7 @@ export const usePreferenceStore = defineStore('preference', {
         value: "",
         type: 'string',
         group: 'Shelflisting',
-        index: 4
+        index: 7
       },
 
     '--b-edit-main-splitpane-edit-inline-mode' : {


### PR DESCRIPTION
Adds a preference to set the script size of literal fields. If the value is one for the script, it'll use the value of the other literal font-size option.

This also adjusts the order that preferences appear in the menus. Order was the order the preferences was added, now it should preserve the order in `preference.js`. 

Add some more options to the links for the shelflist tool.