### PR TITLE
Edit Hub Button

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -921,6 +921,11 @@
 
       },
 
+      editHub: function(uri){
+        let editUrl = "https://editor.id.loc.gov/bfe2/quartz/?action=loadhub&url=" + this.rewriteURI(uri) + ".decomposed.rdf&profile=lc:RT:bf2:HubBasic:Hub"
+        return editUrl
+      },
+
       rewriteURI: function(uri, forBFDB=false){
         let returnUrls = useConfigStore().returnUrls
 
@@ -1238,6 +1243,7 @@
                         </div>
                         <template v-if="activeContext.uri.includes('/resources/')">
                           <a style="color:#2c3e50; float: none;    border: none;border-radius: 0;background-color: transparent;font-size: 1em;padding: 0;" v-if="activeContext.type!='Literal Value'" :href="rewriteURI(activeContext.uri, true)" target="_blank" :style="`${this.preferenceStore.styleModalTextColor()}`">view on BFDB</a>
+                          <a class="edit-hub" v-if="activeContext.uri.includes('/hubs/') && checkLcOnly()"  :href="editHub(activeContext.uri)" target="_blank">Edit</a>
                           <br />
                         </template>
                         <a style="color:#2c3e50; float: none;    border: none;border-radius: 0;background-color: transparent;font-size: 1em;padding: 0;" v-if="activeContext.type!='Literal Value'" :href="rewriteURI(activeContext.uri)" target="_blank" :style="`${this.preferenceStore.styleModalTextColor()}`">view on ID</a>
@@ -1821,5 +1827,10 @@
 .pub-date {
   font-style: italic;
 }
+
+.edit-hub {
+  margin-left: 5px;
+}
+
 
 </style>

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1862,6 +1862,9 @@ export default {
         this.contextData.literal = true
       }
 
+      // remove duplicates from contextData.variantLabels
+      this.contextData.variantLabels = [...new Set(this.contextData.variantLabels)]
+
       this.contextRequestInProgress = false
     },
 

--- a/src/components/panels/edit/modals/helpers/ComplexSearchResultsDisplay.vue
+++ b/src/components/panels/edit/modals/helpers/ComplexSearchResultsDisplay.vue
@@ -42,6 +42,16 @@
                 :searchMode="searchMode"
             />
             <SearchResultOption
+                searchType="subjectsChildren"
+                label="CYAC Simple"
+                index="searchResults.subjectsChildrenComplex.length + ix"
+                :searchResults="searchResults"
+                :pickLookup="pickLookup"
+                @selectContext="selectContext"
+                @emitLoadContext="loadContext"
+                :searchMode="searchMode"
+            />
+            <SearchResultOption
                 searchType="names"
                 label="LCNAF"
                 index="(searchResults.names.length - ix) * - 1"
@@ -66,16 +76,6 @@
                 searchType="subjectsChildrenComplex"
                 label="CYAC Complex"
                 index="ix"
-                :searchResults="searchResults"
-                :pickLookup="pickLookup"
-                @selectContext="selectContext"
-                @emitLoadContext="loadContext"
-                :searchMode="searchMode"
-            />
-            <SearchResultOption
-                searchType="subjectsChildren"
-                label="CYAC Simple"
-                index="searchResults.subjectsChildrenComplex.length + ix"
                 :searchResults="searchResults"
                 :pickLookup="pickLookup"
                 @selectContext="selectContext"

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -75,14 +75,14 @@
             <template v-for="key in panelDetailOrder">
                 <div v-if="contextData[key] && contextData[key].length > 0">
                     <template
-                        v-if="contextData[key] && contextData[key].length > 0 && ['nonlatinLabels', 'variantLabels', 'varianttitles', 'contributors', 'relateds'].includes(key)">
+                        v-if="contextData[key] && contextData[key].length > 0 && ['nonlatinLabels', 'variantLabels', 'varianttitles', 'contributors', 'relateds', 'hasEarlierEstablishedForms', 'hasLaterEstablishedForms'].includes(key)">
                         <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
                             this.labelMap[key] : key }}:</div>
                         <ul class="details-list">
                             <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])"
                                 v-for="(v, idx) in contextData[key]" v-bind:key="'var' + idx">
                                 <span v-if="key != 'sees' && key != 'relateds'">{{ v }}</span>
-                                <div v-else-if="key == 'relateds'">
+                                <div v-else-if="['relateds', 'hasEarlierEstablishedForms', 'hasLaterEstablishedForms'].includes(key)">
                                     {{ v }}<button class="material-icons see-search"
                                         @click="newSearch(v)">search</button>
                                 </div>
