### PR TITLE
fix MLC number not generating MARC conversion

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -1309,6 +1309,10 @@ export default {
 
         let data = this.profileStore.returnLccInfo(this.guid, this.structure)
         // console.log("HERE for LCC data", data,  this.guid, this.structure)
+
+        // if it is a MLC number we dont need to show the extra interface
+        if (data && data.classNumber.startsWith("MLC")){ return false }
+
         if (data.contributors && data.contributors.length>0){
           data.contributors[0].secondLetterLabel = data.contributors[0].label.substring(1)
         }

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -1294,6 +1294,7 @@ const utilsExport = {
 								// console.log(ptObj.propertyURI, 'Does not have @type, something is wrong here', userValue)
 								// console.log("suggest type is:",await this.suggestType(ptObj.propertyURI))
 								console.warn("Should not be here")
+								console.log("ptObj", ptObj)
 								// alert("Not everything entered was serialized into XML, please report this record and check the output.")
 							}
 

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -3042,6 +3042,15 @@ const utilsNetwork = {
       let url = useConfigStore().returnUrls.folioMLCEndpoint + `?sequence=mlc${size}`
       let r = await fetch(url, { headers: getAuthHeaders() })
       r = await r.json()
+      // let r = {
+      //     "generator": "mlc_2026",
+      //     "sequence": "mlcm",
+      //     "status": "OK",
+      //     "nextValue": "MLCM 2026/00156"
+      // }
+      // alert("Remove test response")
+
+
 
       if (r && r.nextValue){
         return r.nextValue

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -4007,23 +4007,91 @@ export const useProfileStore = defineStore('profile', {
         pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'] = [{
           "@guid": short.generate(),
           "@type": "http://id.loc.gov/ontologies/bibframe/ClassificationLcc",
+          "http://id.loc.gov/ontologies/bibframe/assigner": [{
+            "@guid": short.generate(),
+            "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
+            "@type": "http://id.loc.gov/ontologies/bibframe/Agent",
+            "http://www.w3.org/2000/01/rdf-schema#label": [{
+              "@guid": short.generate(),
+              "http://www.w3.org/2000/01/rdf-schema#label": "United States, Library of Congress"
+            }]
+          }],
           "http://id.loc.gov/ontologies/bibframe/classificationPortion": [{
             "@guid": dataFieldGuid,
             "http://id.loc.gov/ontologies/bibframe/classificationPortion": number
+          }],
+          "http://id.loc.gov/ontologies/bibframe/status": [{
+            "@guid": short.generate(),
+            "@id": "http://id.loc.gov/vocabulary/mstatus/uba",
+            "@type": "http://id.loc.gov/ontologies/bibframe/Status",
+            "http://www.w3.org/2000/01/rdf-schema#label": [{
+              "@guid": short.generate(),
+              "http://www.w3.org/2000/01/rdf-schema#label": "used by assigner"
+            }]
           }]
         }]
-      }else if (!pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]['http://id.loc.gov/ontologies/bibframe/classificationPortion']){
-        pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]['http://id.loc.gov/ontologies/bibframe/classificationPortion'] = [{
-          "@guid": dataFieldGuid,
-          "http://id.loc.gov/ontologies/bibframe/classificationPortion": number
-        }]
       }else{
-        pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]['http://id.loc.gov/ontologies/bibframe/classificationPortion'][0] = {
-          "@guid": dataFieldGuid,
-          "http://id.loc.gov/ontologies/bibframe/classificationPortion": number
+        let classEntry = pt.userValue['http://id.loc.gov/ontologies/bibframe/classification'][0]
+        if (!classEntry['@guid']) classEntry['@guid'] = short.generate()
+        if (!classEntry['@type']) classEntry['@type'] = "http://id.loc.gov/ontologies/bibframe/ClassificationLcc"
+        if (!classEntry['http://id.loc.gov/ontologies/bibframe/assigner']){
+          classEntry['http://id.loc.gov/ontologies/bibframe/assigner'] = [{
+            "@guid": short.generate(),
+            "@id": "http://id.loc.gov/vocabulary/organizations/dlc",
+            "@type": "http://id.loc.gov/ontologies/bibframe/Agent",
+            "http://www.w3.org/2000/01/rdf-schema#label": [{
+              "@guid": short.generate(),
+              "http://www.w3.org/2000/01/rdf-schema#label": "United States, Library of Congress"
+            }]
+          }]
+        }
+        if (!classEntry['http://id.loc.gov/ontologies/bibframe/status']){
+          classEntry['http://id.loc.gov/ontologies/bibframe/status'] = [{
+            "@guid": short.generate(),
+            "@id": "http://id.loc.gov/vocabulary/mstatus/uba",
+            "@type": "http://id.loc.gov/ontologies/bibframe/Status",
+            "http://www.w3.org/2000/01/rdf-schema#label": [{
+              "@guid": short.generate(),
+              "http://www.w3.org/2000/01/rdf-schema#label": "used by assigner"
+            }]
+          }]
+        }
+        if (!classEntry['http://id.loc.gov/ontologies/bibframe/classificationPortion']){
+          classEntry['http://id.loc.gov/ontologies/bibframe/classificationPortion'] = [{
+            "@guid": dataFieldGuid,
+            "http://id.loc.gov/ontologies/bibframe/classificationPortion": number
+          }]
+        }else{
+          classEntry['http://id.loc.gov/ontologies/bibframe/classificationPortion'][0] = {
+            "@guid": dataFieldGuid,
+            "http://id.loc.gov/ontologies/bibframe/classificationPortion": number
+          }
         }
       }
 
+      // remove any empty classification entries (cloned but never populated)
+      for (let rtId in this.activeProfile.rt){
+        for (let ptId in this.activeProfile.rt[rtId].pt){
+          let ptObj = this.activeProfile.rt[rtId].pt[ptId]
+          if (ptObj.propertyURI === 'http://id.loc.gov/ontologies/bibframe/classification' && ptObj.userValue){
+            if (!ptObj.userValue['http://id.loc.gov/ontologies/bibframe/classification']){
+              // userValue only has @root, nothing else — mark as deleted
+              ptObj.deleted = true
+            }else{
+              let classArr = ptObj.userValue['http://id.loc.gov/ontologies/bibframe/classification']
+              for (let i = classArr.length - 1; i >= 0; i--){
+                if (!classArr[i]['http://id.loc.gov/ontologies/bibframe/classificationPortion']){
+                  classArr.splice(i, 1)
+                }
+              }
+            }
+          }
+        }
+      }
+
+
+
+      this.dataChanged()
 
       return dataFieldGuid
 


### PR DESCRIPTION
- The MLC number generator was not triggering the correct 050 generation
- Now removes any empty classification nodes after it generates a MLC number
- Now hides the LCC action-zone helper interface when it is a MLC number