### PR TITLE
Improve SOR splitting regex for `and`

### DIFF
--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -1585,25 +1585,7 @@
             }
           }
 
-          // /\s{1};\s{1}|,\s*(?=[^)^\]]*(?:\(|\[|$))|\&|and|und/g) --> split on <space>;<space> and commas not in ()
-          // favor splitting on semicolon. Seems reliable to get the first name without bleed from other names. But after that, anything can happen
-          if (this.statementOfResponsibility && this.statementOfResponsibility.split(/;\s+and|und|\&\s+|\s+e\s+|;/g).length>1){
-            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/;\s+and|und|\&\s+|\s+e\s+|;/g)
-          } else if (this.statementOfResponsibility && this.statementOfResponsibility.split(/,\s+and|und|\&\s+|,/g).length>1){
-            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/,\s+and|und|\&\s+|,/g)
-          } else if (this.statementOfResponsibility && this.statementOfResponsibility.split(/and|und|\&/g).length>1){
-            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/and|und|\&/g)
-          }
-
-          // SOR examples that make rules difficult
-          // Cecilia Leibovitz ; photographs by David Lewis Taylor & Talia Marek
-          // Ana Rodriguez Alvarez, Jeffrey J. Mora Sanchez (directores) ; prologo E. Raul Zaffaroni; prologo a la edicion costarricense Javier Llobet Rodriguez
-          // Sally Friedman and Davy Schultz, Editors
-          // Pedro Romaguera Esteva ; pròleg, Dr. Jordi Maíz Chacón, Professor de la UIB
-          // Dina de Sousa e Santos (organizadora) ; prefácios, Professor Phillip Rothwell (Universidade de Oxford), Doutora Elisabete Vera Cruz (Universidade Agostinho Neto, UAN)
-          // Archie Bogle and Don McKay ; compiled by by Gordon Andreassend, Andrew Blackman and Don McKay
-          // editor-in-chief, Elaine Wyllie ; associate editors, Barry E. Gidal, Ahsan Moosa Naduvil Valappil, Howard P. Goodkin, Elaine Wirrell, Stephan Schuele
-          // Alberto Pitta ; organização, Thais Darzé, Paulo Darzé ; curadoria e texto, Daniel Rangel
+          this.statementOfResponsibilityOptions = this.splitSor(this.statementOfResponsibility)
 
           let addingDefaultExtraMarcStatements = false
 
@@ -1771,6 +1753,35 @@
 
           // console.log(this.scriptShifterOptions)
 
