### PR TITLE
NAR CIP 670 $b

### DIFF
--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -1508,10 +1508,16 @@
           this.instanceURI =  this.profileStore.nacoStubReturnInstanceURI()
           this.field245 = this.profileStore.nacoStubReturn245()
 
-
+          // Check if the record might be a CIP
+          let isCip = this.profileStore.checkCip()
 
           if (this.statementOfResponsibility && (this.activeNARStubComponent.source && this.activeNARStubComponent.source != 'subject')){
-            this.mainTitleNote = "title page (" + this.statementOfResponsibility  + ")"
+            if (isCip){
+              this.mainTitleNote = "CIP title page (" + this.statementOfResponsibility  + ")"
+            }
+            else {
+              this.mainTitleNote = "title page (" + this.statementOfResponsibility  + ")"
+            }
           }
 
           if (this.statementOfResponsibility && (this.activeNARStubComponent.source && this.activeNARStubComponent.source == 'subject')){
@@ -1533,7 +1539,11 @@
             }
 
             if (startPos && endPos){
-              this.mainTitleNote = "title page (" + _245.slice(startPos, endPos).trim() + ")"
+              if (isCip){
+                this.mainTitleNote = "CIP title page (" + _245.slice(startPos, endPos).trim() + ")"
+              } else {
+                this.mainTitleNote = "title page (" + _245.slice(startPos, endPos).trim() + ")"
+              }
             }
           }
 
@@ -2095,7 +2105,7 @@
                       <div style="padding: 0.2em;">
                         Multi SOR found:
                         <template v-for="(sor, index) in statementOfResponsibilityOptions">
