### PR TITLE
Subject finder imrpovments 04 2026

### DIFF
--- a/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
+++ b/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
@@ -15,7 +15,7 @@
             @dragging="dragResize"
             :sticks="['br']"
             :stickSize="22"
-            style="background-color: whitesmoke"
+            style="background-color: whitesmoke; box-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);"
             >
 
             <div class="yoshino-modal" ref="yoshinoContent" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
@@ -91,7 +91,11 @@
                     </div>
 
                     <div v-if="results && !loading" class="yoshino-results">
-                        <div class="yoshino-results-columns">
+                        <div class="yoshino-tabs">
+                            <button :class="{'yoshino-tab': true, 'yoshino-tab-active': resultsTab === 'subjects'}" @click="resultsTab = 'subjects'">Subjects</button>
+                            <button :class="{'yoshino-tab': true, 'yoshino-tab-active': resultsTab === 'classifications'}" @click="resultsTab = 'classifications'">Classifications<span v-if="results.classifications && results.classifications.length" class="yoshino-tab-count">{{ results.classifications.length }}</span></button>
+                        </div>
+                        <div v-if="resultsTab === 'subjects'" class="yoshino-results-columns">
                             <div class="yoshino-recommended">
                                 <h2>Recommended Subjects</h2>
                                 <div v-if="results.recommended.length === 0" class="yoshino-empty">No recommended subjects found.</div>
@@ -141,6 +145,32 @@
                                     </li>
                                 </ul>
                             </div>
+                        </div>
+
+                        <div v-if="resultsTab === 'classifications'" class="yoshino-classifications">
+                            <div v-if="!sortedClassifications.length" class="yoshino-empty">No classifications found.</div>
+                            <ul v-else>
+                                <li v-for="(c, idx) in sortedClassifications" :key="'cls-'+idx"
+                                    :class="{'yoshino-inserted': insertedClassifications.has(c.key)}">
+                                    <div class="yoshino-subject-row">
+                                        <div class="yoshino-subject-info">
+                                            <span class="yoshino-classification-type">{{ classificationLabel(c.type) }}<span v-if="c.edition"> ({{ c.edition }})</span></span>
+                                            <span class="yoshino-subject-label">{{ c.portion }}</span>
+                                            <a v-if="results.classificationSourceMap && results.classificationSourceMap[c.key]"
+                                               :href="'https://preprod.id.loc.gov/resources/works/' + results.classificationSourceMap[c.key]"
+                                               target="_blank"
+                                               class="yoshino-lccn-link">source</a>
+                                            <span v-if="results.classificationCounts && results.classificationCounts[c.key] > 1"
+                                                  class="yoshino-usage-badge"
+                                                  :title="'Used on ' + results.classificationCounts[c.key] + ' of the retrieved similar records'">{{ results.classificationCounts[c.key] }}×</span>
+                                        </div>
+                                        <button v-if="!insertedClassifications.has(c.key)"
+                                                @click="insertClassification(c)"
+                                                class="yoshino-insert-btn">Insert</button>
+                                        <span v-else class="yoshino-inserted-label">Inserted</span>
+                                    </div>
+                                </li>
+                            </ul>
                         </div>
 
                         <div class="yoshino-actions">
@@ -381,6 +411,63 @@
         padding: 1px 5px;
     }
 
+    .yoshino-tabs {
+        display: flex;
+        gap: 4px;
+        margin-bottom: 8px;
+        border-bottom: 1px solid #ccc;
+    }
+
+    .yoshino-tab {
+        background: #eee;
+        border: 1px solid #ccc;
+        border-bottom: none;
+        border-radius: 4px 4px 0 0;
+        padding: 4px 12px;
+        cursor: pointer;
+        font-size: 0.85rem;
+    }
+
+    .yoshino-tab-active {
+        background: white;
+        font-weight: bold;
+    }
+
+    .yoshino-tab-count {
+        margin-left: 6px;
+        font-size: 0.75rem;
+        color: #666;
+        background: #ddd;
+        border-radius: 8px;
+        padding: 0 6px;
+    }
+
+    .yoshino-classifications {
+        flex: 1;
+        overflow-y: auto;
+        background: white;
+        border-radius: 5px;
+        border: 1px solid #ccc;
+        padding: 8px;
+    }
+
+    .yoshino-classifications ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .yoshino-classification-type {
+        display: inline-block;
+        font-size: 0.7rem;
+        font-weight: bold;
+        background: #1976d2;
+        color: white;
+        border-radius: 3px;
+        padding: 1px 6px;
+        margin-right: 6px;
+    }
+
     .yoshino-insert-btn {
         background-color: #1976d2;
         color: white;
@@ -474,6 +561,8 @@
             statusMessage: '',
             subjectUsageCounts: {},
             enrichmentRunId: 0,
+            resultsTab: 'subjects',
+            insertedClassifications: new Set(),
         }
     },
 