+        },
+
+        splitSor: function(sor){
+          let split = []
+          // /\s{1};\s{1}|,\s*(?=[^)^\]]*(?:\(|\[|$))|\&|and|und/g) --> split on <space>;<space> and commas not in ()
+          // favor splitting on semicolon. Seems reliable to get the first name without bleed from other names. But after that, anything can happen
+          // \s{1};\s{1}|;\s*(?=[^)^\]]*(?:\(|\[|$))|\&|and|und
+          // ;\s+and|und|\&\s+|\s+e\s+|;\s+
+          // ;|;\s?(?=(and))|(?<=;)\s?and
+          // ;|;\s?(?=and)
+          if (sor && sor.split(/(?:;?\s?(?:and|und|\&))\s?(?<=;.*)|\s?;\s?/g).length>1){
+            split = sor.split(/(?:;?\s?(?:and|und|\&))\s?(?<=;.*)|\s?;\s?/g)
+          } else if (sor && sor.split(/(?:,?\s?(?:and|und|\&))\s?(?<=,.*)|\s?,\s?/g).length>1){
+            split = sor.split(/(?:,?\s?(?:and|und|\&))\s?(?<=,.*)|\s?,\s?/g)
+          } else if (sor && sor.split(/\s+(?:and|und|\&){1}\s+/g).length>1){
+            split = sor.split(/\s+(?:and|und|\&){1}\s+/g)
+          }
+
+          return split //.map((name) => name.trim())
+
+          // SOR examples that make rules difficult
+          // Cecilia Leibovitz ; photographs by David Lewis Taylor & Talia Marek
+          // Ana Rodriguez Alvarez, Jeffrey J. Mora Sanchez (directores) ; prologo E. Raul Zaffaroni; prologo a la edicion costarricense Javier Llobet Rodriguez
+          // Sally Friedman and Davy Schultz, Editors
+          // Pedro Romaguera Esteva ; pròleg, Dr. Jordi Maíz Chacón, Professor de la UIB
+          // Dina de Sousa e Santos (organizadora) ; prefácios, Professor Phillip Rothwell (Universidade de Oxford), Doutora Elisabete Vera Cruz (Universidade Agostinho Neto, UAN)
+          // Archie Bogle and Don McKay ; compiled by by Gordon Andreassend, Andrew Blackman and Don McKay
+          // editor-in-chief, Elaine Wyllie ; associate editors, Barry E. Gidal, Ahsan Moosa Naduvil Valappil, Howard P. Goodkin, Elaine Wirrell, Stephan Schuele
+          // Alberto Pitta ; organização, Thais Darzé, Paulo Darzé ; curadoria e texto, Daniel Rangel
         },
 
         update670: function(){

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -1587,10 +1587,12 @@
 
           // /\s{1};\s{1}|,\s*(?=[^)^\]]*(?:\(|\[|$))|\&|and|und/g) --> split on <space>;<space> and commas not in ()
           // favor splitting on semicolon. Seems reliable to get the first name without bleed from other names. But after that, anything can happen
-          if (this.statementOfResponsibility && this.statementOfResponsibility.split(/,?\s+and|und|\&\s+|\s+e\s+|;/g).length>1){
-            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/,?\s+and|und|\&\s+|\s+e\s+|;/g)
-          } else if (this.statementOfResponsibility && this.statementOfResponsibility.split(/,?\s+and|und|\&\s+|,/g).length>1){
-            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/,?\s+and|und|\&\s+|,/g)
+          if (this.statementOfResponsibility && this.statementOfResponsibility.split(/;\s+and|und|\&\s+|\s+e\s+|;/g).length>1){
+            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/;\s+and|und|\&\s+|\s+e\s+|;/g)
+          } else if (this.statementOfResponsibility && this.statementOfResponsibility.split(/,\s+and|und|\&\s+|,/g).length>1){
+            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/,\s+and|und|\&\s+|,/g)
+          } else if (this.statementOfResponsibility && this.statementOfResponsibility.split(/and|und|\&/g).length>1){
+            this.statementOfResponsibilityOptions = this.statementOfResponsibility.split(/and|und|\&/g)
           }
 
           // SOR examples that make rules difficult

