### PR TITLE
make quick select change reflect in the LiteralLang modal as well

### DIFF
--- a/src/components/panels/edit/modals/LiteralLang.vue
+++ b/src/components/panels/edit/modals/LiteralLang.vue
@@ -211,10 +211,16 @@
 
         setLanguageFromQuickSelect(langStr, v){
 
-          console.log(langStr,v)
-
           this.profileStore.setValueLiteral(this.literalLangInfo.componentGuid,v['@guid'],this.literalLangInfo.propertyPath,v.value,langStr)
 
+          // update the reactive store state so the modal reflects the new value
+          for (let sValue of this.literalLangInfo.values){
+            if (sValue['@guid'] == v['@guid']){
+              sValue['@language'] = langStr
+            }
+          }
+
+          this.lastUsedLangScript = langStr
 
         },
 


### PR DESCRIPTION
When using quick select in the LiteralLang modal it was not updating the text @ value in the modal, just the store data. Now it reflects the quick select usage in the modal as well.