@@ -544,6 +633,24 @@
             if (!this.results || !this.results.otherSubjects) return []
             return [...this.results.otherSubjects].sort((a, b) => a.localeCompare(b))
         },
+
+        sortedClassifications() {
+            if (!this.results || !this.results.classifications) return []
+            const order = {
+                'http://id.loc.gov/ontologies/bibframe/ClassificationLcc': 1,
+                'http://id.loc.gov/ontologies/bibframe/ClassificationDdc': 2,
+                'http://id.loc.gov/ontologies/bibframe/ClassificationNlm': 3,
+                'http://id.loc.gov/ontologies/bibframe/ClassificationNal': 4,
+                'http://id.loc.gov/ontologies/bibframe/ClassificationOther': 5,
+                'http://id.loc.gov/ontologies/bibframe/Classification': 6,
+            }
+            return [...this.results.classifications].sort((a, b) => {
+                const oa = order[a.type] || 99
+                const ob = order[b.type] || 99
+                if (oa !== ob) return oa - ob
+                return a.portion.localeCompare(b.portion)
+            })
+        },
     },
 
     methods: {
@@ -570,8 +677,10 @@
             this.topK = 10
             this.results = null
             this.insertedSubjects = new Set()
+            this.insertedClassifications = new Set()
             this.subjectUsageCounts = {}
             this.enrichmentRunId++
+            this.resultsTab = 'subjects'
             this.statusMessage = ''
             this.extractProfileData()
         },
@@ -595,8 +704,10 @@
             this.noSubjectsFound = false
             this.results = null
             this.insertedSubjects = new Set()
+            this.insertedClassifications = new Set()
             this.subjectUsageCounts = {}
             this.enrichmentRunId++
+            this.resultsTab = 'subjects'
 
             this.profileStore.logEvent('SUBJECT_FINDER_START')
             try {
@@ -690,6 +801,24 @@
             this.insertedSubjects = new Set(this.insertedSubjects)
         },
 
+        classificationLabel(type) {
+            switch (type) {
+                case 'http://id.loc.gov/ontologies/bibframe/ClassificationLcc': return 'LCC'
+                case 'http://id.loc.gov/ontologies/bibframe/ClassificationDdc': return 'DDC'
+                case 'http://id.loc.gov/ontologies/bibframe/ClassificationNlm': return 'NLM'
+                case 'http://id.loc.gov/ontologies/bibframe/ClassificationNal': return 'NAL'
+                case 'http://id.loc.gov/ontologies/bibframe/ClassificationOther': return 'Other'
+                default: return 'Class'
+            }
+        },
+
+        insertClassification: function(c) {
+            this.profileStore.yoshinoInsertClassification(c)
+            this.profileStore.logEvent('SUBJECT_FINDER_INSERT_CLASSIFICATION', { metadata: [c.portion] })
+            this.insertedClassifications.add(c.key)
+            this.insertedClassifications = new Set(this.insertedClassifications)
+        },
+
         onSelectElement(event) {
             const tagName = event.target.tagName
             if (tagName === 'INPUT' || tagName === 'TD' || tagName === 'BUTTON' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'A') {
@@ -699,6 +828,16 @@
     },
 
     mounted: function() {
+        this.results = null
+        this.insertedSubjects = new Set()
+        this.insertedClassifications = new Set()
+        this.subjectUsageCounts = {}
+        this.enrichmentRunId++
+        this.topK = 10
+        this.error = null
+        this.noSubjectsFound = false
+        this.statusMessage = ''
+        this.resultsTab = 'subjects'
         this.extractProfileData()
     },
   };

--- a/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
+++ b/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
@@ -33,17 +33,17 @@
                             <label>Title:</label>
                             <span class="yoshino-value">{{ title || '(not found)' }}</span>
                         </div>
-                        <div class="yoshino-field">
+                        <div class="yoshino-field" :class="{'yoshino-disabled': useUserDescription}">
                             <label>Summary:</label>
                             <div v-if="summaryAlternatives.length > 0" class="yoshino-radio-group">
                                 <label class="yoshino-radio-option">
