### PR TITLE
Remove authorization headers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -116,7 +116,10 @@ export default {
     // this.profileStore.buildProfiles()
     //window.setTimeout(async ()=>{
 
-    if (!hasSsoUser){
+    if (this.configStore.returnUrls.disableSSO) {
+      // SSO disabled for this region — show the standard login modal
+      this.preferenceStore.showLoginModal = true
+    } else if (!hasSsoUser){
       // No valid JWT — redirect to SSO login
       this.preferenceStore.ssoLogin(this.configStore.returnUrls.util)
     } else {

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -329,10 +329,13 @@ const utilsNetwork = {
       if (json){
         options = {headers: {'Content-Type': 'application/json', 'Accept': 'application/json'}, mode: "cors", signal: signal}
       }
-      // Add auth headers for util-service requests
-      const authHdrs = getAuthHeaders()
-      if (Object.keys(authHdrs).length > 0) {
-        options.headers = { ...options.headers, ...authHdrs }
+      // Add auth headers for util-service requests, but not for id.loc.gov / preprod id.loc.gov (except preprod-3001)
+      const isIdLocGov = /^https:\/\/(preprod(-(?!3001)\d+)?\.)?id\.loc\.gov/i.test(url)
+      if (!isIdLocGov) {
+        const authHdrs = getAuthHeaders()
+        if (Object.keys(authHdrs).length > 0) {
+          options.headers = { ...options.headers, ...authHdrs }
+        }
       }
 
       // console.log("url:",url)

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -8,7 +8,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 5,
-    versionPatch: 3,
+    versionPatch: 2,
 
 
 


### PR DESCRIPTION
This removes the authorization header on requests made via the simple lookup components which were causing varnish pass them through the cache and take a long time to return.

also adds disableSSO flag for config that will not force the SSO auth flow