@@ -104,7 +104,8 @@
                             </li>
                         </ul>
                     </template>
-                    <template v-else-if="key == 'sources'">
+                    <!-- <template v-else-if="key == 'sources'"> -->
+                    <template v-else-if="['sources'].includes(key)">
                         <span class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
                             this.labelMap[key] : key }}:</span>
                         <ul>
@@ -324,7 +325,6 @@ export default {
                 "countName": "Contributor to",
                 "vernacularMarcKeys": "Variant MARC Key",
                 "vernacularLabels": "Vernacular Labels",
-                "relateds": "Related",
                 "hasRelatedAuthoritys": "Has Related Authorities",
                 "hasEarlierEstablishedForms": "Earlier Established Forms",
                 "hasLaterEstablishedForms": "Later Established Forms",
@@ -333,10 +333,12 @@ export default {
             },
 
             panelDetailOrder: [
-                "notes", "gacs", "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds", "birthdates", "deathdates", "birthplaces",
+                "notes", "gacs", "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds", "hasEarlierEstablishedForms", "hasLaterEstablishedForms",
+                "birthdates", "deathdates", "birthplaces",
                 "locales", "activityfields", "occupations", "languages",
                 "sources", "sees", "lcclasses", "lcclasss", "identifiers", "broaders",
-                "collections", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "hasRelatedAuthoritys", "useFors"
+                "collections", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "hasRelatedAuthoritys", "hasRelatedAuthoritys",
+                "useFors"
             ],
         }
     },

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -31,15 +31,13 @@
             <div class="modal-context-data-title" v-if="contextData.rdftypes">
                 {{ contextData.rdftypes.includes('Hub') ? 'Hub' :
                     contextData.rdftypes[0] }}</div>
-            <template v-if="contextData.uri.includes('/resources/')">
-                <a style="color:#2c3e50; float: none;    border: none;border-radius: 0;background-color: transparent;font-size: 1em;padding: 0;" v-if="contextData.type!='Literal Value'" :href="rewriteURI(contextData.uri, true)" target="_blank" :style="`${this.preferenceStore.styleModalTextColor()}`">view on BFDB</a>
-                <a class="edit-hub" v-if="contextData.uri.includes('/hubs/') && checkLcOnly()"  :href="editHub(contextData.uri)" target="_blank">Edit</a>
+            <template v-if="contextData && contextData.uri && contextData.uri.includes('/resources/')">
+                <a style="color:#2c3e50; float: none; border: none;border-radius: 0;background-color: transparent;font-size: 1em;padding: 0;" v-if="contextData.type!='Literal Value'" :href="rewriteURI(contextData.uri, true)" target="_blank" :style="`${this.preferenceStore.styleModalTextColor()}`">view on BFDB</a>
+                <a class="edit-hub" v-if="contextData.uri.includes('/hubs/') && checkLcOnly()" :href="editHub(contextData.uri)" target="_blank">Edit</a>
                 <br>
             </template>
             <a style="color:#2c3e50" :href="rewriteURI(contextData.uri)" target="_blank"
-                v-if="contextData.literal != true">view
-                on id.loc.gov</a>
-
+                v-if="contextData.literal != true">view on id.loc.gov</a>
             <!-- Dates -->
             <template v-if="(Object.keys(contextData).includes('birthdates') && contextData['birthdates'].length > 0)
                 || (Object.keys(contextData).includes('deathdates') && contextData['deathdates'].length > 0)">
@@ -237,7 +235,7 @@
                         </template>
                         <template v-for="key in panelDetailOrder">
                             <template
-                                v-if='contextData[key] && contextData[key].length > 0 && ["notes", "collections", "subjects", "marcKeys", "lcclasss"].includes(key)'>
+                                v-if='contextData[key] && contextData[key].length > 0 && ["notes", "collections", "rdftypes", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "lcclasss", "hasRelatedAuthoritys", "useFors"].includes(key)'>
                                 <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ?
                                     this.labelMap[key] : key }}:</div>
                                 <ul>