-                                    <input type="radio" name="summary-source" value="record" v-model="summarySource" @change="summary = recordSummary">
+                                    <input type="radio" name="summary-source" value="record" v-model="summarySource" @change="summary = recordSummary" :disabled="useUserDescription">
                                     <span class="yoshino-radio-source">Record</span>
                                     <span class="yoshino-radio-text">{{ recordSummary ? (recordSummary.length > 200 ? recordSummary.substring(0, 200) + '...' : recordSummary) : '(not found)' }}</span>
                                     <span v-if="recordSummary" class="yoshino-word-count">({{ recordSummary.split(/\s+/).length }} words)</span>
                                 </label>
                                 <label v-for="(alt, idx) in summaryAlternatives" :key="'sum-alt-'+idx" class="yoshino-radio-option">
-                                    <input type="radio" name="summary-source" :value="'alt-sum-'+idx" v-model="summarySource" @change="summary = alt.value">
+                                    <input type="radio" name="summary-source" :value="'alt-sum-'+idx" v-model="summarySource" @change="summary = alt.value" :disabled="useUserDescription">
                                     <span class="yoshino-radio-source">{{ alt.label }}</span>
                                     <span class="yoshino-radio-text">{{ alt.value.length > 200 ? alt.value.substring(0, 200) + '...' : alt.value }}</span>
                                     <span class="yoshino-word-count">({{ alt.value.split(/\s+/).length }} words)</span>
@@ -55,23 +55,30 @@
                             <label>Creator:</label>
                             <span class="yoshino-value">{{ creator || '(not found)' }}</span>
                         </div>
-                        <div class="yoshino-field">
+                        <div class="yoshino-field" :class="{'yoshino-disabled': useUserDescription}">
                             <label>Contents:</label>
                             <div v-if="contentsAlternatives.length > 0" class="yoshino-radio-group">
                                 <label class="yoshino-radio-option">
-                                    <input type="radio" name="contents-source" value="record" v-model="contentsSource" @change="contents = recordContents">
+                                    <input type="radio" name="contents-source" value="record" v-model="contentsSource" @change="contents = recordContents" :disabled="useUserDescription">
                                     <span class="yoshino-radio-source">Record</span>
                                     <span class="yoshino-radio-text">{{ recordContents ? (recordContents.length > 200 ? recordContents.substring(0, 200) + '...' : recordContents) : '(not found)' }}</span>
                                     <span v-if="recordContents" class="yoshino-word-count">({{ recordContents.split(/\s+/).length }} words)</span>
                                 </label>
                                 <label v-for="(alt, idx) in contentsAlternatives" :key="'toc-alt-'+idx" class="yoshino-radio-option">
-                                    <input type="radio" name="contents-source" :value="'alt-toc-'+idx" v-model="contentsSource" @change="contents = alt.value">
+                                    <input type="radio" name="contents-source" :value="'alt-toc-'+idx" v-model="contentsSource" @change="contents = alt.value" :disabled="useUserDescription">
                                     <span class="yoshino-radio-source">{{ alt.label }}</span>
                                     <span class="yoshino-radio-text">{{ alt.value.length > 200 ? alt.value.substring(0, 200) + '...' : alt.value }}</span>
                                     <span class="yoshino-word-count">({{ alt.value.split(/\s+/).length }} words)</span>
                                 </label>
                             </div>
                             <span v-else class="yoshino-value">{{ contents ? (contents.length > 200 ? contents.substring(0, 200) + '...' : contents) : '(not found)' }}</span>
+                        </div>
+                        <div class="yoshino-field">
+                            <label>Or describe:</label>
+                            <textarea v-model="userDescription"
+                                      class="yoshino-user-description"
+                                      rows="3"
+                                      placeholder="Optional. Type a description of the work to use instead of Summary/Contents."></textarea>
                         </div>
                         <div style="margin-top: 12px">
                             <button @click="runClassify()" :disabled="!title">Get Subject Recommendations</button>
@@ -457,6 +464,23 @@
         margin: 0;
     }
 
+    .yoshino-disabled {
+        opacity: 0.45;
+        pointer-events: none;
+    }
+
+    .yoshino-user-description {
+        width: 100%;
+        max-width: 700px;
+        font-size: 0.85rem;
+        padding: 6px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        resize: vertical;
+        font-family: inherit;
+        box-sizing: border-box;
+    }
+
     .yoshino-classification-type {
         display: inline-block;
         font-size: 0.7rem;
@@ -563,6 +587,7 @@
             enrichmentRunId: 0,
             resultsTab: 'subjects',
             insertedClassifications: new Set(),
+            userDescription: '',
         }
     },
 
