### PR TITLE
April 2026 todos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.6.1] - 2025-04-27
+### Update
+- 046 generation in NAR creation should be more smoothly updating on change
+- When multiple LCCs are set for a work and use the Tool nav bar to open shelflisting it will only use the first LCC component
+- Remove the legacy DCTap option, it tries to sniff out the stage marva profile if no pref is set in localstorage
+### Added
+- Added a Quick Select for the Literal "Set Language" modal that populates based on previous usage.
+
+
+
 ## [1.6.x] - 2025-03-20
 ### Added
 - Introduced MLC Number Generator (https://bibframe.org/docs/view/documentation-marva-manual/Marva%20tools/mlc-numbers.md)

--- a/src/components/panels/edit/modals/LiteralLang.vue
+++ b/src/components/panels/edit/modals/LiteralLang.vue
@@ -33,6 +33,8 @@
 
         currentlySelectedLang: null,
 
+        lastUsedLangScript: null,
+
         // // 2 char lang
         // iso639_1: [{"code":"ab","name":"Abkhaz"},{"code":"aa","name":"Afar"},{"code":"af","name":"Afrikaans"},{"code":"ak","name":"Akan"},{"code":"sq","name":"Albanian"},{"code":"am","name":"Amharic"},{"code":"ar","name":"Arabic"},{"code":"an","name":"Aragonese"},{"code":"hy","name":"Armenian"},{"code":"as","name":"Assamese"},{"code":"av","name":"Avaric"},{"code":"ae","name":"Avestan"},{"code":"ay","name":"Aymara"},{"code":"az","name":"Azerbaijani"},{"code":"bm","name":"Bambara"},{"code":"ba","name":"Bashkir"},{"code":"eu","name":"Basque"},{"code":"be","name":"Belarusian"},{"code":"bn","name":"Bengali; Bangla"},{"code":"bh","name":"Bihari"},{"code":"bi","name":"Bislama"},{"code":"bs","name":"Bosnian"},{"code":"br","name":"Breton"},{"code":"bg","name":"Bulgarian"},{"code":"my","name":"Burmese"},{"code":"ca","name":"Catalan; Valencian"},{"code":"ch","name":"Chamorro"},{"code":"ce","name":"Chechen"},{"code":"ny","name":"Chichewa; Chewa; Nyanja"},{"code":"zh","name":"Chinese"},{"code":"cv","name":"Chuvash"},{"code":"kw","name":"Cornish"},{"code":"co","name":"Corsican"},{"code":"cr","name":"Cree"},{"code":"hr","name":"Croatian"},{"code":"cs","name":"Czech"},{"code":"da","name":"Danish"},{"code":"dv","name":"Divehi; Dhivehi; Maldivian;"},{"code":"nl","name":"Dutch"},{"code":"dz","name":"Dzongkha"},{"code":"en","name":"English"},{"code":"eo","name":"Esperanto"},{"code":"et","name":"Estonian"},{"code":"ee","name":"Ewe"},{"code":"fo","name":"Faroese"},{"code":"fj","name":"Fijian"},{"code":"fi","name":"Finnish"},{"code":"fr","name":"French"},{"code":"ff","name":"Fula; Fulah; Pulaar; Pular"},{"code":"gl","name":"Galician"},{"code":"ka","name":"Georgian"},{"code":"de","name":"German"},{"code":"el","name":"Greek, Modern"},{"code":"gn","name":"GuaranÃ­"},{"code":"gu","name":"Gujarati"},{"code":"ht","name":"Haitian; Haitian Creole"},{"code":"ha","name":"Hausa"},{"code":"he","name":"Hebrew (modern)"},{"code":"hz","name":"Herero"},{"code":"hi","name":"Hindi"},{"code":"ho","name":"Hiri Motu"},{"code":"hu","name":"Hungarian"},{"code":"ia","name":"Interlingua"},{"code":"id","name":"Indonesian"},{"code":"ie","name":"Interlingue"},{"code":"ga","name":"Irish"},{"code":"ig","name":"Igbo"},{"code":"ik","name":"Inupiaq"},{"code":"io","name":"Ido"},{"code":"is","name":"Icelandic"},{"code":"it","name":"Italian"},{"code":"iu","name":"Inuktitut"},{"code":"ja","name":"Japanese"},{"code":"jv","name":"Javanese"},{"code":"kl","name":"Kalaallisut, Greenlandic"},{"code":"kn","name":"Kannada"},{"code":"kr","name":"Kanuri"},{"code":"ks","name":"Kashmiri"},{"code":"kk","name":"Kazakh"},{"code":"km","name":"Khmer"},{"code":"ki","name":"Kikuyu, Gikuyu"},{"code":"rw","name":"Kinyarwanda"},{"code":"ky","name":"Kyrgyz"},{"code":"kv","name":"Komi"},{"code":"kg","name":"Kongo"},{"code":"ko","name":"Korean"},{"code":"ku","name":"Kurdish"},{"code":"kj","name":"Kwanyama, Kuanyama"},{"code":"la","name":"Latin"},{"code":"lb","name":"Luxembourgish, Letzeburgesch"},{"code":"lg","name":"Ganda"},{"code":"li","name":"Limburgish, Limburgan, Limburger"},{"code":"ln","name":"Lingala"},{"code":"lo","name":"Lao"},{"code":"lt","name":"Lithuanian"},{"code":"lu","name":"Luba-Katanga"},{"code":"lv","name":"Latvian"},{"code":"gv","name":"Manx"},{"code":"mk","name":"Macedonian"},{"code":"mg","name":"Malagasy"},{"code":"ms","name":"Malay"},{"code":"ml","name":"Malayalam"},{"code":"mt","name":"Maltese"},{"code":"mi","name":"MÄori"},{"code":"mr","name":"Marathi (MarÄá¹­hÄ«)"},{"code":"mh","name":"Marshallese"},{"code":"mn","name":"Mongolian"},{"code":"na","name":"Nauru"},{"code":"nv","name":"Navajo, Navaho"},{"code":"nb","name":"Norwegian BokmÃ¥l"},{"code":"nd","name":"North Ndebele"},{"code":"ne","name":"Nepali"},{"code":"ng","name":"Ndonga"},{"code":"nn","name":"Norwegian Nynorsk"},{"code":"no","name":"Norwegian"},{"code":"ii","name":"Nuosu"},{"code":"nr","name":"South Ndebele"},{"code":"oc","name":"Occitan"},{"code":"oj","name":"Ojibwe, Ojibwa"},{"code":"cu","name":"Old Church Slavonic, Church Slavic, Church Slavonic, Old Bulgarian, Old Slavonic"},{"code":"om","name":"Oromo"},{"code":"or","name":"Oriya"},{"code":"os","name":"Ossetian, Ossetic"},{"code":"pa","name":"Panjabi, Punjabi"},{"code":"pi","name":"PÄli"},{"code":"fa","name":"Persian (Farsi)"},{"code":"pl","name":"Polish"},{"code":"ps","name":"Pashto, Pushto"},{"code":"pt","name":"Portuguese"},{"code":"qu","name":"Quechua"},{"code":"rm","name":"Romansh"},{"code":"rn","name":"Kirundi"},{"code":"ro","name":"Romanian, [])"},{"code":"ru","name":"Russian"},{"code":"sa","name":"Sanskrit (Saá¹ská¹›ta)"},{"code":"sc","name":"Sardinian"},{"code":"sd","name":"Sindhi"},{"code":"se","name":"Northern Sami"},{"code":"sm","name":"Samoan"},{"code":"sg","name":"Sango"},{"code":"sr","name":"Serbian"},{"code":"gd","name":"Scottish Gaelic; Gaelic"},{"code":"sn","name":"Shona"},{"code":"si","name":"Sinhala, Sinhalese"},{"code":"sk","name":"Slovak"},{"code":"sl","name":"Slovene"},{"code":"so","name":"Somali"},{"code":"st","name":"Southern Sotho"},{"code":"es","name":"Spanish; Castilian"},{"code":"su","name":"Sundanese"},{"code":"sw","name":"Swahili"},{"code":"ss","name":"Swati"},{"code":"sv","name":"Swedish"},{"code":"ta","name":"Tamil"},{"code":"te","name":"Telugu"},{"code":"tg","name":"Tajik"},{"code":"th","name":"Thai"},{"code":"ti","name":"Tigrinya"},{"code":"bo","name":"Tibetan Standard, Tibetan, Central"},{"code":"tk","name":"Turkmen"},{"code":"tl","name":"Tagalog"},{"code":"tn","name":"Tswana"},{"code":"to","name":"Tonga (Tonga Islands)"},{"code":"tr","name":"Turkish"},{"code":"ts","name":"Tsonga"},{"code":"tt","name":"Tatar"},{"code":"tw","name":"Twi"},{"code":"ty","name":"Tahitian"},{"code":"ug","name":"Uyghur, Uighur"},{"code":"uk","name":"Ukrainian"},{"code":"ur","name":"Urdu"},{"code":"uz","name":"Uzbek"},{"code":"ve","name":"Venda"},{"code":"vi","name":"Vietnamese"},{"code":"vo","name":"VolapÃ¼k"},{"code":"wa","name":"Walloon"},{"code":"cy","name":"Welsh"},{"code":"wo","name":"Wolof"},{"code":"fy","name":"Western Frisian"},{"code":"xh","name":"Xhosa"},{"code":"yi","name":"Yiddish"},{"code":"yo","name":"Yoruba"},{"code":"za","name":"Zhuang, Chuang"},{"code":"zu","name":"Zulu"}],
         // // 4 char lang
@@ -69,7 +71,7 @@
 
         let results = this.iso15924.map((d)=>{return {code:d.alpha_4, numeric: d.numeric,name:d.name}})
         results = results.sort((a,b) => (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0))
-        console.log(results)
+        // console.log(results)
         return results
       },
       /**
@@ -97,6 +99,15 @@
       return results
 
       }, 
+
+      previouslyUsedLangScripts(){
+
+        let storedLangScripts = JSON.parse(localStorage.getItem('lastUsedLangScripts') || "[]")
+        // remove any "" or null values
+        storedLangScripts = storedLangScripts.filter((d)=>{ return d})
+        return storedLangScripts
+
+      },
 
 
 
@@ -192,6 +203,17 @@
           // console.log(lang,script)
           // console.log(langStr)
 
+          this.lastUsedLangScript = langStr
+
+
+
+        },
+
+        setLanguageFromQuickSelect(langStr, v){
+
+          console.log(langStr,v)
+
+          this.profileStore.setValueLiteral(this.literalLangInfo.componentGuid,v['@guid'],this.literalLangInfo.propertyPath,v.value,langStr)
 
 
         },
@@ -214,6 +236,23 @@
 
         },
         closeModal(){
+
+
+          // console.log(this.lastUsedLangScript)
+
+
+
+          // save it for later if not saved for later already
+          let storedLangScripts = JSON.parse(localStorage.getItem('lastUsedLangScripts') || "[]")
+          if (!storedLangScripts.includes(this.lastUsedLangScript)){
+            storedLangScripts.push(this.lastUsedLangScript)
+            if (storedLangScripts.length > 10){
+              storedLangScripts.shift()
+            }
+            localStorage.setItem('lastUsedLangScripts', JSON.stringify(storedLangScripts))
+          }
+          
+
 
           this.$emit('langStrSet', this.currentlySelectedLang)
 
@@ -292,9 +331,17 @@
                 </template>                  
               </select>
               
-              <button @click="clearLanguage($event,v)" style="float: right;">Clear Language &amp; Script</button>
+              <div style="display: flex; align-items: center; gap: 0.5em; font-size: 0.85em;">
+                <template v-if="previouslyUsedLangScripts.length > 0">
+                  <span>Quick Select:</span>
+                  <button v-for="langStr in previouslyUsedLangScripts" @click="setLanguageFromQuickSelect(langStr, v)" style="padding: 0.2em 0.5em; border: solid 1px black; border-radius: 4px; background-color: white; cursor: pointer; font-size: 0.75em;">{{ langStr }}</button>
+                </template>
+                <button @click="clearLanguage($event,v)" style="margin-left: auto; padding: 0.2em 0.5em; font-size: 0.75em;">Clear Language &amp; Script</button>
+              </div>
 
             </div>
+
+
             
             <div style="text-align: center; margin-top: 4em;">
               <button @click="closeModal" style="font-size: 1.25em;">Done</button>

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -748,6 +748,15 @@
               this.zero46 = {}
             }
 
+            if (Object.keys(this.zero46).length > 0){
+              this.rebuild046()
+            }else{
+              
+              // not really nessary 
+
+
+            }
+
             if (dollarKey.a){
               // Check for compound last names: hyphenated ("Jacobsen-Smith, Alejandro") or spaced ("Jacobsen Smith, Alejandro")
               let isHyphenated = /[A-Z][a-z]+\-[A-Z][a-z]+/.test(dollarKey.a)
@@ -1316,6 +1325,20 @@
             this.checkFourXX()
           }
 
+          this.rebuild046()
+
+
+
+
+          window.setTimeout(()=>{
+            event.target.value = 'home'
+          },500)
+
+        },
+
+
+        rebuild046(){
+
           // rebuild 046 if $d is present
           if (this.oneXX.includes("$d")){
             let tmp046 = this.build046()
@@ -1350,12 +1373,6 @@
             }
           }
 
-
-
-
-          window.setTimeout(()=>{
-            event.target.value = 'home'
-          },500)
 
         },
 

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -882,23 +882,35 @@ export default {
         }
 
         // Add Legacy Profiles option at the bottom
-        if (!config.returnUrls.isBibframeDotOrg) {
-          dancerMenuItems.push({
-            text: 'Legacy Profiles',
-            icon: !currentWorkspace ? 'check' : '',
-            click: () => {
-              window.localStorage.removeItem('marva-dancerWorkspace')
-              window.location.reload()
-            }
-          })
-        }
+        // We dont add the legacy profiles anymore after a period of transition
+        // if (!config.returnUrls.isBibframeDotOrg) {
+        //   dancerMenuItems.push({
+        //     text: 'Legacy Profiles',
+        //     icon: !currentWorkspace ? 'check' : '',
+        //     click: () => {
+        //       window.localStorage.removeItem('marva-dancerWorkspace')
+        //       window.location.reload()
+        //     }
+        //   })
+        // }
 
         // Find the current workspace name
-        let currentWorkspaceName = 'Legacy'
+        let currentWorkspaceName = ''
+        // if we are in staging try to find the staging workspace name and set it
+        if (config.returnUrls.env === 'staging') {
+          currentWorkspaceName = 'marva-stage'
+        } 
+        if (config.returnUrls.isBibframeDotOrg){
+          currentWorkspaceName = 'marva-prod'
+        }
+
+        // if it stored in the local storage find it by name
         const selectedWorkspace = this.dancerWorkspaces.find(w => w.id === currentWorkspace)
         if (selectedWorkspace) {
           currentWorkspaceName = selectedWorkspace.name.substring(0, 10)
         }
+
+
 
         menu.push({
           text: 'DCTap: ' + currentWorkspaceName,

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -8,7 +8,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 6,
-    versionPatch: 1,
+    versionPatch: 2,
 
 
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -89,6 +89,7 @@ export const useConfigStore = defineStore('config', {
         id: 'https://id.loc.gov/',
         env : 'staging',
         dev: true,
+        externalDev: true,
         displayLCOnlyFeatures: true,
         simpleLookupLang: 'en',
         publicEndpoints:true,

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -7830,9 +7830,13 @@ export const useProfileStore = defineStore('profile', {
                       {level: 1, propertyURI: 'http://id.loc.gov/ontologies/bibframe/itemPortion'}
                     ]
 
-                    console.log("Found LCC data:",this.activeShelfListData)
-                    console.log(JSON.stringify(pt,null,2))
+                    // console.log("Found LCC data:",this.activeShelfListData)
+                    // console.log(JSON.stringify(pt,null,2))
                     foundLCC = true
+
+                    // this is what we want,break here to prevent hitting the second lcc if the recrd has two
+                    break
+
                   }else{
                     // not LCC
                     // continue
@@ -7870,7 +7874,7 @@ export const useProfileStore = defineStore('profile', {
           }
         }
       }
-
+      console.log("Final activeShelfListData:",this.activeShelfListData)
 
     },
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -632,6 +632,31 @@ export const useProfileStore = defineStore('profile', {
           } catch (err) {
             console.error('Error fetching dancer workspace list:', err)
           }
+        }else{
+          try {
+            let wsResponse = await fetch(config.returnUrls.dancerWorkspaceList)
+            let wsData = await wsResponse.json()
+            console.log("wsData",wsData)
+            let defaultWs
+            // if we are stage try to find stage
+            if (config.returnUrls.env === 'staging') {
+              defaultWs = wsData.data.find(ws => ws.name === 'marva-stage')
+            } 
+            if (config.returnUrls.env === 'production') {
+              defaultWs = wsData.data.find(ws => ws.name === 'marva-prod')
+            } 
+
+            if (defaultWs) {
+                let dancerBaseUrl = config.returnUrls.dancerWorkspaceList.split('workspaces')[0]
+                profilesURL = dancerBaseUrl + defaultWs.id + '/profile'
+                startingURL = dancerBaseUrl + defaultWs.id + '/starting-points'
+            }
+          } catch (err) {
+            console.error('Error fetching dancer workspace list:', err)
+          }
+
+
+
         }
       }
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -651,6 +651,14 @@ export const useProfileStore = defineStore('profile', {
                 profilesURL = dancerBaseUrl + defaultWs.id + '/profile'
                 startingURL = dancerBaseUrl + defaultWs.id + '/starting-points'
             }
+
+            if (config.returnUrls.externalDev) {
+                profilesURL = config.returnUrls.profiles
+                startingURL = config.returnUrls.starting
+
+            }
+
+
           } catch (err) {
             console.error('Error fetching dancer workspace list:', err)
           }


### PR DESCRIPTION
### Update
- 046 generation in NAR creation should be more smoothly updating on change
- When multiple LCCs are set for a work and use the Tool nav bar to open shelflisting it will only use the first LCC component
- Remove the legacy DCTap option, it tries to sniff out the stage marva profile if no pref is set in localstorage
### Added
- Added a Quick Select for the Literal "Set Language" modal that populates based on previous usage.
<img width="870" height="465" alt="image" src="https://github.com/user-attachments/assets/8cfce63f-9c00-484f-aa1a-c781d909436f" />
