### PR TITLE
normalize dash

### DIFF
--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -828,6 +828,7 @@
 
           this.fourXXErrors = []
           this.fourXX = this.fourXX.replace(/  +/g, ' ')
+          this.fourXX = this.fourXX.replace(/[‒‐—–―]/g, '-') // normalize different types of dashes to a standard hyphen
 
           if (this.fourXX.length<3){ return true}
 

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -595,6 +595,10 @@
         checkOneXX(){
           this.oneXXErrors = []
           this.oneXX = this.oneXX.replace(/  +/g, ' ')
+          this.oneXX = this.oneXX.replace(/[‒‐—–―]/g, '-') // normalize different types of dashes to a standard hyphen
+
+          
+          
 
           if (this.oneXX.length<3){ return true}
 
@@ -1599,7 +1603,7 @@
 
 
           this.populatedValue = this.profileStore.nacoStubReturnPopulatedValue(this.profileStore.activeNARStubComponent.guid)
-          console.log("populatedValue",this.populatedValue)
+          // console.log("populatedValue",this.populatedValue)
           if (this.populatedValue && this.populatedValue.marcKey && !resetMode){
 
             // we never want 7xx so replace it


### PR DESCRIPTION
Replace these
[U+2010] ‐ Hyphen (standard usage)
[U+2011] ‑ Non-Breaking Hyphen (prevents line-breaks)
[U+2012] ‒ Figure Dash (same width as digits)
[U+2013] – En Dash (usually indicates ranges)
[U+2014] — Em Dash (used to break sentences)
[U+2015] ― Horizontal Bar (used for quotes)
with this
[U+002D] - Hyphen-Minus (standard keyboard dash)

In the NAR 1xx and 4xx field