@@ -634,6 +659,10 @@
             return [...this.results.otherSubjects].sort((a, b) => a.localeCompare(b))
         },
 
+        useUserDescription() {
+            return !!(this.userDescription && this.userDescription.trim())
+        },
+
         sortedClassifications() {
             if (!this.results || !this.results.classifications) return []
             const order = {
@@ -682,6 +711,7 @@
             this.enrichmentRunId++
             this.resultsTab = 'subjects'
             this.statusMessage = ''
+            this.userDescription = ''
             this.extractProfileData()
         },
 
@@ -711,13 +741,15 @@
 
             this.profileStore.logEvent('SUBJECT_FINDER_START')
             try {
+                const usingUserDesc = this.useUserDescription
                 this.results = await yoshinoClassify(
                     this.title,
-                    this.summary || '',
+                    usingUserDesc ? '' : (this.summary || ''),
                     this.creator || '',
                     (msg) => { this.statusMessage = msg },
                     this.topK,
-                    this.contents || ''
+                    usingUserDesc ? '' : (this.contents || ''),
+                    usingUserDesc ? this.userDescription.trim() : ''
                 )
                 console.log("Classification results:", this.results)
                 this.enrichRecommendedUsage(this.results, this.enrichmentRunId)
@@ -838,6 +870,14 @@
         this.noSubjectsFound = false
         this.statusMessage = ''
         this.resultsTab = 'subjects'
+        this.userDescription = ''
+        const ldStaleForActiveProfile = this.linkedData &&
+            this.linkedData.eId !== undefined &&
+            this.activeProfile &&
+            this.linkedData.eId !== this.activeProfile.eId
+        if (ldStaleForActiveProfile) {
+            this.profileStore.linkedData = {}
+        }
         this.extractProfileData()
     },
   };

--- a/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
+++ b/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
@@ -106,6 +106,7 @@
                                                    :href="'https://preprod.id.loc.gov/resources/works/' + results.subjectSourceMap[subj]"
                                                    target="_blank"
                                                    class="yoshino-lccn-link">source</a>
+                                                <span v-if="subjectUsageCounts[subj] !== undefined" class="yoshino-usage-badge">{{ subjectUsageCounts[subj] }} usage</span>
                                             </div>
                                             <button v-if="!insertedSubjects.has(subj)"
                                                     @click="insertSubject(subj)"
@@ -130,6 +131,7 @@
                                                    :href="'https://preprod.id.loc.gov/resources/works/' + results.subjectSourceMap[subj]"
                                                    target="_blank"
                                                    class="yoshino-lccn-link">source</a>
+                                                <span v-if="subjectUsageCounts[subj] !== undefined" class="yoshino-usage-badge">{{ subjectUsageCounts[subj] }} usage</span>
                                             </div>
                                             <button v-if="!insertedSubjects.has(subj)"
                                                     @click="insertSubject(subj)"
@@ -370,6 +372,15 @@
         color: #1976d2;
     }
 
+    .yoshino-usage-badge {
+        font-size: 0.75rem;
+        margin-left: 6px;
+        color: #555;
+        background: #e8eef5;
+        border-radius: 3px;
+        padding: 1px 5px;
+    }
+
     .yoshino-insert-btn {
         background-color: #1976d2;
         color: white;
@@ -461,6 +472,8 @@
             noSubjectsFound: false,
             topK: 10,
             statusMessage: '',
+            subjectUsageCounts: {},
+            enrichmentRunId: 0,
         }
     },
 
@@ -546,6 +559,7 @@
             this.loading = false
             this.error = null
             this.statusMessage = ''
+            this.enrichmentRunId++
             this.showYoshinoSubjectsModal = false
         },
 
@@ -556,6 +570,8 @@
             this.topK = 10
             this.results = null
             this.insertedSubjects = new Set()
+            this.subjectUsageCounts = {}
+            this.enrichmentRunId++
             this.statusMessage = ''
             this.extractProfileData()
         },
@@ -579,6 +595,8 @@
             this.noSubjectsFound = false
             this.results = null
             this.insertedSubjects = new Set()
+            this.subjectUsageCounts = {}
+            this.enrichmentRunId++
 
             this.profileStore.logEvent('SUBJECT_FINDER_START')
             try {
@@ -590,6 +608,8 @@
                     this.topK,
                     this.contents || ''
                 )