--- a/src/lib/__tests__/NacoStubCreate/splitSor.test.js
+++ b/src/lib/__tests__/NacoStubCreate/splitSor.test.js
@@ -1,0 +1,134 @@
+import { expect, test } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import NacoStubCreateModal from '@/components/panels/edit/modals/NacoStubCreateModal.vue'
+
+
+const sorSemi = 'Timothy R. Amidon; Ehren Helmut Pflugfelder; Daniel P. Richards; Donnie Johnson Sackey'
+const sorSpaceSemi = 'Timothy R. Amidon ; Ehren Helmut Pflugfelder ; Daniel P. Richards ; Donnie Johnson Sackey'
+const sorSpaceMixedSemi = 'Timothy R. Amidon ; Ehren Helmut Pflugfelder; Daniel P. Richards ; Donnie Johnson Sackey'
+const sorSemiAnd = 'Timothy R. Amidon; Ehren Helmut Pflugfelder; Daniel P. Richards and Donnie Johnson Sackey'
+const sorSemisAnd = 'Timothy R. Amidon; Ehren Helmut Pflugfelder; Daniel P. Richards; and Donnie Johnson Sackey'
+
+const sorSemiAmp = 'Timothy R. Amidon; Ehren Helmut Pflugfelder; Daniel P. Richards & Donnie Johnson Sackey'
+const sorSemisAmp = 'Timothy R. Amidon; Ehren Helmut Pflugfelder; Daniel P. Richards; & Donnie Johnson Sackey'
+
+const sorSemiUnd = 'Timothy R. Amidon; Ehren Helmut Pflugfelder; Daniel P. Richards und Donnie Johnson Sackey'
+const sorSemisUnd = 'Timothy R. Amidon; Ehren Helmut Pflugfelder; Daniel P. Richards; und Donnie Johnson Sackey'
+
+const sorCommas = 'Timothy R. Amidon, Ehren Helmut Pflugfelder, Daniel P. Richards, Donnie Johnson Sackey'
+const sorCommasAnd = 'Timothy R. Amidon, Ehren Helmut Pflugfelder, Daniel P. Richards, and Donnie Johnson Sackey'
+const sorCommaAnd = 'Timothy R. Amidon, Ehren Helmut Pflugfelder, Daniel P. Richards and Donnie Johnson Sackey'
+
+const sorCommasUnd = 'Timothy R. Amidon, Ehren Helmut Pflugfelder, Daniel P. Richards, und Donnie Johnson Sackey'
+const sorCommasAmp = 'Timothy R. Amidon, Ehren Helmut Pflugfelder, Daniel P. Richards, & Donnie Johnson Sackey'
+
+const sorCommaUnd = 'Timothy R. Amidon, Ehren Helmut Pflugfelder, Daniel P. Richards und Donnie Johnson Sackey'
+const sorCommaAmp = 'Timothy R. Amidon, Ehren Helmut Pflugfelder, Daniel P. Richards & Donnie Johnson Sackey'
+
+
+const sorAnd = 'Timothy R. Amidon and Ehren Helmut Pflugfelder and Daniel P. Richards and Donnie Johnson Sackey'
+
+const resultExpected = ['Timothy R. Amidon', 'Ehren Helmut Pflugfelder', 'Daniel P. Richards', 'Donnie Johnson Sackey']
+
+describe('SOR Splitting', () => {
+
+    test('Only Semicolons', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSemi)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('<space> Semicolons', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSpaceSemi)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('Mixed spaced semicolons', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSpaceMixedSemi)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('semicolons with "and"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSemiAnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('semicolons with "; and"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSemisAnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('semicolons with "&"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSemiAmp)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('semicolons with "; &"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSemisAmp)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('semicolons with "und"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSemiUnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('semicolons with "; und"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorSemisUnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('only commas', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorCommas)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('commas with ", and"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorCommasAnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('commas with "and"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorCommaAnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('commas with "und"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorCommaUnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('commas with "&"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorCommaAmp)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('commas with ", und"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorCommasUnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('commas with ", &"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorCommasAmp)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+    test('Only "and"', async () => {
+        let split = NacoStubCreateModal.methods.splitSor(sorAnd)
+        expect(split).toStrictEqual(resultExpected)
+    });
+
+
+})
+
+
+// const wrapper = shallowMount(SubjectEditor)
+// wrapper.setData({
+//     components: expectedSimpleSubect,
+//     searchResults: {
+//         subjectsComplex: [],
+//         subjectsChildrenComplex: []
+//     }
+// })
+// wrapper.vm.add()
+// expect(wrapper.vm.components).toEqual(expectedSimpleSubect)
+// expect(wrapper.emitted().subjectAdded).toEqual([[expectedSimpleSubect]])

--- a/src/lib/__tests__/NacoStubCreate/splitSor.test.js
+++ b/src/lib/__tests__/NacoStubCreate/splitSor.test.js
@@ -119,16 +119,3 @@ describe('SOR Splitting', () => {
 
 
 })
-
-
-// const wrapper = shallowMount(SubjectEditor)
-// wrapper.setData({
-//     components: expectedSimpleSubect,
-//     searchResults: {
-//         subjectsComplex: [],
-//         subjectsChildrenComplex: []
-//     }
-// })
-// wrapper.vm.add()
-// expect(wrapper.vm.components).toEqual(expectedSimpleSubect)
-// expect(wrapper.emitted().subjectAdded).toEqual([[expectedSimpleSubect]])


### PR DESCRIPTION
Was catching `and` no matter the punctuation causing a match on the first condition even when there were no `;` in the SOR.