### PR TITLE
Update Empty Record AdminMetadata

### DIFF
--- a/src/components/panels/edit/modals/DebugModal.vue
+++ b/src/components/panels/edit/modals/DebugModal.vue
@@ -56,7 +56,7 @@
     },
 
     methods: {
-        
+
         dragResize: function(newRect){
 
           this.width = newRect.width
@@ -83,7 +83,7 @@
 
     mounted() {
       this.$nextTick(()=>{
-     
+
       })
 
     }
@@ -101,7 +101,7 @@
       :hide-overlay="true"
       :overlay-transition="'vfm-fade'"
 
-      
+
     >
         <VueDragResize
           :is-active="true"
@@ -119,11 +119,11 @@
               <button class="close-button" @pointerup="showDebugModal=false">X</button>
             </div>
 
-            <vue-json-pretty 
+            <vue-json-pretty
               :path="'res'"
               :highlightMouseoverNode="true"
               :collapsedOnClickBrackets="true"
-              :data="debugModalData"      
+              :data="debugModalData"
               >
             </vue-json-pretty>
 
@@ -141,7 +141,7 @@
 
 <style scoped>
 
- 
+
 
   .checkbox-option{
     width: 20px;
@@ -180,7 +180,7 @@
   }
   .debug-modal{
     background-color: white;
-    -webkit-box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27); 
+    -webkit-box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
     box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
     border-radius: 1em;
     padding:1em;

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -569,7 +569,6 @@ const utilsParse = {
       }
 
       // is there admin metdata in the data? If so we need to insert that profile template into the pt
-
       let adminMetadataCount = xml.getElementsByTagName('bf:adminMetadata').length
       if (adminMetadataCount>0){
         let parent
@@ -615,6 +614,7 @@ const utilsParse = {
         profile.rt[pkey].ptOrder.push('id_loc_gov_ontologies_bibframe_adminmetadata')
 
       }
+
       // some more optional xml enrichment here to help the process
       // first try to give hints to which PT to use based on some rules we are using at LC
       if (tle == "bf:Work"){
@@ -1937,6 +1937,23 @@ const utilsParse = {
 
 
             }
+
+            // if a "new" record is being loaded, update it
+            if (profile.rt[pkey].pt[key].adminMetadataType == 'primary'){
+              let status = userValue["http://id.loc.gov/ontologies/bibframe/status"][0]
+              if (status["@id"] == "http://id.loc.gov/vocabulary/mstatus/n"){
+              // status = change
+                status["@id"] = "http://id.loc.gov/vocabulary/mstatus/c"
+                status["http://www.w3.org/2000/01/rdf-schema#label"][0]["http://www.w3.org/2000/01/rdf-schema#label"] = "changed"
+
+                // update date
+                let date = userValue["http://id.loc.gov/ontologies/bibframe/date"][0]
+                date["http://id.loc.gov/ontologies/bibframe/date"] = new Date().toISOString().split('T')[0]
+
+                // delete userValue["http://id.loc.gov/ontologies/bibframe/status"]
+                // delete userValue["http://id.loc.gov/ontologies/bibframe/date"]
+              }
+            }
           }
 
           // if we're working on the primary admin field
@@ -2002,7 +2019,6 @@ const utilsParse = {
 
 
       }
-
 
       let uniquePropertyURIs  = {}
       // we are now going to do some ananlyis on profile, see how many properties are acutally used, what is not used, etc

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -1940,18 +1940,20 @@ const utilsParse = {
 
             // if a "new" record is being loaded, update it
             if (profile.rt[pkey].pt[key].adminMetadataType == 'primary'){
-              let status = userValue["http://id.loc.gov/ontologies/bibframe/status"][0]
-              if (status["@id"] == "http://id.loc.gov/vocabulary/mstatus/n"){
-              // status = change
-                status["@id"] = "http://id.loc.gov/vocabulary/mstatus/c"
-                status["http://www.w3.org/2000/01/rdf-schema#label"][0]["http://www.w3.org/2000/01/rdf-schema#label"] = "changed"
+              if (userValue["http://id.loc.gov/ontologies/bibframe/status"]){
+                let status = userValue["http://id.loc.gov/ontologies/bibframe/status"][0]
+                if (status["@id"] == "http://id.loc.gov/vocabulary/mstatus/n"){
+                // status = change
+                  status["@id"] = "http://id.loc.gov/vocabulary/mstatus/c"
+                  status["http://www.w3.org/2000/01/rdf-schema#label"][0]["http://www.w3.org/2000/01/rdf-schema#label"] = "changed"
 
-                // update date
-                let date = userValue["http://id.loc.gov/ontologies/bibframe/date"][0]
-                date["http://id.loc.gov/ontologies/bibframe/date"] = new Date().toISOString().split('T')[0]
+                  // update date
+                  let date = userValue["http://id.loc.gov/ontologies/bibframe/date"][0]
+                  date["http://id.loc.gov/ontologies/bibframe/date"] = new Date().toISOString().split('T')[0]
 
-                // delete userValue["http://id.loc.gov/ontologies/bibframe/status"]
-                // delete userValue["http://id.loc.gov/ontologies/bibframe/date"]
+                  // delete userValue["http://id.loc.gov/ontologies/bibframe/status"]
+                  // delete userValue["http://id.loc.gov/ontologies/bibframe/date"]
+                }
               }
             }
           }

--- a/src/lib/utils_profile.js
+++ b/src/lib/utils_profile.js
@@ -470,10 +470,7 @@ const utilsProfile = {
     let xml = await utilsNetwork.loadSavedRecord(recordId)
     let meta = this.returnMetaFromSavedXML(xml)
 
-
-
     utilsParse.parseXml(meta.xml)
-
     // alert(parseBfdb.hasItem)
 
     let useProfile = null
@@ -510,15 +507,9 @@ const utilsProfile = {
               }
             }
           }
-
-
-
       }
-
-
-
-
     }
+
 
 
 

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1090,6 +1090,25 @@ export default {
                         "@id": "http://id.loc.gov/vocabulary/languages/eng",
                         "@type": "http://id.loc.gov/ontologies/bibframe/Language"
                       }
+                    ],
+                    "http://id.loc.gov/ontologies/bflc/catalogerId": [
+                      {
+                        "@guid": "fgHPJYcNZNBkeELEUv1M3E",
+                        "http://id.loc.gov/ontologies/bflc/catalogerId": this.preferenceStore.catInitals
+                      }
+                    ],
+                    "http://id.loc.gov/ontologies/bflc/encodingLevel": [
+                      {
+                        "@guid": "dnad4YqMcoo2ro8FVkCxfB",
+                        "@id": "http://id.loc.gov/vocabulary/menclvl/5",
+                        "http://www.w3.org/2000/01/rdf-schema#label": [
+                          {
+                            "@guid": "ncCaUaqE51cuig7YYnDThG",
+                            "http://www.w3.org/2000/01/rdf-schema#label": "preliminary "
+                          }
+                        ],
+                        "@type": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+                      }
                     ]
                   }
                 ]

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1064,6 +1064,12 @@ export default {
                         ]
                       }
                     ],
