### PR TITLE
Update Marva NAR Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.6.4] - 2025-07-17
+### Update
+- Adjust NAR creation
+  - Don't create empty fields
+  - stricter indicator check
+  - Don't allow post if field data or subfield are empty
+
 ## [1.6.3] - 2025-06-26
 ### Added
 - Buttons for `Create NAR/Hub` when looking for a hub

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -142,6 +142,10 @@
           return true
         }
 
+        if (this.validationResult && ['Empty subfields.', 'Empty datafields.'].includes(this.validationResult.validation[0].message)){
+          return true
+        }
+
         return false
       }
 
@@ -224,9 +228,9 @@
         return good
       },
 
-      // Check that the advanced marc entry have indicators
+      // Check that the advanced marc entry have indicators and they are valid
       goodIndicators: function(){
-        let good = this.extraMarcStatements.every((row) => row.indicators.length == 2)
+        let good = this.extraMarcStatements.every((row) => row.indicators.length == 2 && /[0-9# ]{2}/.test(row.indicators))
         return good
       },
 
@@ -2136,7 +2140,7 @@
                   <template v-else>
                     <div>
                           <span class="material-icons not-unique-icon">cancel</span>
-                          <span class="not-unique-text">Indicators Missing</span><span data-tooltip="Add missing indicator in the red field" class="simptip-position-left"><span class="material-icons help-icon">help</span></span>
+                          <span class="not-unique-text">Indicators Missing or Invalid</span><span data-tooltip="Add missing indicator in the red field" class="simptip-position-left"><span class="material-icons help-icon">help</span></span>
                         </div>
                   </template>
 
@@ -2258,7 +2262,7 @@
                       maxlength="2"
                       placeholder="IND"
                       :style="`margin-right: 1em; width: 40px; font-family: 'Courier New', Courier, monospace; font-size: ${preferenceStore.returnValue('--n-edit-main-literal-font-size')}; color: ${preferenceStore.returnValue('--c-edit-main-literal-font-color')};`"
-                      :class="['extra-marc-ind', {'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font'), 'missing-indicators': row.indicators.length != 2}]"
+                      :class="['extra-marc-ind', {'literal-bold': preferenceStore.returnValue('--b-edit-main-literal-bold-font'), 'missing-indicators': row.indicators.length != 2 || !/[0-9# ]{2}/.test(row.indicators)}]"
                     />
 
                     <textarea

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -117,6 +117,13 @@
 
 
       disableAddButton() {
+        console.info("disable:")
+        console.info("\t this.oneXXErrors: ", this.oneXXErrors)
+        console.info("\t this.fourXXErrors: ", this.fourXXErrors)
+        console.info("\t this.mainTitle: ", this.mainTitle)
+        console.info("\t this.goodIndicators(): ", this.goodIndicators())
+        console.info("\t this.goodTags(): ", this.goodTags())
+        console.info("\t this.validationResult: ", this.validationResult)
         if (this.oneXXErrors.length > 0 || this.fourXXErrors.length > 0){
           return true
         }

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -117,13 +117,6 @@
 
 
       disableAddButton() {
-        console.info("disable:")
-        console.info("\t this.oneXXErrors: ", this.oneXXErrors)
-        console.info("\t this.fourXXErrors: ", this.fourXXErrors)
-        console.info("\t this.mainTitle: ", this.mainTitle)
-        console.info("\t this.goodIndicators(): ", this.goodIndicators())
-        console.info("\t this.goodTags(): ", this.goodTags())
-        console.info("\t this.validationResult: ", this.validationResult)
         if (this.oneXXErrors.length > 0 || this.fourXXErrors.length > 0){
           return true
         }

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2218,6 +2218,15 @@ const utilsExport = {
 	},
 
 	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements,useAdvancedMode){
+		console.info("createStub: ")
+		console.info("\t oneXXParts: ", oneXXParts)
+		console.info("\t fourXXParts: ", fourXXParts)
+		console.info("\t mainTitle: ", mainTitle)
+		console.info("\t lccn: ", lccn)
+		console.info("\t instanceUri: ", instanceUri)
+		console.info("\t zero46: ", zero46)
+		console.info("\t extraMarcStatements: ", extraMarcStatements)
+
 		let marcTxt = ''
 		marcTxt = marcTxt + " 111111111122222222223333333333\n"
 		marcTxt = marcTxt + "       0123456789012345678901234567890123456789\n"
@@ -2373,6 +2382,7 @@ const utilsExport = {
 
 
 		if (zero46 && Object.keys(zero46).length > 0){
+			console.info("building 046?", zero46)
 
 			let good = false
 			let field046 = document.createElementNS(marcNamespace,"marcxml:datafield");
@@ -2433,6 +2443,8 @@ const utilsExport = {
 				subfieldsValues.push(`$t ${zero46.t}`)
 				good = true
 			}
+
+			console.info("good: ", good)
 
 			if (good){
 				let field0462 = document.createElementNS(marcNamespace,"marcxml:subfield");
@@ -2617,6 +2629,7 @@ const utilsExport = {
 
 		if (extraMarcStatements && extraMarcStatements.length > 0){
 			for (let x of extraMarcStatements){
+				let hasValue = false
 				if (x.fieldTag && x.fieldTag.trim() != ''){
 					let field = document.createElementNS(marcNamespace,"marcxml:datafield");
 					field.setAttribute( 'tag', x.fieldTag)
@@ -2631,11 +2644,13 @@ const utilsExport = {
 							subfield.innerHTML = x[key][1].replace(/[\r\n]+/g, ' ')
 							field.appendChild(subfield)
 							useSubfieldsValues.push(`$${x[key][0]} ${x[key][1].replace(/[\r\n]+/g, ' ')}`)
-
+							hasValue = true
 						}
 					}
-					rootEl.appendChild(field)
-					marcTextArray.push({txt: this.buildMarcTxtLine(x.fieldTag, x.indicators.charAt(0), x.indicators.charAt(1), useSubfieldsValues), field: x.fieldTag, fieldInt: parseInt(x.fieldTag)})
+					if (hasValue){
+						rootEl.appendChild(field)
+						marcTextArray.push({txt: this.buildMarcTxtLine(x.fieldTag, x.indicators.charAt(0), x.indicators.charAt(1), useSubfieldsValues), field: x.fieldTag, fieldInt: parseInt(x.fieldTag)})
+					}
 				}
 			}
 		}

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2374,6 +2374,7 @@ const utilsExport = {
 
 		if (zero46 && Object.keys(zero46).length > 0){
 
+			let good = false
 			let field046 = document.createElementNS(marcNamespace,"marcxml:datafield");
 			field046.setAttribute( 'tag', '046')
 			field046.setAttribute( 'ind1', ' ')
@@ -2385,6 +2386,7 @@ const utilsExport = {
 				field046f.innerHTML = zero46.f
 				field046.appendChild(field046f)
 				subfieldsValues.push(`$f ${zero46.f}`)
+				good = true
 
 			}
 			if (zero46.g && zero46.g.length > 0){
@@ -2393,6 +2395,7 @@ const utilsExport = {
 				field046g.innerHTML = zero46.g
 				field046.appendChild(field046g)
 				subfieldsValues.push(`$g ${zero46.g}`)
+				good = true
 			}
 
 			if (zero46.q){
@@ -2401,6 +2404,7 @@ const utilsExport = {
 				field046q.innerHTML = zero46.q
 				field046.appendChild(field046q)
 				subfieldsValues.push(`$q ${zero46.q}`)
+				good = true
 
 			}
 			if (zero46.r && zero46.r.length > 0){
@@ -2409,6 +2413,7 @@ const utilsExport = {
 				field046r.innerHTML = zero46.r
 				field046.appendChild(field046r)
 				subfieldsValues.push(`$r ${zero46.r}`)
+				good = true
 			}
 
 			if (zero46.s){
@@ -2417,6 +2422,7 @@ const utilsExport = {
 				field046s.innerHTML = zero46.s
 				field046.appendChild(field046s)
 				subfieldsValues.push(`$q ${zero46.s}`)
+				good = true
 
 			}
 			if (zero46.t && zero46.t.length > 0){
@@ -2425,18 +2431,20 @@ const utilsExport = {
 				field046t.innerHTML = zero46.t
 				field046.appendChild(field046t)
 				subfieldsValues.push(`$t ${zero46.t}`)
+				good = true
 			}
 
-			let field0462 = document.createElementNS(marcNamespace,"marcxml:subfield");
-			field0462.setAttribute( 'code', '2')
-			field0462.innerHTML = 'edtf'
-			subfieldsValues.push(`$2 edtf`)
-			field046.appendChild(field0462)
-			rootEl.appendChild(field046)
+			if (good){
+				let field0462 = document.createElementNS(marcNamespace,"marcxml:subfield");
+				field0462.setAttribute( 'code', '2')
+				field0462.innerHTML = 'edtf'
+				subfieldsValues.push(`$2 edtf`)
+				field046.appendChild(field0462)
+				rootEl.appendChild(field046)
 
 
-			marcTextArray.push({txt: this.buildMarcTxtLine('046',' ',' ',subfieldsValues), field: '046', fieldInt: 46})
-
+				marcTextArray.push({txt: this.buildMarcTxtLine('046',' ',' ',subfieldsValues), field: '046', fieldInt: 46})
+			}
 
 		}
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2218,15 +2218,6 @@ const utilsExport = {
 	},
 
 	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements,useAdvancedMode){
-		console.info("createStub: ")
-		console.info("\t oneXXParts: ", oneXXParts)
-		console.info("\t fourXXParts: ", fourXXParts)
-		console.info("\t mainTitle: ", mainTitle)
-		console.info("\t lccn: ", lccn)
-		console.info("\t instanceUri: ", instanceUri)
-		console.info("\t zero46: ", zero46)
-		console.info("\t extraMarcStatements: ", extraMarcStatements)
-
 		let marcTxt = ''
 		marcTxt = marcTxt + " 111111111122222222223333333333\n"
 		marcTxt = marcTxt + "       0123456789012345678901234567890123456789\n"
@@ -2382,8 +2373,6 @@ const utilsExport = {
 
 
 		if (zero46 && Object.keys(zero46).length > 0){
-			console.info("building 046?", zero46)
-
 			let good = false
 			let field046 = document.createElementNS(marcNamespace,"marcxml:datafield");
 			field046.setAttribute( 'tag', '046')
@@ -2443,8 +2432,6 @@ const utilsExport = {
 				subfieldsValues.push(`$t ${zero46.t}`)
 				good = true
 			}
-
-			console.info("good: ", good)
 
 			if (good){
 				let field0462 = document.createElementNS(marcNamespace,"marcxml:subfield");

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -8,7 +8,7 @@ export const useConfigStore = defineStore('config', {
 
     versionMajor: 1,
     versionMinor: 6,
-    versionPatch: 3,
+    versionPatch: 4,
 
 
 


### PR DESCRIPTION
Updates:
- Stricter indicator check: match `[0-9 #]{2}`
- Don't allow post if validation is in `'Empty subfields.', 'Empty datafields.'`
- Don't create empty `datafields`