+                console.log("Classification results:", this.results)
+                this.enrichRecommendedUsage(this.results, this.enrichmentRunId)
             } catch (e) {
                 this.error = e.message || 'An error occurred during classification.'
                 if (this.error.toLowerCase().includes('no subjects found')) {
@@ -597,6 +617,52 @@
                 }
             } finally {
                 this.loading = false
+            }
+        },
+
+        enrichRecommendedUsage: async function(results, runId) {
+            if (!results) return
+            const seen = new Set()
+            const subjects = []
+            for (const subj of [...(results.recommended || []), ...(results.otherSubjects || [])]) {
+                if (seen.has(subj)) continue
+                seen.add(subj)
+                subjects.push(subj)
+            }
+            const batchSize = 2
+            for (let i = 0; i < subjects.length; i += batchSize) {
+                if (runId !== this.enrichmentRunId) return
+                const batch = subjects.slice(i, i + batchSize)
+                await Promise.all(batch.map(subj => this.fetchSubjectUsage(subj, results, runId)))
+            }
+        },
+
+        fetchSubjectUsage: async function(subj, results, runId) {
+            try {
+                const uri = results.subjectUriMap && results.subjectUriMap[subj]
+                let url
+                if (uri) {
+                    const id = uri.substring(uri.lastIndexOf('/') + 1)
+                    url = `https://preprod-8080.id.loc.gov/authorities/subjects/suggest2?q=${encodeURIComponent(id)}&usage=2`
+                } else {
+                    url = `https://preprod-8080.id.loc.gov/entities/subjects/suggest2/?q=${encodeURIComponent(subj)}&searchtype=left&count=250&usage=true`
+                }
+                const resp = await fetch(url)
+                if (!resp.ok) return
+                const data = await resp.json()
+                if (runId !== this.enrichmentRunId) return
+                const hit = data && data.hits && data.hits[0]
+                if (!hit) return
+                if (uri) {
+                    if (hit.uri !== uri) return
+                } else {
+                    if (hit.aLabel !== subj) return
+                }
+                const count = hit['subject-of']
+                if (typeof count !== 'number') return
+                this.subjectUsageCounts = { ...this.subjectUsageCounts, [subj]: count }
+            } catch (e) {
+                // silent — enrichment is best-effort
             }
         },
 

--- a/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
+++ b/src/components/panels/edit/modals/YoshinoSubjectsModal.vue
@@ -24,6 +24,7 @@
                         <button @click="closeModal()" class="close-button">Close</button>
                     </div>
                 </div>
+                <button @click="preferenceStore.togglePanel('linkedData')" class="yoshino-toggle-ld-button">Toggle LD Panel</button>
                 <div ref="yoshinoModalContainer" class="yoshino-modal-container">
                     <h1 style="margin-left: 5px">Subject Finder</h1>
 
@@ -174,6 +175,17 @@
         position: absolute;
         right: 5px;
         top: 5px;
