### PR TITLE
Find and Replace, TitleCase

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -81,6 +81,7 @@
                     @keyup="navKey"
                     :ref="'input_' + lValue['@guid']"
                     :data-guid="lValue['@guid']"
+                    :data-parent="guid"
                     :disabled="readOnly"
                     ></textarea>
                 </div>
@@ -110,6 +111,7 @@
                   @keydown="keyDown"
                   :ref="'input_' + lValue['@guid']"
                   :data-guid="lValue['@guid']"
+                  :data-parent="guid"
                   :disabled="readOnly"
                   :readonly="structure.propertyLabel=='Local identifier'"
                   ></textarea>

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -137,9 +137,9 @@ export default {
             if (!all) {
                 let target = this.matches[this.activeMatch]
                 this.replace(target)
-                if (this.activeMatch < this.matches.length-1){
-                    this.activeMatch++
-                }
+                // if (this.activeMatch < this.matches.length-1){
+                //     this.activeMatch++
+                // }
             } else {
                 for (let target of this.matches) {
                     this.replace(target)

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -44,9 +44,7 @@ export default {
     computed: {
         ...mapStores(useProfileStore, usePreferenceStore),
         ...mapWritableState(usePreferenceStore, ['showFindReplaceModal', 'panelDisplay', 'panelSizePresets']),
-        ...mapWritableState(useProfileStore, ['activeProfile', 'findLiterals', 'setValueLiteral', 'buildPropertyPath', 'returnStructureByGUID', 'returnLiteralValueFromProfile']),
-
-
+        ...mapWritableState(useProfileStore, ['activeComponent', 'activeProfile', 'findLiterals', 'setValueLiteral', 'buildPropertyPath', 'returnStructureByGUID', 'returnLiteralValueFromProfile']),
 
 
 
@@ -54,8 +52,6 @@ export default {
 
     watch: {
         matchCase(newVal, oldVal) {
-            console.info("newVal: ", newVal)
-            console.info("oldVal: ", oldVal)
             this.matchCase = newVal
             this.find()
         }
@@ -85,11 +81,6 @@ export default {
 
         find() {
             this.matches = []
-            console.info("finding: ", this.findTarget)
-            console.info("\tactiveProfile: ", this.activeProfile)
-            console.info("\tmatchCase? ", this.matchCase)
-            console.info("\tmatches: ", this.matches)
-
             let literals = document.getElementsByTagName('textarea')
             for (let field of literals) {
                 let fieldGuid = field.getAttribute("data-guid")
@@ -101,7 +92,7 @@ export default {
                     let matches = value.matchAll(reg)
                     for (let match of matches) {
                         let structure = this.returnStructureByGUID(targetGuid)
-                        console.info("struct: ", structure)
+                        console.info("structure: ", structure)
                         this.matches.push({ 'match': match, 'text': value, 'field': field, 'component': structure })
                     }
                 } else {
@@ -109,24 +100,17 @@ export default {
                     let matches = value.matchAll(reg)
                     for (let match of matches) {
                         let structure = this.returnStructureByGUID(targetGuid)
-                        console.info("struct: ", structure)
+                        console.info("structure: ", structure)
                         this.matches.push({ 'match': match, 'text': value, 'field': field, 'component': structure })
                     }
                 }
             }
-
-            console.info("matches: ", this.matches)
-
         },
 
         replace(data) {
-            console.info("Replacing: ", data)
             let target = data.field
             let fieldGuid = target.getAttribute("data-guid")
             let targetGuid = target.getAttribute("data-parent")
-
-            console.info("\ttarget: ", target.value)
-
             let newText = target.value.slice(0, data.match.indices[0][0]) + this.replaceTarget + target.value.slice(data.match.indices[0][1])
 
             let pp
@@ -137,18 +121,12 @@ export default {
                 console.error("Error building PropertyPath: ", err)
                 return
             }
+            console.info("pp: ", pp)
             let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
-            console.info("\tcurrentValue: ", currentValue)
-            console.info("\tnewText: ", newText)
+            console.info("currentValue: ", currentValue)
 
             for (let val of currentValue) {
                 if ((val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null) {
-                    // console.info("\tdo it")
-                    // console.info("\t\t", targetGuid)
-                    // console.info("\t\t", fieldGuid)
-                    // console.info("\t\t", pp)
-                    // console.info("\t\t", newText)
-                    // console.info("\t\t", val['@language'])
                     this.setValueLiteral(targetGuid, fieldGuid, pp, newText, val['@language'], false)
                     target.value = newText
                 }
@@ -156,15 +134,6 @@ export default {
         },
 
         loopLiteralsToReplace(all = false) {
-
-            /**
-             * TODO:
-             *   - [X] Case matching
-             *   - [X] How to handle mulitple matches in 1 textarea
-             *   - [X] Replace All
-             *   - [] Handle non-Latin?
-             */
-
             console.info("replacing")
             if (!this.replaceTarget) {
                 let cont = confirm("There's no replacement text. Continuing will delete text.")
@@ -173,9 +142,6 @@ export default {
             if (!all) {
                 let target = this.matches[this.activeMatch]
                 this.replace(target)
-                // if (this.activeMatch < this.matches.length){
-                //     this.activeMatch++
-                // }
             } else {
                 for (let target of this.matches) {
                     this.replace(target)
@@ -202,6 +168,11 @@ export default {
             }
 
             return text
+        },
+
+        jumpToComponent(pName, eName){
+            this.showFindReplaceModal = false
+            this.activeComponent = this.activeProfile.rt[pName].pt[eName]
         },
 
 
@@ -238,7 +209,6 @@ export default {
                         <button class="close-button" @pointerup="close">X</button>
                     </div>
                     <h2>Find & Replace</h2>
-                    {{ initalHeight }}
                     <div class="container-search">
                         <div class="search-fields">
                             <label for="input-find" onclick="" class="toggle-btn">Find: </label>
@@ -265,13 +235,15 @@ export default {
                         <table>
                             <thead>
                                 <tr>
+                                    <th>Source</th>
                                     <th>Component</th>
                                     <th>Value</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr v-for="(match, idx) of matches">
-                                    <td class="component-label">{{ match.component.propertyLabel }}</td>
+                                    <td>{{ match.component.parentId.split(":").at(-1) }}</td>
+                                    <td class="component-label" @click="jumpToComponent(match.component.parentId, match.component.id)">{{ match.component.propertyLabel }}</td>
                                     <td :class="{ active: activeMatch === idx }" @click="activeMatch = idx"
                                         v-html="buildDisplay(match.text, match)">
                                     </td>
@@ -316,6 +288,10 @@ span.match-bold {
 </style>
 
 <style scoped>
+.component-label {
+    cursor: 'pointer';
+}
+
 .container-search {
     display: table;
 }

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -21,7 +21,8 @@ export default {
             top: 100,
             left: 0,
 
-            initalHeight: 700,
+            initialWidth: 900,
+            initalHeight: 500,
             initalLeft: 400,
 
             iconColor: '#000000',
@@ -52,7 +53,7 @@ export default {
     },
 
     watch: {
-        matchCase(newVal, oldVal){
+        matchCase(newVal, oldVal) {
             console.info("newVal: ", newVal)
             console.info("oldVal: ", oldVal)
             this.matchCase = newVal
@@ -91,26 +92,34 @@ export default {
 
             let literals = document.getElementsByTagName('textarea')
             for (let field of literals) {
+                let fieldGuid = field.getAttribute("data-guid")
+                let targetGuid = field.getAttribute("data-parent")
+
                 let value = field.value
                 if (!this.matchCase) {
                     let reg = new RegExp(this.findTarget, "dig")
                     let matches = value.matchAll(reg)
-                    for (let match of matches){
-                        this.matches.push({'match': match, 'text': value, 'field': field})
+                    for (let match of matches) {
+                        let structure = this.returnStructureByGUID(targetGuid)
+                        console.info("struct: ", structure)
+                        this.matches.push({ 'match': match, 'text': value, 'field': field, 'component': structure })
                     }
                 } else {
                     let reg = new RegExp(this.findTarget, "dg")
                     let matches = value.matchAll(reg)
-                    for (let match of matches){
-                        this.matches.push({'match': match, 'text': value, 'field': field})
+                    for (let match of matches) {
+                        let structure = this.returnStructureByGUID(targetGuid)
+                        console.info("struct: ", structure)
+                        this.matches.push({ 'match': match, 'text': value, 'field': field, 'component': structure })
                     }
                 }
             }
 
             console.info("matches: ", this.matches)
+
         },
 
-        replace(data){
+        replace(data) {
             console.info("Replacing: ", data)
             let target = data.field
             let fieldGuid = target.getAttribute("data-guid")
@@ -124,7 +133,7 @@ export default {
             try {
                 let structure = this.returnStructureByGUID(targetGuid)
                 pp = this.buildPropertyPath(structure, [], fieldGuid)
-            } catch(err){
+            } catch (err) {
                 console.error("Error building PropertyPath: ", err)
                 return
             }
@@ -132,8 +141,8 @@ export default {
             console.info("\tcurrentValue: ", currentValue)
             console.info("\tnewText: ", newText)
 
-            for (let val of currentValue){
-                if (( val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null){
+            for (let val of currentValue) {
+                if ((val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null) {
                     // console.info("\tdo it")
                     // console.info("\t\t", targetGuid)
                     // console.info("\t\t", fieldGuid)
@@ -151,35 +160,35 @@ export default {
             /**
              * TODO:
              *   - [X] Case matching
-             *   - [] How to handle mulitple matches in 1 textarea
-             *   - [] Replace All
+             *   - [X] How to handle mulitple matches in 1 textarea
+             *   - [X] Replace All
              *   - [] Handle non-Latin?
              */
 
             console.info("replacing")
-            if (!this.replaceTarget){
+            if (!this.replaceTarget) {
                 let cont = confirm("There's no replacement text. Continuing will delete text.")
-                if (!cont){ return }
+                if (!cont) { return }
             }
-            if (!all){
+            if (!all) {
                 let target = this.matches[this.activeMatch]
                 this.replace(target)
                 // if (this.activeMatch < this.matches.length){
                 //     this.activeMatch++
                 // }
             } else {
-                for (let target of this.matches){
+                for (let target of this.matches) {
                     this.replace(target)
                 }
             }
 
 
-            setTimeout(()=>{
+            setTimeout(() => {
                 this.find()
             }, 500)
         },
 
-        buildDisplay(text, details){
+        buildDisplay(text, details) {
             // wrap target text in HTML to style it
             let target = this.findTarget
             const tag = "<span class='match-bold'>"
@@ -187,9 +196,9 @@ export default {
             const idxStart = details.match.indices[0][0]
             const idxEnd = Number(idxStart) + target.length + tag.length
 
-            if (idxStart >= 0 && idxEnd >= 0 ){
+            if (idxStart >= 0 && idxEnd >= 0) {
                 text = text.slice(0, idxStart) + tag + text.slice(idxStart);
-                text = text.slice(0, idxStart+tag.length + target.length) + "</span>" + text.slice(idxEnd)
+                text = text.slice(0, idxStart + tag.length + target.length) + "</span>" + text.slice(idxEnd)
             }
 
             return text
@@ -217,55 +226,70 @@ export default {
 
 
     <VueFinalModal display-directive="show" :hide-overlay="false" :overlay-transition="'vfm-fade'">
-        <VueDragResize :is-active="true" :w="850" :h="initalHeight" :x="initalLeft" :y="50" class="debug-modal"
-            @resizing="dragResize" @dragging="dragResize" :sticks="['br']" :stickSize="22">
-            <div id="panel-resize-content" ref="panelResizeContent" @mousedown="onSelectElement($event)"
-                @touchstart="onSelectElement($event)">
-                <div class="menu-buttons">
-                    <button class="close-button" @pointerup="close">X</button>
+        <div
+            >
+            <VueDragResize :is-active="true" :w="initialWidth" :h="initalHeight" :x="initalLeft" :y="50" class="debug-modal"
+                @resizing="dragResize" @dragging="dragResize" :sticks="['br']" :stickSize="22"
+                :style="`${this.preferenceStore.styleModalBackgroundColor()}; ${this.preferenceStore.styleModalTextColor()}`"
+                >
+                <div id="panel-resize-content" ref="panelResizeContent" @mousedown="onSelectElement($event)"
+                    @touchstart="onSelectElement($event)">
+                    <div class="menu-buttons">
+                        <button class="close-button" @pointerup="close">X</button>
+                    </div>
+                    <h2>Find & Replace</h2>
+                    {{ initalHeight }}
+                    <div class="container-search">
+                        <div class="search-fields">
+                            <label for="input-find" onclick="" class="toggle-btn">Find: </label>
+                            <input id="input-find" type="text" class="search-mode-radio" v-model="findTarget"
+                                name="inputFind" autofocus />
+                            &nbsp;&nbsp;&nbsp;
+                            <label for="input-case" onclick="" class="toggle-btn">Match Case? </label>
+                            <input id="input-case" type="checkbox" class="search-mode-radio" v-model="matchCase"
+                                name="inputFind" />
+                        </div>
+
+                        <div class="search-fields">
+                            <label for="input-replace" onclick="" class="toggle-btn">Replace: </label>
+                            <input id="input-replace" type="text" class="search-mode-radio" v-model="replaceTarget"
+                                name="inputReplace" />
+                        </div>
+
+                        <br>
+
+                        <button @click="find">Find</button>
+                    </div>
+
+                    <div v-if="matches.length >= 0" class="container-results">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Component</th>
+                                    <th>Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-for="(match, idx) of matches">
+                                    <td class="component-label">{{ match.component.propertyLabel }}</td>
+                                    <td :class="{ active: activeMatch === idx }" @click="activeMatch = idx"
+                                        v-html="buildDisplay(match.text, match)">
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+
+                        <button @click="loopLiteralsToReplace()">Replace</button>
+                        <button @click="loopLiteralsToReplace(true)">Replace All</button>
+                    </div>
+
                 </div>
-                <h2>Find & Replace</h2>
-
-                <div class="container-search">
-                    <label for="input-find" onclick="" class="toggle-btn">Find: </label>
-                    <input id="input-find" type="text" class="search-mode-radio" v-model="findTarget"
-                        name="inputFind" />
-
-                    <label for="input-case" onclick="" class="toggle-btn">Match Case? </label>
-                    <input id="input-case" type="checkbox" class="search-mode-radio" v-model="matchCase"
-                        name="inputFind" />
-
-                    <br>
-
-                    <label for="input-replace" onclick="" class="toggle-btn">Replace: </label>
-                    <input id="input-replace" type="text" class="search-mode-radio" v-model="replaceTarget"
-                        name="inputReplace" />
-
-                    <br>
-
-                    <button @click="find">Find</button>
-                </div>
-
-                <div v-if="matches.length > 0" class="container-results">
-                    <table>
-                        <tbody>
-                            <tr v-for="(match, idx) of matches">
-                                <td :class="{ active: activeMatch === idx }" @click="activeMatch = idx" v-html="buildDisplay(match.text, match)">
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-
-                    <button @click="loopLiteralsToReplace()">Replace</button>
-                    <button @click="loopLiteralsToReplace(true)">Replace All</button>
-                </div>
-
-            </div>
 
 
 
 
-        </VueDragResize>
+            </VueDragResize>
+        </div>
     </VueFinalModal>
 
 
@@ -273,26 +297,70 @@ export default {
 
 </template>
 <style>
-
 span.match-bold {
     font-weight: bolder;
     font-size: 16px;
 }
 
+.content-container {
+    padding: 10px;
+    background-color: unset;
+}
+
+.container-results {
+    padding-top: 15px;
+    max-height: 50%;
+    width: 100%;
+    overflow: scroll;
+}
 </style>
 
 <style scoped>
+.container-search {
+    display: table;
+}
+.search-fields {
+    display: table-row;
+}
+
+label,
+input{
+    display: table-cell
+}
+
+.container-search {
+    padding-top: 5px;
+}
+
+.menu-buttons {
+    margin-right: 5px;
+    padding-top: 5px;
+    padding-left: 15px;
+    float: right;
+    z-index: 99;
+}
+
 table {
     border-collapse: collapse;
     border: 2px solid rgb(140 140 140);
     font-family: sans-serif;
     font-size: 0.8rem;
     letter-spacing: 1px;
+
+    width: 100%;
+    margin-bottom: 15px;
 }
 
+th {
+    font-weight: bold;
+    font-size: 14px;
+}
+
+th,
 td {
     border: 1px solid rgb(160 160 160);
     padding: 8px 10px;
+    text-align: center;
 }
 
 .active {

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -92,7 +92,6 @@ export default {
                     let matches = value.matchAll(reg)
                     for (let match of matches) {
                         let structure = this.returnStructureByGUID(targetGuid)
-                        console.info("structure: ", structure)
                         this.matches.push({ 'match': match, 'text': value, 'field': field, 'component': structure })
                     }
                 } else {
@@ -100,7 +99,6 @@ export default {
                     let matches = value.matchAll(reg)
                     for (let match of matches) {
                         let structure = this.returnStructureByGUID(targetGuid)
-                        console.info("structure: ", structure)
                         this.matches.push({ 'match': match, 'text': value, 'field': field, 'component': structure })
                     }
                 }
@@ -121,9 +119,7 @@ export default {
                 console.error("Error building PropertyPath: ", err)
                 return
             }
-            console.info("pp: ", pp)
             let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
-            console.info("currentValue: ", currentValue)
 
             for (let val of currentValue) {
                 if ((val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null) {
@@ -134,7 +130,6 @@ export default {
         },
 
         loopLiteralsToReplace(all = false) {
-            console.info("replacing")
             if (!this.replaceTarget) {
                 let cont = confirm("There's no replacement text. Continuing will delete text.")
                 if (!cont) { return }
@@ -142,6 +137,9 @@ export default {
             if (!all) {
                 let target = this.matches[this.activeMatch]
                 this.replace(target)
+                if (this.activeMatch < this.matches.length-1){
+                    this.activeMatch++
+                }
             } else {
                 for (let target of this.matches) {
                     this.replace(target)
@@ -286,12 +284,14 @@ span.match-bold {
     width: 100%;
     overflow: scroll;
 }
+
+.component-label {
+    cursor: pointer;
+}
 </style>
 
 <style scoped>
-.component-label {
-    cursor: 'pointer';
-}
+
 
 .container-search {
     display: table;

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -1,0 +1,255 @@
+<script>
+import { usePreferenceStore } from '@/stores/preference'
+// import { useConfigStore } from '@/stores/config'
+import { useProfileStore } from '@/stores/profile'
+
+import { mapStores, mapState, mapWritableState } from 'pinia'
+import { VueFinalModal } from 'vue-final-modal'
+import VueDragResize from 'vue3-drag-resize'
+import "vue3-colorpicker/style.css";
+
+export default {
+    components: {
+        VueFinalModal,
+        VueDragResize,
+    },
+
+    data() {
+        return {
+            width: 0,
+            height: 0,
+            top: 100,
+            left: 0,
+
+            initalHeight: 700,
+            initalLeft: 400,
+
+            iconColor: '#000000',
+
+            customIcon: '',
+
+            presetIcon: null,
+            useAsDefault: false,
+
+
+            findTarget: '',
+            replaceTarget: '',
+            activeMatch: 0,
+            matches: [],
+            matchCase: false,
+
+        }
+    },
+    computed: {
+        ...mapStores(useProfileStore, usePreferenceStore),
+        ...mapWritableState(usePreferenceStore, ['showFindReplaceModal', 'panelDisplay', 'panelSizePresets']),
+        ...mapWritableState(useProfileStore, ['activeProfile', 'findLiterals', 'setValueLiteral', 'buildPropertyPath', 'returnStructureByGUID', 'returnLiteralValueFromProfile']),
+
+
+
+
+
+    },
+
+    watch: {
+
+
+    },
+
+    methods: {
+
+        dragResize: function (newRect) {
+            this.width = newRect.width
+            this.height = newRect.height
+            this.top = newRect.top
+            this.left = newRect.left
+        },
+
+        onSelectElement(event) {
+            const tagName = event.target.tagName
+            if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'LABEL' || tagName === 'SELECT' || tagName === 'SPAN' || tagName == 'INPUT' || tagName === 'TD') {
+                event.stopPropagation()
+            }
+        },
+
+        close() {
+            this.matches = []
+            this.showFindReplaceModal = false
+        },
+
+        find() {
+            this.matches = []
+            console.info("finding: ", this.findTarget)
+            console.info("activeProfile: ", this.activeProfile)
+
+            let literals = document.getElementsByTagName('textarea')
+            for (let field of literals) {
+                let value = field.value
+                if (!this.matchCase) {
+                    if (value.toLocaleLowerCase().includes(this.findTarget.toLocaleLowerCase())) {
+                        this.matches.push(field)
+                    }
+                } else {
+                    if (value.includes(this.findTarget)) {
+                        this.matches.push(field)
+                    }
+                }
+            }
+
+            console.info("matches: ", this.matches)
+        },
+
+        replace(all = false) {
+            console.info("replacing")
+            if (!this.replaceTarget){
+                let cont = confirm("There's no replacement text. Continuing will delete text.")
+                if (!cont){ return }
+            }
+            if (!all){
+                let target = this.matches[this.activeMatch]
+                let fieldGuid = target.getAttribute("data-guid")
+                let targetGuid = target.getAttribute("data-parent")
+                // need to account for matching case
+                let newText = target.value.replace(this.findTarget, this.replaceTarget)
+
+                let pp
+                try {
+                    let structure = this.returnStructureByGUID(targetGuid)
+                    pp = this.buildPropertyPath(structure, [], fieldGuid)
+                } catch(err){
+                    console.error("Error building PropertyPath: ", err)
+                    return
+                }
+                let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
+                console.info("currentValue: ", currentValue)
+
+                for (let val of currentValue){
+                    if (( val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null){
+                        this.setValueLiteral(targetGuid, fieldGuid, pp, newText, val['@language'], false)
+                    }
+                }
+            } else {
+
+            }
+
+            // do search again
+            this.find()
+        },
+
+        buildDisplay(text){
+            // TODO account for case matching
+            let target = this.findTarget
+            const tag = "<span class='match-bold'>"
+            const idxStart = text.indexOf(target);
+            const idxEnd = Number(idxStart) + target.length + tag.length
+
+            text = text.slice(0, idxStart) + tag + text.slice(idxStart);
+            text = text.slice(0, idxStart+tag.length + target.length) + "</span>" + text.slice(idxEnd)
+
+            return text
+        },
+
+
+    },
+
+
+    created() {
+
+
+    },
+
+    async mounted() {
+        this.panelSizePresets = this.preferenceStore.returnValue('--o-edit-main-splitpane-edit-panel-size-presets')
+    }
+}
+
+
+
+</script>
+
+<template>
+
+
+    <VueFinalModal display-directive="show" :hide-overlay="false" :overlay-transition="'vfm-fade'">
+        <VueDragResize :is-active="true" :w="850" :h="initalHeight" :x="initalLeft" :y="50" class="debug-modal"
+            @resizing="dragResize" @dragging="dragResize" :sticks="['br']" :stickSize="22">
+            <div id="panel-resize-content" ref="panelResizeContent" @mousedown="onSelectElement($event)"
+                @touchstart="onSelectElement($event)">
+                <div class="menu-buttons">
+                    <button class="close-button" @pointerup="close">X</button>
+                </div>
+                <h2>Find & Replace</h2>
+
+                <div class="container-search">
+                    <label for="input-find" onclick="" class="toggle-btn">Find: </label>
+                    <input id="input-find" type="text" class="search-mode-radio" v-model="findTarget"
+                        name="inputFind" />
+
+                    <label for="input-case" onclick="" class="toggle-btn">Match Case? </label>
+                    <input id="input-case" type="checkbox" class="search-mode-radio" v-model="matchCase"
+                        name="inputFind" />
+
+                    <br>
+
+                    <label for="input-replace" onclick="" class="toggle-btn">Replace: </label>
+                    <input id="input-replace" type="text" class="search-mode-radio" v-model="replaceTarget"
+                        name="inputReplace" />
+
+                    <br>
+
+                    <button @click="find">Find</button>
+                </div>
+
+                <div v-if="matches.length > 0" class="container-results">
+                    <table>
+                        <tbody>
+                            <tr v-for="(match, idx) of matches">
+                                <td :class="{ active: activeMatch === idx }" @click="activeMatch = idx" v-html="buildDisplay(match.value)">
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <button @click="replace()">Replace</button>
+                    <button @click="replace(true)">Replace All</button>
+                </div>
+
+            </div>
+
+
+
+
+        </VueDragResize>
+    </VueFinalModal>
+
+
+
+
+</template>
+<style>
+
+span.match-bold {
+    font-weight: bolder;
+    font-size: 16px;
+}
+
+</style>
+
+<style scoped>
+table {
+    border-collapse: collapse;
+    border: 2px solid rgb(140 140 140);
+    font-family: sans-serif;
+    font-size: 0.8rem;
+    letter-spacing: 1px;
+}
+
+td {
+    border: 1px solid rgb(160 160 160);
+    padding: 8px 10px;
+}
+
+.active {
+    background-color: rgb(131, 131, 255);
+}
+</style>

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -210,25 +210,26 @@ export default {
                     </div>
                     <h2>Find & Replace</h2>
                     <div class="container-search">
-                        <div class="search-fields">
-                            <label for="input-find" onclick="" class="toggle-btn">Find: </label>
-                            <input id="input-find" type="text" class="search-mode-radio" v-model="findTarget"
-                                name="inputFind" autofocus />
-                            &nbsp;&nbsp;&nbsp;
-                            <label for="input-case" onclick="" class="toggle-btn">Match Case? </label>
-                            <input id="input-case" type="checkbox" class="search-mode-radio" v-model="matchCase"
-                                name="inputFind" />
-                        </div>
+                        <form ref="urlToLoadForm" v-on:submit.prevent="">
+                            <div class="search-fields">
+                                <label for="input-find" onclick="" class="toggle-btn">Find: </label>
+                                <input id="input-find" type="text" class="search-mode-radio" v-model="findTarget"
+                                    name="inputFind" autofocus />
+                                &nbsp;&nbsp;&nbsp;
+                                <label for="input-case" onclick="" class="toggle-btn">Match Case? </label>
+                                <input id="input-case" type="checkbox" class="search-mode-radio" v-model="matchCase"
+                                    name="inputFind" />
+                            </div>
 
-                        <div class="search-fields">
-                            <label for="input-replace" onclick="" class="toggle-btn">Replace: </label>
-                            <input id="input-replace" type="text" class="search-mode-radio" v-model="replaceTarget"
-                                name="inputReplace" />
-                        </div>
+                            <div class="search-fields">
+                                <label for="input-replace" onclick="" class="toggle-btn">Replace: </label>
+                                <input id="input-replace" type="text" class="search-mode-radio" v-model="replaceTarget"
+                                    name="inputReplace" />
+                            </div>
+                            <br>
+                            <button @click="find">Find</button>
+                        </form>
 
-                        <br>
-
-                        <button @click="find">Find</button>
                     </div>
 
                     <div v-if="matches.length >= 0" class="container-results">

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -52,7 +52,12 @@ export default {
     },
 
     watch: {
-
+        matchCase(newVal, oldVal){
+            console.info("newVal: ", newVal)
+            console.info("oldVal: ", oldVal)
+            this.matchCase = newVal
+            this.find()
+        }
 
     },
 
@@ -80,18 +85,24 @@ export default {
         find() {
             this.matches = []
             console.info("finding: ", this.findTarget)
-            console.info("activeProfile: ", this.activeProfile)
+            console.info("\tactiveProfile: ", this.activeProfile)
+            console.info("\tmatchCase? ", this.matchCase)
+            console.info("\tmatches: ", this.matches)
 
             let literals = document.getElementsByTagName('textarea')
             for (let field of literals) {
                 let value = field.value
                 if (!this.matchCase) {
-                    if (value.toLocaleLowerCase().includes(this.findTarget.toLocaleLowerCase())) {
-                        this.matches.push(field)
+                    let reg = new RegExp(this.findTarget, "dig")
+                    let matches = value.matchAll(reg)
+                    for (let match of matches){
+                        this.matches.push({'match': match, 'text': value, 'field': field})
                     }
                 } else {
-                    if (value.includes(this.findTarget)) {
-                        this.matches.push(field)
+                    let reg = new RegExp(this.findTarget, "dg")
+                    let matches = value.matchAll(reg)
+                    for (let match of matches){
+                        this.matches.push({'match': match, 'text': value, 'field': field})
                     }
                 }
             }
@@ -99,7 +110,52 @@ export default {
             console.info("matches: ", this.matches)
         },
 
-        replace(all = false) {
+        replace(data){
+            console.info("Replacing: ", data)
+            let target = data.field
+            let fieldGuid = target.getAttribute("data-guid")
+            let targetGuid = target.getAttribute("data-parent")
+
+            console.info("\ttarget: ", target.value)
+
+            let newText = target.value.slice(0, data.match.indices[0][0]) + this.replaceTarget + target.value.slice(data.match.indices[0][1])
+
+            let pp
+            try {
+                let structure = this.returnStructureByGUID(targetGuid)
+                pp = this.buildPropertyPath(structure, [], fieldGuid)
+            } catch(err){
+                console.error("Error building PropertyPath: ", err)
+                return
+            }
+            let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
+            console.info("\tcurrentValue: ", currentValue)
+            console.info("\tnewText: ", newText)
+
+            for (let val of currentValue){
+                if (( val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null){
+                    // console.info("\tdo it")
+                    // console.info("\t\t", targetGuid)
+                    // console.info("\t\t", fieldGuid)
+                    // console.info("\t\t", pp)
+                    // console.info("\t\t", newText)
+                    // console.info("\t\t", val['@language'])
+                    this.setValueLiteral(targetGuid, fieldGuid, pp, newText, val['@language'], false)
+                    target.value = newText
+                }
+            }
+        },
+
+        loopLiteralsToReplace(all = false) {
+
+            /**
+             * TODO:
+             *   - [X] Case matching
+             *   - [] How to handle mulitple matches in 1 textarea
+             *   - [] Replace All
+             *   - [] Handle non-Latin?
+             */
+
             console.info("replacing")
             if (!this.replaceTarget){
                 let cont = confirm("There's no replacement text. Continuing will delete text.")
@@ -107,44 +163,34 @@ export default {
             }
             if (!all){
                 let target = this.matches[this.activeMatch]
-                let fieldGuid = target.getAttribute("data-guid")
-                let targetGuid = target.getAttribute("data-parent")
-                // need to account for matching case
-                let newText = target.value.replace(this.findTarget, this.replaceTarget)
-
-                let pp
-                try {
-                    let structure = this.returnStructureByGUID(targetGuid)
-                    pp = this.buildPropertyPath(structure, [], fieldGuid)
-                } catch(err){
-                    console.error("Error building PropertyPath: ", err)
-                    return
-                }
-                let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
-                console.info("currentValue: ", currentValue)
-
-                for (let val of currentValue){
-                    if (( val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null){
-                        this.setValueLiteral(targetGuid, fieldGuid, pp, newText, val['@language'], false)
-                    }
-                }
+                this.replace(target)
+                // if (this.activeMatch < this.matches.length){
+                //     this.activeMatch++
+                // }
             } else {
-
+                for (let target of this.matches){
+                    this.replace(target)
+                }
             }
 
-            // do search again
-            this.find()
+
+            setTimeout(()=>{
+                this.find()
+            }, 500)
         },
 
-        buildDisplay(text){
-            // TODO account for case matching
+        buildDisplay(text, details){
+            // wrap target text in HTML to style it
             let target = this.findTarget
             const tag = "<span class='match-bold'>"
-            const idxStart = text.indexOf(target);
+
+            const idxStart = details.match.indices[0][0]
             const idxEnd = Number(idxStart) + target.length + tag.length
 
-            text = text.slice(0, idxStart) + tag + text.slice(idxStart);
-            text = text.slice(0, idxStart+tag.length + target.length) + "</span>" + text.slice(idxEnd)
+            if (idxStart >= 0 && idxEnd >= 0 ){
+                text = text.slice(0, idxStart) + tag + text.slice(idxStart);
+                text = text.slice(0, idxStart+tag.length + target.length) + "</span>" + text.slice(idxEnd)
+            }
 
             return text
         },
@@ -204,14 +250,14 @@ export default {
                     <table>
                         <tbody>
                             <tr v-for="(match, idx) of matches">
-                                <td :class="{ active: activeMatch === idx }" @click="activeMatch = idx" v-html="buildDisplay(match.value)">
+                                <td :class="{ active: activeMatch === idx }" @click="activeMatch = idx" v-html="buildDisplay(match.text, match)">
                                 </td>
                             </tr>
                         </tbody>
                     </table>
 
-                    <button @click="replace()">Replace</button>
-                    <button @click="replace(true)">Replace All</button>
+                    <button @click="loopLiteralsToReplace()">Replace</button>
+                    <button @click="loopLiteralsToReplace(true)">Replace All</button>
                 </div>
 
             </div>

--- a/src/components/panels/edit/modals/FindReplaceModal.vue
+++ b/src/components/panels/edit/modals/FindReplaceModal.vue
@@ -242,7 +242,10 @@ export default {
                             <tbody>
                                 <tr v-for="(match, idx) of matches">
                                     <td>{{ match.component.parentId.split(":").at(-1) }}</td>
-                                    <td class="component-label" @click="jumpToComponent(match.component.parentId, match.component.id)">{{ match.component.propertyLabel }}</td>
+                                    <td class="component-label" @click="jumpToComponent(match.component.parentId, match.component.id)">
+                                        {{ match.component.propertyLabel }}
+                                        <span class="material-icons">move_down</span>
+                                    </td>
                                     <td :class="{ active: activeMatch === idx }" @click="activeMatch = idx"
                                         v-html="buildDisplay(match.text, match)">
                                     </td>

--- a/src/components/panels/edit/modals/PanelSizeModal.vue
+++ b/src/components/panels/edit/modals/PanelSizeModal.vue
@@ -163,6 +163,7 @@
           @dragging="dragResize"
           :sticks="['br']"
           :stickSize="22"
+          :style="`${this.preferenceStore.styleModalBackgroundColor()}; ${this.preferenceStore.styleModalTextColor()}`"
         >
           <div id="panel-resize-content" ref="panelResizeContent" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
             <div class="menu-buttons">
@@ -241,14 +242,17 @@
 </template>
 <style>
 
-  .content-container{
-
-    background-color: white;
-  }
+  /* .content-container{
+    background-color: white !important;
+  } */
 
 </style>
 
 <style scoped>
+
+  .content-container{
+    background-color: white !important;
+  }
 
   .icon-size{
     font-size: 2.5em;

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -304,6 +304,13 @@ export default {
                     hotkey: "ctrl+y",
                     // class: (this.profileStore.redoRecords.length > 0) ? "active" : "inactive",
                     click: () => { this.profileStore.redoChange() }
+                  },
+                  {
+                    text: "Title Case",
+                    title: "Title Case",
+                    icon: "titlecase",
+                    hotkey: "ctrl+alt+t",
+                    click: () => { this.profileStore.getHighlightedText() }
                   }
                 // )
               // }
@@ -899,7 +906,7 @@ export default {
         // if we are in staging try to find the staging workspace name and set it
         if (config.returnUrls.env === 'staging') {
           currentWorkspaceName = 'marva-stage'
-        } 
+        }
         if (config.returnUrls.isBibframeDotOrg){
           currentWorkspaceName = 'marva-prod'
         }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -35,6 +35,10 @@
         <PanelSizeModal v-model="showPanelSizeModal" />
       </template>
 
+      <template v-if="showFindReplaceModal == true">
+        <FindReplaceModal v-model="showFindReplaceModal" />
+      </template>
+
 
     </Teleport>
 
@@ -57,6 +61,7 @@ import AdHocModal from "@/components/panels/nav/AdHocModal.vue";
 import GenericSelectionModal from '../edit/modals/GenericSelectionModal.vue'
 
 import PanelSizeModal from '../edit/modals/PanelSizeModal.vue'
+import FindReplaceModal from '../edit/modals/FindReplaceModal.vue'
 
 import StatusIndicator from './nav_components/StatusIndicator.vue'
 import RecordHistory from './nav_components/RecordHistory.vue'
@@ -72,7 +77,7 @@ const timeAgo = new TimeAgo('en-US')
 
 
 export default {
-  components: { VueFileToolbarMenu, PostModal, ValidateModal, RecoveryModal, ItemInstanceSelectionModal, AdHocModal, GenericSelectionModal, PanelSizeModal },
+  components: { VueFileToolbarMenu, PostModal, ValidateModal, RecoveryModal, ItemInstanceSelectionModal, AdHocModal, GenericSelectionModal, PanelSizeModal, FindReplaceModal },
 
   data() {
     return {
@@ -103,7 +108,7 @@ export default {
     ...mapState(useProfileStore, ['profilesLoaded', 'activeProfile', 'rtLookup', 'activeProfileSaved', 'isEmptyComponent', 'returnComponentLibrary']),
     ...mapState(usePreferenceStore, ['styleDefault', 'showPrefModal', 'panelDisplay', 'customLayouts', 'createLayoutMode', 'panelSizePresets']),
     ...mapState(useConfigStore, ['layouts']),
-    ...mapWritableState(usePreferenceStore, ['showLoginModal', 'showLoginModalSSO', 'showScriptshifterConfigModal', 'showDiacriticConfigModal', 'showTextMacroModal', 'layoutActiveFilter', 'layoutActive', 'showFieldColorsModal', 'customLayouts', 'createLayoutMode', 'showPanelSizeModal']),
+    ...mapWritableState(usePreferenceStore, ['showLoginModal', 'showLoginModalSSO', 'showScriptshifterConfigModal', 'showDiacriticConfigModal', 'showTextMacroModal', 'layoutActiveFilter', 'layoutActive', 'showFieldColorsModal', 'customLayouts', 'createLayoutMode', 'showPanelSizeModal', 'showFindReplaceModal']),
     ...mapWritableState(useProfileStore, ['showPostModal', 'showShelfListingModal', 'activeShelfListData', 'showValidateModal', 'showRecoveryModal', 'showAutoDeweyModal', 'showYoshinoSubjectsModal', 'showItemInstanceSelection', 'showAdHocModal', 'emptyComponents', 'activeProfilePosted', 'activeProfilePostedTimestamp', 'copyCatMode', 'showUserDirectoryModal', 'showFolioSyncModal']),
     ...mapWritableState(useConfigStore, ['showNonLatinBulkModal', 'showNonLatinAgentModal']),
 
@@ -311,6 +316,13 @@ export default {
                     icon: "titlecase",
                     hotkey: "ctrl+alt+t",
                     click: () => { this.profileStore.getHighlightedText() }
+                  },
+                  {
+                    text: "Find & Replace",
+                    title: "find Replace",
+                    icon: "find_replace",
+                    hotkey: "ctrl+alt+h",
+                    click: () => { this.showFindReplaceModal = true; }
                   }
                 // )
               // }

--- a/src/components/panels/nav/Nav.vue
+++ b/src/components/panels/nav/Nav.vue
@@ -1130,7 +1130,7 @@ export default {
 
   methods: {
 
-    profileOrStaging(){
+    profileOrStaging(){ // TODO: get this back on the nav bar
       if (this.isStaging()) {
         return  "STAGING: "
       }

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -3498,7 +3498,13 @@ const utilsNetwork = {
     */
     scriptShifterRequestTrans: async function(lang,text,capitalize,t_dir){
 
-            let url = useConfigStore().returnUrls.scriptshifter + 'trans'
+      console.info("scriptShifterRequestTrans")
+      console.info("\tlang:", lang)
+      console.info("\ttext:", text)
+      console.info("\tcapitalize:", capitalize)
+      console.info("\tt_dir:", t_dir)
+
+      let url = useConfigStore().returnUrls.scriptshifter + 'trans'
 
       let r = await fetch(url, {
         method: 'POST',

--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -2596,10 +2596,6 @@ const utilsParse = {
 
 
 
-
-
-
-
 }
 
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -72,9 +72,9 @@ export const usePreferenceStore = defineStore('preference', {
     // keeps a copy of the orginal values to be able to reset
     styleDefaultOrginal: {},
     panelDisplayOrginal: {},
-
-
     copyMode: false,
+
+    showFindReplaceModal: false,
 
     panelDisplay:{
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -641,10 +641,10 @@ export const useProfileStore = defineStore('profile', {
             // if we are stage try to find stage
             if (config.returnUrls.env === 'staging') {
               defaultWs = wsData.data.find(ws => ws.name === 'marva-stage')
-            } 
+            }
             if (config.returnUrls.env === 'production') {
               defaultWs = wsData.data.find(ws => ws.name === 'marva-prod')
-            } 
+            }
 
             if (defaultWs) {
                 let dancerBaseUrl = config.returnUrls.dancerWorkspaceList.split('workspaces')[0]
@@ -8594,6 +8594,79 @@ export const useProfileStore = defineStore('profile', {
       if (usePreferenceStore().returnValue('--b-general-auto-save')){
         this.saveRecord()
       }
+    },
+
+    getHighlightedText: function(){
+      let titleCase = false
+      let highlightedText = window.getSelection ? window.getSelection().toString().trim() : ''
+      let el = false
+      if (highlightedText){
+        const selection = document.getSelection();
+        console.info("selection: ", selection)
+        console.info("selection: ", selection.anchorNode[0])
+        el = selection.anchorNode[0] // this doesn't work in firefox
+      }
+
+      if (el){
+        let fieldGuid = el.getAttribute("data-guid")
+        let targetGuid = el.getAttribute("data-parent")
+        let pt = utilsProfile.returnPt(this.activeProfile, targetGuid)
+        let structure = this.returnStructureByGUID(targetGuid)
+        // make titlecase
+        titleCase = this.toTitleCase(highlightedText)
+
+        // {level: 0, propertyURI: structure.propertyURI},
+        let pp = this.buildPropertyPath(structure, [], fieldGuid)
+        let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
+        this.setValueLiteral(targetGuid, fieldGuid, pp, currentValue[0].value.replace(highlightedText, titleCase), currentValue[0]['@language'], false)
+      }
+
+
+    },
+
+    toTitleCase: function (str) {
+      return str.replace(
+        /\w\S*/g,
+        text => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
+      );
+    },
+
+    /**
+     * Build the property path from the initial component GUID until we find the fieldGuid
+     *
+     * @param {Object} structure - Structure to build the propertyPath for
+     * @param {Object} pp - Starting propertyPath, has the first piece of the path
+     * @param {String} endGuid - target at the end of path
+     */
+    buildPropertyPath: function(structure, pp, endGuid){
+      let userValue = structure.userValue
+
+      // go through UserValue building path to endGuid
+      const traverse = (target, node) => {
+        if (node['@guid'] && node['@guid'] == target){
+          return
+        } else if(Array.isArray(node)) {
+          for (let el in node){
+            return traverse( target, node[el])
+          }
+        }else if (typeof node === "object"){
+          for (let key of Object.keys(node)){
+            if (!key.startsWith("@")){
+              pp.push(
+                {
+                  level: pp.length,
+                  propertyURI: key
+                }
+              )
+              return  traverse( target, node[key])
+            }
+          }
+        }
+      };
+
+      traverse(endGuid, userValue)
+
+      return pp
     },
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2033,6 +2033,8 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
+      console.info("setValueLiteral")
+      console.info("\tvalue: ", value)
       //Save
       //  componentGuid:  aiPuH4YsetZ9xmcv7rqisJ
       //  fieldGuid:  pdtUXGpNDJ9mz33JM3uxje
@@ -8596,7 +8598,7 @@ export const useProfileStore = defineStore('profile', {
       }
     },
 
-    getHighlightedText: function(){
+    getHighlightedText: async function(){
       let titleCase = false
       let highlightedText = window.getSelection ? window.getSelection().toString().trim() : ''
       let el = false
@@ -8618,7 +8620,42 @@ export const useProfileStore = defineStore('profile', {
         // {level: 0, propertyURI: structure.propertyURI},
         let pp = this.buildPropertyPath(structure, [], fieldGuid)
         let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
-        this.setValueLiteral(targetGuid, fieldGuid, pp, currentValue[0].value.replace(highlightedText, titleCase), currentValue[0]['@language'], false)
+
+        console.info("currentValue: ", currentValue)
+        if (currentValue.length > 1){
+          let newText = ""
+          let nonLatin = false
+          for (let val of currentValue){
+            if (val['@language'].toLowerCase().includes('latn')){
+              newText = val.value.replace(highlightedText, titleCase)
+              this.setValueLiteral(targetGuid, fieldGuid, pp, newText, val['@language'], false)
+            } else {
+              nonLatin = val
+            }
+          }
+
+          // Adjust the non-Latin form to match
+          let otherScriptCodes = false
+          const config = useConfigStore()
+          for (let key in config.scriptShifterLangCodes){
+            let codeObj = config.scriptShifterLangCodes[key]
+            console.info("codeObj", codeObj)
+            console.info("nonLatin['@language']", nonLatin['@language'])
+            if (nonLatin['@language'] && codeObj.code.toLowerCase() == nonLatin['@language'].toLowerCase()){
+              otherScriptCodes = key
+              console.info("otherScriptCodes: ", otherScriptCodes)
+              break
+            }
+          }
+
+          let transValue = await utilsNetwork.scriptShifterRequestTrans(otherScriptCodes, newText, false, "r2s") //abazin_cyrillic
+          console.info("transValue: ", transValue, "--", typeof transValue)
+          this.setValueLiteral(targetGuid, nonLatin['@guid'], pp, transValue.output, nonLatin['@language'], false)
+        } else {
+          this.setValueLiteral(targetGuid, fieldGuid, pp, currentValue[0].value.replace(highlightedText, titleCase), currentValue[0]['@language'], false)
+        }
+
+
       }
 
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2033,13 +2033,12 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
-      console.info("--------------------------\nsetValueLiteral")
-      console.info("\tcomponentGuid: ", componentGuid)
-      console.info("\tfieldGuid: ", fieldGuid)
-      console.info("\tpropertyPath: ", propertyPath)
-      console.info("\tvalue: ", )
-      console.info("\tlang: ", lang)
-      Save
+      // console.info("--------------------------\nsetValueLiteral")
+      // console.info("\tcomponentGuid: ", componentGuid)
+      // console.info("\tfieldGuid: ", fieldGuid)
+      // console.info("\tpropertyPath: ", propertyPath)
+      // console.info("\tvalue: ", )
+      // console.info("\tlang: ", lang)
       //  componentGuid:  aiPuH4YsetZ9xmcv7rqisJ
       //  fieldGuid:  pdtUXGpNDJ9mz33JM3uxje
 
@@ -8681,33 +8680,66 @@ export const useProfileStore = defineStore('profile', {
      * @param {String} endGuid - target at the end of path
      */
     buildPropertyPath: function(structure, pp, endGuid){
+      console.info("buildingPath to ", endGuid)
       let userValue = structure.userValue
 
       // go through UserValue building path to endGuid
+      // const traverse = (target, node) => {
+      //   console.info("travsering: ", node)
+      //   if (node['@guid'] && node['@guid'] == target){
+      //     return
+      //   } else if(Array.isArray(node)) {
+      //     for (let el in node){
+      //       return traverse( target, node[el])
+      //     }
+      //   } else if (typeof node === "object"){
+      //     for (let key of Object.keys(node)){
+      //       if (!key.startsWith("@")){
+      //         pp.push(
+      //           {
+      //             level: pp.length,
+      //             propertyURI: key
+      //           }
+      //         )
+      //         return  traverse( target, node[key])
+      //       }
+      //     }
+      //   }
+      // };
+
+      // https://stackoverflow.com/questions/53543303/find-a-full-object-path-to-a-given-value-with-javascript
       const traverse = (target, node) => {
-        if (node['@guid'] && node['@guid'] == target){
-          return
-        } else if(Array.isArray(node)) {
-          for (let el in node){
-            return traverse( target, node[el])
-          }
-        } else if (typeof node === "object"){
-          for (let key of Object.keys(node)){
-            if (!key.startsWith("@")){
-              pp.push(
-                {
-                  level: pp.length,
-                  propertyURI: key
-                }
-              )
-              return  traverse( target, node[key])
+        for (let el in node){
+          if (node[el] && typeof node[el] === "object"){
+            let result  = traverse(target, node[el])
+            if (result){
+              if (el.startsWith("http")){
+                result.unshift(el)
+              }
+              return result
+            }
+          } else if (node['@guid'] && node['@guid'] == target){
+            if (el.startsWith("http")){
+              return [el]
+            } else {
+              return []
             }
           }
         }
+
       };
 
-      traverse(endGuid, userValue)
+      let path = traverse(endGuid, userValue)
+      for (let p of path){
+        pp.push(
+          {
+            level: pp.length,
+            propertyURI: p
+          }
+        )
+      }
 
+      console.info("pp: ", pp)
       return pp
     },
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2033,6 +2033,12 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
+      // console.info("--------------------------\nsetValueLiteral")
+      // console.info("\tcomponentGuid: ", componentGuid)
+      // console.info("\tfieldGuid: ", fieldGuid)
+      // console.info("\tpropertyPath: ", propertyPath)
+      // console.info("\tvalue: ", )
+      // console.info("\tlang: ", lang)
       //Save
       //  componentGuid:  aiPuH4YsetZ9xmcv7rqisJ
       //  fieldGuid:  pdtUXGpNDJ9mz33JM3uxje

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2033,13 +2033,13 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
-      // console.info("--------------------------\nsetValueLiteral")
-      // console.info("\tcomponentGuid: ", componentGuid)
-      // console.info("\tfieldGuid: ", fieldGuid)
-      // console.info("\tpropertyPath: ", propertyPath)
-      // console.info("\tvalue: ", )
-      // console.info("\tlang: ", lang)
-      //Save
+      console.info("--------------------------\nsetValueLiteral")
+      console.info("\tcomponentGuid: ", componentGuid)
+      console.info("\tfieldGuid: ", fieldGuid)
+      console.info("\tpropertyPath: ", propertyPath)
+      console.info("\tvalue: ", )
+      console.info("\tlang: ", lang)
+      Save
       //  componentGuid:  aiPuH4YsetZ9xmcv7rqisJ
       //  fieldGuid:  pdtUXGpNDJ9mz33JM3uxje
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -2033,8 +2033,6 @@ export const useProfileStore = defineStore('profile', {
     * @return {void}
     */
     setValueLiteral: function(componentGuid, fieldGuid, propertyPath, value, lang, repeatedLiteral){
-      console.info("setValueLiteral")
-      console.info("\tvalue: ", value)
       //Save
       //  componentGuid:  aiPuH4YsetZ9xmcv7rqisJ
       //  fieldGuid:  pdtUXGpNDJ9mz33JM3uxje
@@ -8604,8 +8602,6 @@ export const useProfileStore = defineStore('profile', {
       let el = false
       if (highlightedText){
         const selection = document.getSelection();
-        console.info("selection: ", selection)
-        console.info("selection: ", selection.anchorNode[0])
         el = selection.anchorNode[0] // this doesn't work in firefox
       }
 
@@ -8618,10 +8614,15 @@ export const useProfileStore = defineStore('profile', {
         titleCase = this.toTitleCase(highlightedText)
 
         // {level: 0, propertyURI: structure.propertyURI},
-        let pp = this.buildPropertyPath(structure, [], fieldGuid)
+        let pp
+        try {
+          pp = this.buildPropertyPath(structure, [], fieldGuid)
+        } catch(err){
+          console.error("Error building PropertyPath: ", err)
+          return
+        }
         let currentValue = this.returnLiteralValueFromProfile(targetGuid, pp)
 
-        console.info("currentValue: ", currentValue)
         if (currentValue.length > 1){
           let newText = ""
           let nonLatin = false
@@ -8639,17 +8640,13 @@ export const useProfileStore = defineStore('profile', {
           const config = useConfigStore()
           for (let key in config.scriptShifterLangCodes){
             let codeObj = config.scriptShifterLangCodes[key]
-            console.info("codeObj", codeObj)
-            console.info("nonLatin['@language']", nonLatin['@language'])
             if (nonLatin['@language'] && codeObj.code.toLowerCase() == nonLatin['@language'].toLowerCase()){
               otherScriptCodes = key
-              console.info("otherScriptCodes: ", otherScriptCodes)
               break
             }
           }
 
           let transValue = await utilsNetwork.scriptShifterRequestTrans(otherScriptCodes, newText, false, "r2s") //abazin_cyrillic
-          console.info("transValue: ", transValue, "--", typeof transValue)
           this.setValueLiteral(targetGuid, nonLatin['@guid'], pp, transValue.output, nonLatin['@language'], false)
         } else {
           this.setValueLiteral(targetGuid, fieldGuid, pp, currentValue[0].value.replace(highlightedText, titleCase), currentValue[0]['@language'], false)

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -8676,36 +8676,11 @@ export const useProfileStore = defineStore('profile', {
      * Build the property path from the initial component GUID until we find the fieldGuid
      *
      * @param {Object} structure - Structure to build the propertyPath for
-     * @param {Object} pp - Starting propertyPath, has the first piece of the path
+     * @param {Object} pp - Starting propertyPath
      * @param {String} endGuid - target at the end of path
      */
     buildPropertyPath: function(structure, pp, endGuid){
-      console.info("buildingPath to ", endGuid)
       let userValue = structure.userValue
-
-      // go through UserValue building path to endGuid
-      // const traverse = (target, node) => {
-      //   console.info("travsering: ", node)
-      //   if (node['@guid'] && node['@guid'] == target){
-      //     return
-      //   } else if(Array.isArray(node)) {
-      //     for (let el in node){
-      //       return traverse( target, node[el])
-      //     }
-      //   } else if (typeof node === "object"){
-      //     for (let key of Object.keys(node)){
-      //       if (!key.startsWith("@")){
-      //         pp.push(
-      //           {
-      //             level: pp.length,
-      //             propertyURI: key
-      //           }
-      //         )
-      //         return  traverse( target, node[key])
-      //       }
-      //     }
-      //   }
-      // };
 
       // https://stackoverflow.com/questions/53543303/find-a-full-object-path-to-a-given-value-with-javascript
       const traverse = (target, node) => {
@@ -8739,7 +8714,6 @@ export const useProfileStore = defineStore('profile', {
         )
       }
 
-      console.info("pp: ", pp)
       return pp
     },
 

--- a/src/stores/profile.js
+++ b/src/stores/profile.js
@@ -8601,8 +8601,10 @@ export const useProfileStore = defineStore('profile', {
       let highlightedText = window.getSelection ? window.getSelection().toString().trim() : ''
       let el = false
       if (highlightedText){
-        const selection = document.getSelection();
-        el = selection.anchorNode[0] // this doesn't work in firefox
+        const selection = window.getSelection();
+        try {
+          el = selection.anchorNode[0] // this doesn't work in firefox
+        } catch(err){}
       }
 
       if (el){
@@ -8627,7 +8629,7 @@ export const useProfileStore = defineStore('profile', {
           let newText = ""
           let nonLatin = false
           for (let val of currentValue){
-            if (val['@language'].toLowerCase().includes('latn')){
+            if (( val['@language'] && val['@language'].toLowerCase().includes('latn')) || val['@language'] == null){
               newText = val.value.replace(highlightedText, titleCase)
               this.setValueLiteral(targetGuid, fieldGuid, pp, newText, val['@language'], false)
             } else {
@@ -8683,7 +8685,7 @@ export const useProfileStore = defineStore('profile', {
           for (let el in node){
             return traverse( target, node[el])
           }
-        }else if (typeof node === "object"){
+        } else if (typeof node === "object"){
           for (let key of Object.keys(node)){
             if (!key.startsWith("@")){
               pp.push(
@@ -8702,7 +8704,6 @@ export const useProfileStore = defineStore('profile', {
 
       return pp
     },
-
 
 
 

--- a/src/views/copyCatComponents/RecordComparison.vue
+++ b/src/views/copyCatComponents/RecordComparison.vue
@@ -124,12 +124,10 @@ export default {
             }
         },
         createCopyCat: function(){
-            console.info("creating")
             this.$emit('createCopyCat')
         },
 
         cancelCopyCat: function(){
-            console.info("canceling")
             this.$emit('cancelCopyCat')
         },
 


### PR DESCRIPTION
Added
- Find and Replace to Marva - `ctrl+alt+h`
- Ability to title case highlighted text - `ctrl+alt+t` [don't work so well in FireFox]

Both are available as shortcuts, or under Menu > Edit.

Find and replace will open a modal. Results will have the string the search value is found in, the component's label, and the "source" (Work, Instance, Item...). Can replace all or some of the matching values. If a string contains the value multiple times, each will be display independently. Clicking the "component," will close the search and jump to that component in the record.

<img width="994" height="577" alt="image" src="https://github.com/user-attachments/assets/a3578a6e-02c4-4167-b6c5-97f0d8c276b2" />


Title Case is a quick way to change the casing of highlighted text. Sometimes CIP can come in with text that is all caps and needs to be changed.

<img width="362" height="129" alt="image" src="https://github.com/user-attachments/assets/2cac674f-95a3-4602-9955-401e6c1deb77" />

<img width="344" height="104" alt="image" src="https://github.com/user-attachments/assets/135cbe26-6196-4e80-8223-6b9164543293" />