+                    "http://id.loc.gov/ontologies/bibframe/date": [
+                      {
+                        "@guid": short.generate(),
+                        "http://id.loc.gov/ontologies/bibframe/date": new Date().toISOString().split('T')[0]
+                      }
+                    ],
                     "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication": [
                       {
                         "@guid": "w5ez1o9m9HqWhxGXkfXhvM",

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1059,7 +1059,7 @@ export default {
                           {
                             "@guid": short.generate(),
                             "http://id.loc.gov/ontologies/bibframe/code": "US-dlc",
-                            "@datatype": "http://id.loc.gov/datatypes/orgs/iso15511"
+                            "@datatype": "http://id.loc.gov/datatypes/codes/iso15511"
                           }
                         ]
                       }

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1084,6 +1084,20 @@ export default {
                           "@type": "http://id.loc.gov/ontologies/bibframe/Status"
                         }
                       ],
+                    "http://id.loc.gov/ontologies/bibframe/agent": [
+                      {
+                        "@guid": short.generate(),
+                        "@type": "http://id.loc.gov/ontologies/bibframe/Agent",
+                        "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
+                        "http://id.loc.gov/ontologies/bibframe/code": [
+                          {
+                            "@guid": short.generate(),
+                            "http://id.loc.gov/ontologies/bibframe/code": "DLC",
+                            "@datatype": "http://id.loc.gov/datatypes/orgs/code"
+                          }
+                        ]
+                      }
+                    ],
                     "http://id.loc.gov/ontologies/bibframe/assigner": [
                       {
                         "@guid": short.generate(),

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1020,13 +1020,25 @@ export default {
                           }
                         ],
                         }
-                      ]
-                    ,
+                      ],
+                      "http://id.loc.gov/ontologies/bibframe/status": [
+                        {
+                          "@guid": "fbRKPXtZjPU8b8E3dAFDyq",
+                          "@id": "http://id.loc.gov/vocabulary/mstatus/n",
+                          "http://www.w3.org/2000/01/rdf-schema#label": [
+                            {
+                              "@guid": "q5NhmHwzmMpug1UB7wcG8B",
+                              "http://www.w3.org/2000/01/rdf-schema#label": "new "
+                            }
+                          ],
+                          "@type": "http://id.loc.gov/ontologies/bibframe/Status"
+                        }
+                      ],
                     "http://id.loc.gov/ontologies/bibframe/assigner": [
                       {
                         "@guid": short.generate(),
                         "@type": "http://id.loc.gov/ontologies/bibframe/Organization",
-                        "@id": "http://id.loc.gov/vocabulary/organizations/dlcmrc",
+                        "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
                         "http://www.w3.org/2000/01/rdf-schema#label": [
                           {
                             "@guid": short.generate(),

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -1273,10 +1273,17 @@ export default {
               this.activeProfile.rt[rt].ptOrder.splice(startPos+1, 0, 'id_loc_gov_ontologies_bibframe_identifiedBy__identifiers_1')
               this.activeProfile.rt[rt].ptOrder.splice(startPos+2, 0, 'id_loc_gov_ontologies_bibframe_identifiedBy__identifiers_2')
             }
+
+            // add the defaults
+            //this.profileStore.insertDefaultValuesComponent(component['@guid'], structure)
+            for (let t of Object.keys(pt)){
+              let target = pt[t]
+              let structure = this.profileStore.returnStructureByComponentGuid(target['@guid'])
+              this.profileStore.insertDefaultValuesComponent(target['@guid'], structure)
+            }
           }
         }
       }
-
 
       this.loadingRecord = false
       if (multiTestFlag) {


### PR DESCRIPTION
When creating an empty record:
- Add the cataloger ID
- Set encoding level to 5
- Load the defaults
- Set status new
- Add date

When a record with "status == new" is loaded from the backend, update the status to "changed" and update the date.