### PR TITLE
Add search toggle to hub creation name lookup

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -1119,7 +1119,7 @@
                   <div v-else style="min-height: 27px;"></div>
                 </div>
 
-				  <div id="container" v-if="modalSelectOptions.length == 7">
+				  <div id="container" v-if="modalSelectOptions.length >= 6">
             <span v-if="activeComplexSearch && activeComplexSearch[0]">
 
             </span>


### PR DESCRIPTION
This lookup doesn't have `wikidata` and number of options is smaller.