### PR TITLE
move $7 to the end of the NAR MARC preview text display

### DIFF
--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2468,20 +2468,31 @@ const utilsExport = {
 
 					// there might be repeated subfields, split the value and loop through tem
 					let useValues = fourXXParts[key].split("<REPEATED_MARVA_VALUE>");
+
 					for (let v of useValues){
+
 						let subfield = document.createElementNS(marcNamespace,"marcxml:subfield");
 						subfield.setAttribute( 'code', key)
 						subfield.innerHTML = v.replace(/[\r\n]+/g, ' ').trim()
 						fieldName4xx.appendChild(subfield)
 						fourXXSubfieldsValues.push(`$${key} ${v.replace(/[\r\n]+/g, ' ').trim()}`)
 
-
+						
 					}
 
 				}
 			}
 
 			rootEl.appendChild(fieldName4xx)
+
+			// fourXXSubfieldsValues looks like this: ['$7 (bcp47)ko-hang', '$a BLAH BLAH BLAH']
+			// reorder so the $7 is at the end if it exists
+			let sevenIndex = fourXXSubfieldsValues.findIndex(s => s.startsWith("$7"))
+			if (sevenIndex > -1){
+				let sevenValue = fourXXSubfieldsValues.splice(sevenIndex, 1)[0]
+				fourXXSubfieldsValues.push(sevenValue)
+			}
+
 			marcTextArray.push({txt: this.buildMarcTxtLine(fourXXParts.fieldTag, fourXXParts.indicators.charAt(0).replace(" ","#"), fourXXParts.indicators.charAt(1).replace(" ","#"), fourXXSubfieldsValues), field: fourXXParts.fieldTag, fieldInt: parseInt(fourXXParts.fieldTag)})
 
 		}


### PR DESCRIPTION
400 1# $7 (bcp47)ko-hang $a BLAH BLAH BLAH $d 1999- 
becomes
400 1# $a BLAH BLAH BLAH $d 1999- $7 (bcp47)ko-hang

in NAR MARC Preview Text display (only, the XML is still $7 frist)