@@ -324,13 +322,21 @@ export default {
                 "sees": "See Also",
                 "countSubj": "Subject ff",
                 "countName": "Contributor to",
+                "vernacularMarcKeys": "Variant MARC Key",
+                "vernacularLabels": "Vernacular Labels",
+                "relateds": "Related",
+                "hasRelatedAuthoritys": "Has Related Authorities",
+                "hasEarlierEstablishedForms": "Earlier Established Forms",
+                "hasLaterEstablishedForms": "Later Established Forms",
+                "useFors": "Use For",
+                "rdftypes": "RDF Types"
             },
 
             panelDetailOrder: [
                 "notes", "gacs", "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds", "birthdates", "deathdates", "birthplaces",
                 "locales", "activityfields", "occupations", "languages",
                 "sources", "sees", "lcclasses", "lcclasss", "identifiers", "broaders",
-                "collections", "subjects", "marcKeys"
+                "collections", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "hasRelatedAuthoritys", "useFors", "rdftypes"
             ],
         }
     },

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -336,7 +336,7 @@ export default {
                 "notes", "gacs", "nonlatinLabels", "variantLabels", "varianttitles", "contributors", "relateds", "birthdates", "deathdates", "birthplaces",
                 "locales", "activityfields", "occupations", "languages",
                 "sources", "sees", "lcclasses", "lcclasss", "identifiers", "broaders",
-                "collections", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "hasRelatedAuthoritys", "useFors", "rdftypes"
+                "collections", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "hasRelatedAuthoritys", "useFors"
             ],
         }
     },

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -82,7 +82,7 @@
                             <li class="modal-context-data-li" v-if="Array.isArray(contextData[key])"
                                 v-for="(v, idx) in contextData[key]" v-bind:key="'var' + idx">
                                 <span v-if="key != 'sees' && key != 'relateds'">{{ v }}</span>
-                                <div v-else-if="['relateds', 'hasEarlierEstablishedForms', 'hasLaterEstablishedForms'].includes(key)">
+                                <div v-else-if="['relateds'].includes(key)">
                                     {{ v }}<button class="material-icons see-search"
                                         @click="newSearch(v)">search</button>
                                 </div>
@@ -337,7 +337,7 @@ export default {
                 "birthdates", "deathdates", "birthplaces",
                 "locales", "activityfields", "occupations", "languages",
                 "sources", "sees", "lcclasses", "lcclasss", "identifiers", "broaders",
-                "collections", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "hasRelatedAuthoritys", "hasRelatedAuthoritys",
+                "collections", "subjects", "marcKeys", "vernacularMarcKeys", "vernacularLabels", "rdftypes", "hasRelatedAuthoritys",
                 "useFors"
             ],
         }

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -31,6 +31,11 @@
             <div class="modal-context-data-title" v-if="contextData.rdftypes">
                 {{ contextData.rdftypes.includes('Hub') ? 'Hub' :
                     contextData.rdftypes[0] }}</div>
+            <template v-if="contextData.uri.includes('/resources/')">
+                <a style="color:#2c3e50; float: none;    border: none;border-radius: 0;background-color: transparent;font-size: 1em;padding: 0;" v-if="contextData.type!='Literal Value'" :href="rewriteURI(contextData.uri, true)" target="_blank" :style="`${this.preferenceStore.styleModalTextColor()}`">view on BFDB</a>
+                <a class="edit-hub" v-if="contextData.uri.includes('/hubs/') && checkLcOnly()"  :href="editHub(contextData.uri)" target="_blank">Edit</a>
+                <br>
+            </template>
             <a style="color:#2c3e50" :href="rewriteURI(contextData.uri)" target="_blank"
                 v-if="contextData.literal != true">view
                 on id.loc.gov</a>
@@ -383,6 +388,15 @@ export default {
 
             return pieces.at(-1)
         },
+        checkLcOnly: function(){
+            let config = useConfigStore()
+
+            return config.returnUrls.displayLCOnlyFeatures
+        },
+        editHub: function(uri){
+            let editUrl = "https://editor.id.loc.gov/bfe2/quartz/?action=loadhub&url=" + this.rewriteURI(uri) + ".decomposed.rdf&profile=lc:RT:bf2:HubBasic:Hub"
+            return editUrl
+        },
         rewriteURI: function (uri) {
             if (!uri) { return false }
             let returnUrls = useConfigStore().returnUrls
@@ -478,5 +492,10 @@ ul:has(.modal-context-data-li) {
 .not-usable {
     color: red;
 }
+
+.edit-hub {
+  margin-left: 5px;
+}
+
 
 </style>


### PR DESCRIPTION
Add button to edit hub in the hub search results.

Only appears for hubs with `displayLCOnlyFeatures=true`

Expand data present in subject search. Was done with complex searches previously. (#747)