### PR TITLE
Filter Subject `Related`

### DIFF
--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1865,6 +1865,12 @@ export default {
       // remove duplicates from contextData.variantLabels
       this.contextData.variantLabels = [...new Set(this.contextData.variantLabels)]
 
+      // filter related, so it doesn't duplicate value from earlier/later, broader
+      console.info("this.contextData: ", this.contextData)
+      this.contextData['relateds'] = this.contextData['relateds'].filter(n => !this.contextData['hasEarlierEstablishedForms'].includes(n))
+      this.contextData['relateds'] = this.contextData['relateds'].filter(n => !this.contextData['hasLaterEstablishedForms'].includes(n))
+      this.contextData['relateds'] = this.contextData['relateds'].filter(n => !this.contextData['broaders'].includes(n))
+
       this.contextRequestInProgress = false
     },
 

--- a/src/components/panels/edit/modals/SubjectEditor.vue
+++ b/src/components/panels/edit/modals/SubjectEditor.vue
@@ -1866,7 +1866,6 @@ export default {
       this.contextData.variantLabels = [...new Set(this.contextData.variantLabels)]
 
       // filter related, so it doesn't duplicate value from earlier/later, broader
-      console.info("this.contextData: ", this.contextData)
       this.contextData['relateds'] = this.contextData['relateds'].filter(n => !this.contextData['hasEarlierEstablishedForms'].includes(n))
       this.contextData['relateds'] = this.contextData['relateds'].filter(n => !this.contextData['hasLaterEstablishedForms'].includes(n))
       this.contextData['relateds'] = this.contextData['relateds'].filter(n => !this.contextData['broaders'].includes(n))

--- a/src/components/panels/edit/modals/helpers/DetailsPanel.vue
+++ b/src/components/panels/edit/modals/helpers/DetailsPanel.vue
@@ -507,3 +507,14 @@ ul:has(.modal-context-data-li) {
 
 
 </style>
+
+<style scoped>
+    .simptip-position-bottom::before,
+    .simptip-position-bottom::after {
+        left: -30% !important;
+        text-wrap: auto;
+        word-break: keep-all;
+        width: 520px;
+        height: unset !important;
+    }
+</style>

--- a/tests-playwright/components/complex_lookup/adding_names.spec.js
+++ b/tests-playwright/components/complex_lookup/adding_names.spec.js
@@ -39,6 +39,10 @@ test('Add Non-Latin Name', async ({ page }) => {
     await page.getByRole('listbox').selectOption('http://id.loc.gov/authorities/names/n97907734');
     await page.getByRole('button', { name: 'Add [Shift+Enter]' }).click();
     await page.locator('.child-elements > div > div > div > .caret').first().click();
-    await expect(page.locator('#app')).toContainText('<bf:agent><bf:Agentrdf:about="http://id.loc.gov/authorities/names/n97907734"><rdf:typerdf:resource="http://www.loc.gov/mads/rdf/v1#PersonalName" /><rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">ʻAqīl, ʻAqīl Ḥusayn</rdfs:label><rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"xml:lang="und-arab">عقيل، عقيل حسين</rdfs:label><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">1001 $aʻAqīl, ʻAqīl Ḥusayn</bflc:marcKey><bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/"xml:lang="und-arab">4001 $aعقيل، عقيل حسين$7(bcp47)und-arab</bflc:marcKey></bf:Agent></bf:agent>');
+    await expect(page.locator('#app')).toContainText('<bf:Agentrdf:about="http://id.loc.gov/authorities/names/n97907734">');
+    await expect(page.locator('#app')).toContainText('<rdf:typerdf:resource="http://www.loc.gov/mads/rdf/v1#PersonalName" /><rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">ʻAqīl, ʻAqīl Ḥusayn</rdfs:label>');
+    await expect(page.locator('#app')).toContainText('<rdfs:labelxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"xml:lang="und-arab">عقيل، عقيل حسين</rdfs:label>');
+    await expect(page.locator('#app')).toContainText('<bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/">1001 $aʻAqīl, ʻAqīl Ḥusayn</bflc:marcKey>');
+    await expect(page.locator('#app')).toContainText('<bflc:marcKeyxmlns:bflc="http://id.loc.gov/ontologies/bflc/"xml:lang="und-arab">4001 $aعقيل، عقيل حسين$7(bcp47)und-arab</bflc:marcKey>');
 
 });


### PR DESCRIPTION
Filter narrower relationships from "related" in the details panel. 

Before:
<img width="885" height="561" alt="image" src="https://github.com/user-attachments/assets/3c0bfa33-84fe-4f6c-b4b2-35ac018dceb5" />

Now:
<img width="885" height="505" alt="image" src="https://github.com/user-attachments/assets/21b8ca08-2eb3-4961-8a56-2bc3c59f3e9e" />

Some styling for the classification popup so it fits better when the string is long.

Adjust a test.