### PR TITLE
Fix cursor jumping to the end if there are 2 spaces

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -2022,9 +2022,9 @@
                   <button @click="overrideTG = true; buildFeedbackLink()">Feedback</button>
                   <button @click="previewMarc()" v-if="allowPreview()">Preview</button>
                   <button @click="hideBCP()">Cancel</button>
-                  <tempalte v-if="!allowPreview()">
+                  <template v-if="!allowPreview()">
                     <div class="tg-note">This LCCN has been flagged by the PC TaskGroup. Please provide feedback before continuing.</div>
-                  </tempalte>
+                  </template>
 
                   <!-- open in FOLIO -->
                   <button class="folio-button" @click="openFolioRecord()">FOLIO</button>

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -631,7 +631,6 @@
 
         checkOneXX(){
           this.oneXXErrors = []
-          this.oneXX = this.oneXX.replace(/  +/g, ' ')
           this.oneXX = this.oneXX.replace(/[‒‐—–―]/g, '-') // normalize different types of dashes to a standard hyphen
 
 
@@ -716,6 +715,8 @@
             if (dollarKey.g){
               authLabel = authLabel + ' ' + dollarKey.g
             }
+
+            authLabel = authLabel.replace(/  +/g, ' ')
 
             if (dollarKey.a){
               window.clearTimeout(this.oneXXResultsTimeout)

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -891,7 +891,6 @@
         checkFourXX(){
 
           this.fourXXErrors = []
-          this.fourXX = this.fourXX.replace(/  +/g, ' ')
           this.fourXX = this.fourXX.replace(/[‒‐—–―]/g, '-') // normalize different types of dashes to a standard hyphen
 
           if (this.fourXX.length<3){ return true}
@@ -972,8 +971,11 @@
             if (dollarKey.g){
               authLabel = authLabel + ' ' + dollarKey.g
             }
+            if (dollarKey.t){
+              authLabel = authLabel + ' ' + dollarKey.t
+            }
 
-
+            authLabel = authLabel.replace(/  +/g, ' ')
 
             if (dollarKey.a){
               window.clearTimeout(this.fourXXResultsTimeout)

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -715,6 +715,9 @@
             if (dollarKey.g){
               authLabel = authLabel + ' ' + dollarKey.g
             }
+            if (dollarKey.t){
+              authLabel = authLabel + ' ' + dollarKey.t
+            }
 
             authLabel = authLabel.replace(/  +/g, ' ')
 


### PR DESCRIPTION
Move the space normalization to be on `authLabel` and right before the search.

If the NAR creation has something like `1XX##$aname $t title`, trying to add something to "name" that starts with a space such as " test" would result in the cursor jumping to the end of the field.

Also, add `$t` to the NAR searches.