### PR TITLE
Fix sometimes missing record id

### DIFF
--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -719,9 +719,18 @@ export default {
         return
       }
 
+      // console.info("getting recordId")
+      // console.info("this.existingLCCN: ", this.existingLCCN)
+      // console.info("this.existingISBN: ", this.existingISBN)
+      // console.info("bibId: ", bibId)
+
       let recordId = ''
       if (this.existingLCCN || this.existingISBN) {
-        recordId = bibId
+        if (this.overrideAllow){
+          recordId = this.overrideBibid
+        } else {
+          recordId = bibId
+        }
       } else {
         if (useConfigStore().returnUrls.env != 'production'){
           recordId = marva001
@@ -732,6 +741,7 @@ export default {
       }
 
       console.info("recordId: ", recordId)
+
       if(useConfigStore().returnUrls.env == 'staging'){
         this.urlToLoad = "https://preprod-8299.id.loc.gov/resources/instances/" + recordId + ".cbd.xml"
       } else {


### PR DESCRIPTION
If there was an match on the LCCN, and the cataloger entered a known bibid, the record id would be empty and fail to create the correct URL for the record.