-                          <button style="font-size: 0.75em;" @click="mainTitleNote = 'title page (' + sor.trim() + ')'; update670()">{{ sor }}</button>
+                          <button style="font-size: 0.75em;" @click="mainTitleNote = profileStore.checkCip() ? 'CIP title page (' + sor.trim() + ')' : 'title page (' + sor.trim() + ')'; update670()">{{ sor }}</button>
                         </template>
                       </div>
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -6271,9 +6271,6 @@ export const useProfileStore = defineStore('profile', {
      * @requires activeProfile - Profile must be loaded with valid RT structure
      */
     nacoStubReturnMainTitle(){
-      // Check if the record might be a CIP
-      let isCIP = this.checkCip()
-
       for (let rt of this.activeProfile.rtOrder){
         if (rt.indexOf(":Work")>-1){
           for (let pt of this.activeProfile.rt[rt].ptOrder){
@@ -6292,9 +6289,6 @@ export const useProfileStore = defineStore('profile', {
                   for (let aTitle of pt.userValue['http://id.loc.gov/ontologies/bibframe/title'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle']){
                     if (aTitle['@language'] && aTitle['@language'].toLowerCase().indexOf('latn')>-1){
                       let title = aTitle['http://id.loc.gov/ontologies/bibframe/mainTitle']
-                      if (isCIP){
-                        title = "CIP " + title
-                      }
                       return title
                     }
                   }
@@ -6303,18 +6297,12 @@ export const useProfileStore = defineStore('profile', {
                   for (let aTitle of pt.userValue['http://id.loc.gov/ontologies/bibframe/title'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle']){
                     if (!aTitle['@language']){
                       let title = aTitle['http://id.loc.gov/ontologies/bibframe/mainTitle']
-                      if (isCIP){
-                        title = "CIP " + title
-                      }
                       return title
                     }
                   }
 
                   // if we can't find one without a language tag, just return the first one
                   let title = pt.userValue['http://id.loc.gov/ontologies/bibframe/title'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle']
-                  if (isCIP){
-                    title = "CIP " + title
-                  }
                   return title
                 }
             }

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -6239,7 +6239,6 @@ export const useProfileStore = defineStore('profile', {
             pt = this.activeProfile.rt[rt].pt[pt]
             let userValue = pt.userValue
             if (pt.propertyURI == "http://id.loc.gov/ontologies/bflc/projectedProvisionDate"){
-              console.info("pt: ", pt)
               try {
                 let value = userValue["http://id.loc.gov/ontologies/bflc/projectedProvisionDate"][0]["http://id.loc.gov/ontologies/bflc/projectedProvisionDate"]
                 if (value){
@@ -6248,7 +6247,6 @@ export const useProfileStore = defineStore('profile', {
               } catch { }
             }
             if (pt.propertyURI == "http://id.loc.gov/ontologies/bibframe/adminMetadata" && pt.adminMetadataType == 'primary'){
-              console.info("pt: ", pt)
               try{
                 let encodingLevel = userValue["http://id.loc.gov/ontologies/bibframe/adminMetadata"][0]["http://id.loc.gov/ontologies/bflc/encodingLevel"][0]
                 let code = encodingLevel["http://id.loc.gov/ontologies/bibframe/code"][0]["http://id.loc.gov/ontologies/bibframe/code"]
@@ -6261,7 +6259,6 @@ export const useProfileStore = defineStore('profile', {
         }
       }
 
-      console.info("isCip: ", isCip)
       return isCip
     },
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -176,7 +176,7 @@ export const useProfileStore = defineStore('profile', {
     hiddenClassNumbers: false,
 
 
-    
+
 
     localMarva: false,
 
@@ -2295,8 +2295,8 @@ export const useProfileStore = defineStore('profile', {
             usePreferenceStore().setValue('--b-shelflist-mlc-division',mlcMatch[1].toUpperCase())
           } else {
             usePreferenceStore().setValue('--b-shelflist-mlc-division',"")
-          }            
-        }        
+          }
+        }
 
 
         // console.log("Before prune")
@@ -6220,6 +6220,51 @@ export const useProfileStore = defineStore('profile', {
       return false
     },
 
+    checkCip(){
+      /**
+       * CIP is signaled by
+       *
+       * Projected publication date (YYMM) is populated
+       * encoding level: prepublication
+       * 906 $e ecip <not checking this one>
+       *
+       * in the instance.
+       *
+       * If either of the checks is true, flagging it as a CIP
+       */
+      let isCip = false
+      for (let rt of this.activeProfile.rtOrder){
+        if (rt.indexOf(":Instance")>-1){
+          for (let pt of this.activeProfile.rt[rt].ptOrder){
+            pt = this.activeProfile.rt[rt].pt[pt]
+            let userValue = pt.userValue
+            if (pt.propertyURI == "http://id.loc.gov/ontologies/bflc/projectedProvisionDate"){
+              console.info("pt: ", pt)
+              try {
+                let value = userValue["http://id.loc.gov/ontologies/bflc/projectedProvisionDate"][0]["http://id.loc.gov/ontologies/bflc/projectedProvisionDate"]
+                if (value){
+                  isCip = true
+                }
+              } catch { }
+            }
+            if (pt.propertyURI == "http://id.loc.gov/ontologies/bibframe/adminMetadata" && pt.adminMetadataType == 'primary'){
+              console.info("pt: ", pt)
+              try{
+                let encodingLevel = userValue["http://id.loc.gov/ontologies/bibframe/adminMetadata"][0]["http://id.loc.gov/ontologies/bflc/encodingLevel"][0]
+                let code = encodingLevel["http://id.loc.gov/ontologies/bibframe/code"][0]["http://id.loc.gov/ontologies/bibframe/code"]
+                if (code == 8 || code == '8'){
+                  isCip = true
+                }
+              } catch { }
+            }
+          }
+        }
+      }
+
+      console.info("isCip: ", isCip)
+      return isCip
+    },
+
     /**
      * Retrieves the main title from the NACO stub work profile by traversing the resource template structure.
      * Looks for a property with URI "http://id.loc.gov/ontologies/bibframe/title" and extracts its main title value.
@@ -6229,6 +6274,8 @@ export const useProfileStore = defineStore('profile', {
      * @requires activeProfile - Profile must be loaded with valid RT structure
      */
     nacoStubReturnMainTitle(){
+      // Check if the record might be a CIP
+      let isCIP = this.checkCip()
 
       for (let rt of this.activeProfile.rtOrder){
         if (rt.indexOf(":Work")>-1){
@@ -6247,19 +6294,31 @@ export const useProfileStore = defineStore('profile', {
                   // look for the one that is set as latin first, if we can find it
                   for (let aTitle of pt.userValue['http://id.loc.gov/ontologies/bibframe/title'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle']){
                     if (aTitle['@language'] && aTitle['@language'].toLowerCase().indexOf('latn')>-1){
-                      return aTitle['http://id.loc.gov/ontologies/bibframe/mainTitle']
+                      let title = aTitle['http://id.loc.gov/ontologies/bibframe/mainTitle']
+                      if (isCIP){
+                        title = "CIP " + title
+                      }
+                      return title
                     }
                   }
 
                   // otherwise look for the first one that doesn't have a language tag
                   for (let aTitle of pt.userValue['http://id.loc.gov/ontologies/bibframe/title'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle']){
                     if (!aTitle['@language']){
-                      return aTitle['http://id.loc.gov/ontologies/bibframe/mainTitle']
+                      let title = aTitle['http://id.loc.gov/ontologies/bibframe/mainTitle']
+                      if (isCIP){
+                        title = "CIP " + title
+                      }
+                      return title
                     }
                   }
 
                   // if we can't find one without a language tag, just return the first one
-                  return pt.userValue['http://id.loc.gov/ontologies/bibframe/title'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle']
+                  let title = pt.userValue['http://id.loc.gov/ontologies/bibframe/title'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle'][0]['http://id.loc.gov/ontologies/bibframe/mainTitle']
+                  if (isCIP){
+                    title = "CIP " + title
+                  }
+                  return title
                 }
             }
           }


### PR DESCRIPTION
Add `CIP` after $b for CIP records.

CIP records either have a prepublication date or encodingLevel = 8

<img width="892" height="736" alt="image" src="https://github.com/user-attachments/assets/87f291e2-6f3a-4b54-80a4-5a7463f504b1" />

<img width="892" height="529" alt="image" src="https://github.com/user-attachments/assets/da57592b-b0bf-488b-a35b-548b91af78f3" />