### PR TITLE
Add pref to use arrow keys to nav btwn compts

### DIFF
--- a/src/components/panels/edit/fields/Literal.vue
+++ b/src/components/panels/edit/fields/Literal.vue
@@ -410,12 +410,11 @@ export default {
     navKey: function(event){
 
 
-
-      if (event && event.code === 'ArrowUp'){
+      let useArrowNav = this.preferenceStore.returnValue('--b-edit-main-literal-component-jump')
+      if (useArrowNav && event && event.code === 'ArrowUp'){
         utilsMisc.globalNav('up',event.target)
       }
-      if (event && event.code === 'ArrowDown'){
-
+      if (useArrowNav && event && event.code === 'ArrowDown'){
         utilsMisc.globalNav('down',event.target)
       }
 

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -780,6 +780,15 @@ export const usePreferenceStore = defineStore('preference', {
       group: 'Literal Field',
       range: null
     },
+    '--b-edit-main-literal-component-jump' : {
+      desc: 'Use Up & Down arrows to jump to another component',
+      descShort: 'Move components with arrow keys.',
+      value: false,
+      type: 'boolean',
+      unit: null,
+      group: 'Literal Field',
+      range: [true,false]
+    },
 
 
   // Lookup Field


### PR DESCRIPTION
Was the default, now a preference that is opt in. Only applies to literal fields. Lookups still use arrow keys to move between components.