### PR TITLE
Fix Visual Bug and Trim Value

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -190,7 +190,7 @@
        *
        * @param classNum - number to add
        */
-      addClassNumber: async function(classNum){
+      addClassNumber: async function(classNum, idx){
         // 2025454279
         let profile = this.activeProfile
 
@@ -246,7 +246,7 @@
         try {
           this.setValueLiteral(targetComponent['@guid'], fieldGuid, propertyPath, classNum, null, null)
           // Give user some feedback
-          let button = this.$refs.addClass[0]
+          let button = this.$refs.addClass[idx]
           button.innerText = "check"
         } catch(err) {
           console.error("Couldn't add the class number: ", err)
@@ -1291,10 +1291,10 @@
                           <template v-if="key=='lcclasses'">
                             <span  class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:</span>
                             <ul class="">
-                              <li class="" v-if="key=='lcclasses'" v-for="v in activeContext.extra['lcclasses']">
+                              <li class="" v-if="key=='lcclasses'" v-for="(v, idx) in activeContext.extra['lcclasses']">
                                   <template v-if="v.assigner">({{ v.assigner }}) </template>
                                   <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm='+v.code" target="_blank">{{ v.code }}</a>
-                                <button class="material-icons see-search add-class" @click="addClassNumber(v.code)" ref="addClass">add</button>
+                                <button class="material-icons see-search add-class" @click="addClassNumber(v.code, idx)" ref="addClass">add</button>
                                 <template v-if="v.label">
                                   <span v-if="v.label.split('--').length == 1">
                                     --{{ v.label.split("--").at(-1) }}
@@ -1311,13 +1311,13 @@
                             <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
                                 this.labelMap[key] : key }}:</span>
                             <ul class="">
-                                <li class="" v-if="key == 'lcclasss'" v-for="v in activeContext.extra[key]">
+                                <li class="" v-if="key == 'lcclasss'" v-for="(v, idx) in activeContext.extra[key]">
                                     <template v-if="typeof v == 'string'">
                                         <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm=' + v"
                                             target="_blank">{{ v }}</a>
                                         <button class="material-icons see-search add-class"
                                             ref="addClass"
-                                            @click="addClassNumber(v)">add</button>
+                                            @click="addClassNumber(v, idx)">add</button>
                                     </template>
                                     <template v-else>
                                         {{ v }}

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -191,6 +191,10 @@
        * @param classNum - number to add
        */
       addClassNumber: async function(classNum, idx){
+        // remove any paranthetical
+        if (classNum.match(/\(.*\)/)){
+          classNum = classNum.replace(/\(.*\)/, "")
+        }
         // 2025454279
         let profile = this.activeProfile
 

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -154,14 +154,14 @@
                             <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
                                 this.labelMap[key] : key }}:</span>
                             <ul class="">
-                                <li class="" v-if="key == 'lcclasses'" v-for="v in contextData['lcclasses']">
+                                <li class="" v-if="key == 'lcclasses'" v-for="(v, idx) in contextData['lcclasses']">
                                     <template v-if="typeof v != 'string'">
                                         ({{ v.assigner }})
                                         <a :href="'https://classweb.org/min/minaret?app=Class&mod=Search&auto=1&table=schedules&table=tables&tid=1&menu=/Menu/&iname=span&ilabel=Class%20number&iterm=' + v.code"
                                             target="_blank">{{ v.code }}</a>
                                         <button class="material-icons see-search"
                                             ref="addClass"
-                                            @click="addClassNumber(v.code)">add</button>
+                                            @click="addClassNumber(v.code, idx)">add</button>
                                     </template>
                                     <template v-else>
                                         {{ v }}
@@ -363,8 +363,8 @@ export default {
         newSearch: function (term) {
             this.$emit('newSearch', term)
         },
-        addClassNumber: function (code) {
-            let button = this.$refs.addClass[0]
+        addClassNumber: function (code, idx) {
+            let button = this.$refs.addClass[idx]
             button.innerText = "check"
 
             this.$emit('addClassNumber', code)


### PR DESCRIPTION
If there were multiple class numbers for a subject or name, clicking any of them would add a check mark to the first one. The correct one should get the check now.

If there is parenthetical information in a class number, it'll be stripped out when the class number field is populated. 