+        background-color: white;
+        border-radius: 5px;
+        border: solid 1px black;
+        cursor: pointer;
+        z-index: 100;
+    }
+
+    .yoshino-toggle-ld-button {
+        position: absolute;
+        left: 5px;
+        bottom: 5px;
         background-color: white;
         border-radius: 5px;
         border: solid 1px black;
@@ -424,6 +436,7 @@
     import VueDragResize from 'vue3-drag-resize'
     import { mapStores, mapState, mapWritableState } from 'pinia'
     import { useProfileStore } from '@/stores/profile'
+    import { usePreferenceStore } from '@/stores/preference'
     import { yoshinoClassify, yoshinoExtractTitle, yoshinoExtractSummary, yoshinoExtractCreator, yoshinoExtractContents } from '@/lib/yoshino'
 
     export default {
@@ -452,7 +465,7 @@
     },
 
     computed: {
-        ...mapStores(useProfileStore),
+        ...mapStores(useProfileStore, usePreferenceStore),
         ...mapState(useProfileStore, ['activeProfile', 'linkedData']),
         ...mapWritableState(useProfileStore, ['showYoshinoSubjectsModal', 'yoshinoResults', 'yoshinoInsertedSubjects']),
 

--- a/src/lib/yoshino.js
+++ b/src/lib/yoshino.js
@@ -212,14 +212,42 @@ function yoshinoParseRdf(xmlText) {
     subjects.push(subjectData)
   }
 
-  // Extract LCC classifications
+  // Extract classifications (LCC, DDC, NLM, NAL, Other)
+  const classTypes = ['ClassificationLcc', 'ClassificationDdc', 'ClassificationNlm', 'ClassificationNal', 'ClassificationOther', 'Classification']
   for (const classEl of Array.from(work.getElementsByTagNameNS(NS.bf, 'classification'))) {
-    const lccEls = Array.from(classEl.getElementsByTagNameNS(NS.bf, 'ClassificationLcc'))
-    if (!lccEls.length) continue
-    const portionEl = lccEls[0].getElementsByTagNameNS(NS.bf, 'classificationPortion')
+    let inner = null
+    let typeLocal = null
+    for (const t of classTypes) {
+      const els = Array.from(classEl.getElementsByTagNameNS(NS.bf, t))
+      if (els.length) {
+        inner = els[0]
+        typeLocal = t
+        break
+      }
+    }
+    if (!inner) continue
+    const portionEl = inner.getElementsByTagNameNS(NS.bf, 'classificationPortion')
     if (!portionEl.length || !portionEl[0].textContent) continue
     const portion = portionEl[0].textContent.trim()
-    classifications.push({ portion, xml: new XMLSerializer().serializeToString(classEl) })
+
+    let sourceCode = null
+    const sourceEls = Array.from(inner.getElementsByTagNameNS(NS.bf, 'Source'))
+    if (sourceEls.length) {
+      const codeEl = sourceEls[0].getElementsByTagNameNS(NS.bf, 'code')[0]
+      if (codeEl?.textContent) sourceCode = codeEl.textContent.trim()
+    }
+
+    let edition = null
+    const editionEl = inner.getElementsByTagNameNS(NS.bf, 'edition')[0]
+    if (editionEl?.textContent) edition = editionEl.textContent.trim()
+
+    classifications.push({
+      portion,
+      type: 'http://id.loc.gov/ontologies/bibframe/' + typeLocal,
+      sourceCode,
+      edition,
+      xml: new XMLSerializer().serializeToString(classEl),
+    })
   }
 
   return { subjects, classifications }
@@ -452,6 +480,10 @@ async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}
   const subjectUriMap = {}
   const subjectMarcKeyMap = {}
   const subjectUncontrolledMap = {}
+  const classifications = []
+  const classificationSeen = new Set()
+  const classificationSourceMap = {}
+  const classificationCounts = {}
 
   for (const { id, xml } of rdfResults) {
     if (!xml) continue
@@ -468,6 +500,14 @@ async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}
         if (s.uncontrolled) subjectUncontrolledMap[s.label] = true
         subjectSourceMap[s.label] = id
       }
+    }
+    for (const c of parsed.classifications) {
+      const key = c.type + '|' + c.portion + '|' + (c.sourceCode || '') + '|' + (c.edition || '')
+      classificationCounts[key] = (classificationCounts[key] || 0) + 1
+      if (classificationSeen.has(key)) continue
+      classificationSeen.add(key)
+      classifications.push({ ...c, key })
+      classificationSourceMap[key] = id
     }
   }
 
@@ -503,6 +543,9 @@ async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}
     subjectUriMap,
     subjectMarcKeyMap,
     subjectUncontrolledMap,
+    classifications,
+    classificationSourceMap,
+    classificationCounts,
   }
 }
 

--- a/src/lib/yoshino.js
+++ b/src/lib/yoshino.js
@@ -381,21 +381,52 @@ function yoshinoExtractContents(activeProfile) {
 async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}, topK = 10, content = '') {
   // Step 1: Vector search
   onStatus('Searching for similar records...')
-  let classifyBody = {
-    action: 'classify',
-    title,
-    summary,
-    creator,
-    top_k: topK,
-    ids_only: true,
-  }
-  if (content) classifyBody.content = content
 
-  const classifyRes = await fetch(LAMBDA_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(classifyBody),
-  }).then(r => r.json())
+  let workingSummary = summary
+  let workingContent = content
+  let classifyRes
+  for (let attempt = 0; attempt < 3; attempt++) {
+    let classifyBody = {
+      action: 'classify',
+      title,
+      summary: workingSummary,
+      creator,
+      top_k: topK,
+      ids_only: true,
+    }
+    if (workingContent) classifyBody.content = workingContent
+
+    classifyRes = await fetch(LAMBDA_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(classifyBody),
+    }).then(r => r.json())
+
+    if (classifyRes && classifyRes.search_results) break
+
+    const errMsg = classifyRes && (classifyRes.error || classifyRes.message || '')
+    const tokenMatch = typeof errMsg === 'string' && errMsg.match(/Max input tokens:\s*(\d+).*?request input token count:\s*(\d+)/i)
+    if (tokenMatch) {
+      const maxTokens = parseInt(tokenMatch[1], 10)
+      const requestTokens = parseInt(tokenMatch[2], 10)
+      // ~10% safety margin under the cap
+      const ratio = (maxTokens * 0.9) / requestTokens
+      onStatus('Input too long, truncating and retrying...')
+      const truncate = (s) => {
+        if (!s) return s
+        const targetLen = Math.max(200, Math.floor(s.length * ratio))
+        return s.length > targetLen ? s.substring(0, targetLen) : s
+      }
+      workingSummary = truncate(workingSummary)
+      workingContent = truncate(workingContent)
+      continue
+    }
+    throw new Error(errMsg || 'Vector search failed.')
+  }
+
+  if (!classifyRes || !classifyRes.search_results) {
+    throw new Error((classifyRes && (classifyRes.error || classifyRes.message)) || 'Vector search failed.')
+  }
 
   const ids = classifyRes.search_results
     .map(r => r.metadata?.['001'] || r.lc_001)

--- a/src/lib/yoshino.js
+++ b/src/lib/yoshino.js
@@ -406,7 +406,7 @@ function yoshinoExtractContents(activeProfile) {
  * @param {function} onStatus - Callback for status updates: onStatus(message)
  * @returns {object} { recommended, allSubjects, subjectSources, subjectSourceMap, enrichResult }
  */
-async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}, topK = 10, content = '') {
+async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}, topK = 10, content = '', userDescription = '') {
   // Step 1: Vector search
   onStatus('Searching for similar records...')
 
@@ -423,6 +423,7 @@ async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}
       ids_only: true,
     }
     if (workingContent) classifyBody.content = workingContent
+    if (userDescription) classifyBody.user_description = userDescription
 
     classifyRes = await fetch(LAMBDA_URL, {
       method: 'POST',

--- a/src/lib/yoshino.js
+++ b/src/lib/yoshino.js
@@ -323,29 +323,32 @@ function yoshinoExtractSummary(activeProfile) {
  * Extract Primary Creator label from activeProfile.
  */
 function yoshinoExtractCreator(activeProfile) {
+  let fallbackLabel = null
   for (let rt of activeProfile.rtOrder) {
     if (rt.indexOf(':Work') === -1) continue
     for (let ptId of activeProfile.rt[rt].ptOrder) {
       let pt = activeProfile.rt[rt].pt[ptId]
-      if (pt.propertyURI === 'http://id.loc.gov/ontologies/bibframe/contribution') {
-        if (pt.userValue &&
-            pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'] &&
-            pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0] &&
-            pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['@type'] === 'http://id.loc.gov/ontologies/bibframe/PrimaryContribution' &&
-            pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'] &&
-            pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'][0]
-        ) {
-          let agent = pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution'][0]['http://id.loc.gov/ontologies/bibframe/agent'][0]
-          if (agent['http://www.w3.org/2000/01/rdf-schema#label'] &&
-              agent['http://www.w3.org/2000/01/rdf-schema#label'][0] &&
-              agent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']) {
-            return agent['http://www.w3.org/2000/01/rdf-schema#label'][0]['http://www.w3.org/2000/01/rdf-schema#label']
-          }
+      if (pt.propertyURI !== 'http://id.loc.gov/ontologies/bibframe/contribution') continue
+      let contributions = pt.userValue && pt.userValue['http://id.loc.gov/ontologies/bibframe/contribution']
+      if (!contributions) continue
+      for (let contribution of contributions) {
+        let agent = contribution['http://id.loc.gov/ontologies/bibframe/agent'] &&
+                    contribution['http://id.loc.gov/ontologies/bibframe/agent'][0]
+        if (!agent) continue
+        let labelEntry = agent['http://www.w3.org/2000/01/rdf-schema#label'] &&
+                         agent['http://www.w3.org/2000/01/rdf-schema#label'][0]
+        let label = labelEntry && labelEntry['http://www.w3.org/2000/01/rdf-schema#label']
+        if (!label) continue
+        if (contribution['@type'] === 'http://id.loc.gov/ontologies/bibframe/PrimaryContribution') {
+          return label
+        }
+        if (fallbackLabel === null) {
+          fallbackLabel = label
         }
       }
     }
   }
-  return null
+  return fallbackLabel
 }
 
 /**

--- a/src/lib/yoshino.js
+++ b/src/lib/yoshino.js
@@ -425,6 +425,7 @@ async function yoshinoClassify(title, summary, creator = '', onStatus = () => {}
   for (const { id, xml } of rdfResults) {
     if (!xml) continue
     const parsed = yoshinoParseRdf(xml)
+    console.log("parsed",parsed)
     for (const s of parsed.subjects) {
       if (!subjectSources[s.label]) {
         allSubjects.push(s.label)

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -5429,6 +5429,7 @@ export const useProfileStore = defineStore('profile', {
     prepareForNewRecord:  function(){
 
       this.activeProfile = {}
+      this.linkedData = {}
 
     },
 
@@ -6996,6 +6997,83 @@ export const useProfileStore = defineStore('profile', {
       console.log('Top-level marcKey:', marcKey)
       console.log('Components:', JSON.parse(JSON.stringify(components || [])))
       console.log('Built userValue:', JSON.parse(JSON.stringify(targetPt.userValue)))
+
+      targetPt.hasData = true
+      targetPt.userModified = true
+      targetPt.dataLoaded = false
+
+      this.dataChanged()
+    },
+
+    yoshinoInsertClassification: async function(classification) {
+      let activeProfile = this.activeProfile
+      let workRt = null
+      let emptyPt = null
+      let lastPt = null
+
+      for (let rt of activeProfile.rtOrder) {
+        if (rt.indexOf(':Work') > -1) {
+          workRt = rt
+          break
+        }
+      }
+      if (!workRt) return
+
+      for (let ptId of activeProfile.rt[workRt].ptOrder) {
+        let pt = activeProfile.rt[workRt].pt[ptId]
+        if (pt && pt.propertyURI === 'http://id.loc.gov/ontologies/bibframe/classification' && !pt.deleted) {
+          lastPt = pt
+          let uv = pt.userValue
+          if (!pt.hasData || !uv ||
+              !uv['http://id.loc.gov/ontologies/bibframe/classification'] ||
+              uv['http://id.loc.gov/ontologies/bibframe/classification'].length === 0 ||
+              !uv['http://id.loc.gov/ontologies/bibframe/classification'][0]['@type']) {
+            emptyPt = pt
+          }
+        }
+      }
+
+      let targetPt = emptyPt
+      if (!targetPt && lastPt) {
+        let newGuid = await this.duplicateComponent(lastPt['@guid'], this.returnStructureByGUID(lastPt['@guid']))
+        if (newGuid) {
+          targetPt = this.returnStructureByGUID(newGuid)
+        }
+      }
+      if (!targetPt) return
+
+      let classValue = {
+        '@guid': translator.new(),
+        '@type': classification.type,
+        'http://id.loc.gov/ontologies/bibframe/classificationPortion': [{
+          '@guid': translator.new(),
+          'http://id.loc.gov/ontologies/bibframe/classificationPortion': classification.portion
+        }]
+      }
+
+      if (classification.sourceCode) {
+        classValue['http://id.loc.gov/ontologies/bibframe/source'] = [{
+          '@guid': translator.new(),
+          '@type': 'http://id.loc.gov/ontologies/bibframe/Source',
+          'http://id.loc.gov/ontologies/bibframe/code': [{
+            '@guid': translator.new(),
+            'http://id.loc.gov/ontologies/bibframe/code': classification.sourceCode
+          }]
+        }]
+      }
+
+      if (classification.edition) {
+        classValue['http://id.loc.gov/ontologies/bibframe/edition'] = [{
+          '@guid': translator.new(),
+          'http://id.loc.gov/ontologies/bibframe/edition': classification.edition
+        }]
+      }
+
+      targetPt.userValue = {
+        '@guid': targetPt.userValue?.['@guid'] || translator.new(),
+        '@root': 'http://id.loc.gov/ontologies/bibframe/classification',
+        'http://id.loc.gov/ontologies/bibframe/classification': [classValue]
+      }
 
       targetPt.hasData = true
       targetPt.userModified = true

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -8098,6 +8098,7 @@ export const useProfileStore = defineStore('profile', {
       console.log("linkedData",linkedData)
       this.linkedData = linkedData
       this.linkedData.done = true
+      this.linkedData.eId = this.activeProfile && this.activeProfile.eId
 
     },
 


### PR DESCRIPTION
Various updates / improvements to the LCSH Subject Find Feature:

- Uses the first contributor if no primary contributor is present
- You can open the Linked Data panel from the subject finder popup
- Adds usage counts for BOTH authorized simple and complex subjects AND pre-coordinated subjects found in bib records
- bug fixes
- A new tab that shows classifications found on similar records and allows you to insert them
- Allow you to type (or copy paste) your own description of the book that overrides. The system will build a mock record based on your description and use that to find similar records. Try to be specific for better suggestions. 
