### PR TITLE
BCP Updates

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -2092,7 +2092,7 @@
                   </template>
 
                   <!-- open in FOLIO -->
-                  <button class="folio-button" @click="openFolioRecord()">FOLIO</button>
+                  <!-- <button class="folio-button" @click="openFolioRecord()">FOLIO</button> -->
                 </div>
               </div>
             </template>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -343,6 +343,7 @@
           let lastMod = data.extra.lastmods[0]
           let earlier = new Date(lastMod) < new Date("2026-08-07");
           this.syncNar = earlier
+          console.info("sync earlier: ", lastMod, "--", earlier)
         }
 
         // if the record is less than 10 miuntes old in FOLIO, resync
@@ -353,9 +354,10 @@
           const diffMs = now - modDate;
           const seconds = Math.floor(diffMs / 1000);
           const minutes = Math.floor(seconds / 60);
-          if (minutes && minutes <= 10){
+          if (!this.syncNar && minutes && minutes <= 10){
             this.syncNar = true
           }
+          console.info("sync <= 10 minutes: ", minutes <= 10, "--", minutes)
         } catch(err) {
           console.error("Error checking diff: ", err)
         }
@@ -867,6 +869,7 @@
 
       fetchAuthXML: async function(lccn){
         let r = await utilsNetwork.fetchAuthMarc(lccn, this.syncNar)
+        this.syncNar = false
         return r
       },
 
@@ -2179,7 +2182,9 @@
                           <div class="modal-context-data-title">{{ Object.keys(this.labelMap).includes(key) ? this.labelMap[key] : key }}:
 
                             <button v-if="showBCPButton(key, activeContext.extra)" class="material-icons variant-edit" @click="edit4XX(activeContext)">edit</button>
-
+                            <template v-if="showBCPButton(key, activeContext.extra) && this.syncNar">
+                              Syncing <span class="syncing"><span>&nbsp;</span> <span>&nbsp;</span> <span>&nbsp;</span> </span>
+                            </template>
                           </div>
                           <ul :class="['details-list', {'note-data': key == 'notes'}]">
                             <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
@@ -2948,6 +2953,48 @@ input.prefCheck[type=checkbox]:checked+label {
 :deep() .subfield-7 > .subfield {
   direction: ltr;
   unicode-bidi: embed;
+}
+
+/* https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://codepen.io/itsmanojb/pen/xQpZbR&ved=2ahUKEwjqgeuKx5uWAxVaL1kFHSntE-QQFnoECBoQAQ&usg=AOvVaw1WE0klQuyvFRvuUTtGjyou */
+.syncing {
+  position: absolute;
+  top: 10px;
+  margin-right: 2px;
+
+  span {
+    content: '';
+    animation: blink 1.5s infinite;
+    animation-fill-mode: both;
+    height: 5px;
+    width: 5px;
+    background: #3b5998;;
+    position: absolute;
+    left:0;
+    top:0;
+    border-radius: 50%;
+
+    &:nth-child(2) {
+      animation-delay: .2s;
+      margin-left: 7px;
+    }
+
+    &:nth-child(3) {
+      animation-delay: .4s;
+      margin-left: 14px;
+    }
+  }
+}
+
+@keyframes blink {
+  0% {
+    opacity: .1;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: .1;
+  }
 }
 
 </style>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -567,7 +567,6 @@
       },
 
       previewMarc: async function(){
-        console.info("preview")
         this.submitting = true
         this.showMarcPreview = true
         let prefChecks = this.checkPrefLabels()
@@ -679,7 +678,7 @@
           this.marcData[this.activeIndex].bcpSelection = []
         }
 
-        if (this.marcData[this.activeIndex].bcpSelection.length == 0){
+        if (this.marcData[this.activeIndex] && this.marcData[this.activeIndex].bcpSelection.length == 0){
           let currentSelection = this.marcData[this.activeIndex].subfield_7
           let bcpList = currentSelection ? currentSelection.map(i => i.replace('(bcp47)', '')) : []
           for (let [idx, item] of Object.entries(this.bcpCodes)){
@@ -844,6 +843,10 @@
 
         this.activeIndex = idx
         this.buildNewMarcKey()
+      },
+
+      removeAdded670: function(idx){
+        this.source670s.splice(idx, 1)
       },
 
       removeBcpRow: function(row){
@@ -2067,10 +2070,14 @@
 
                   <div class="new-value-container" v-if="source670s.length > 0">
                     <!-- 667 Note: <textarea type=text v v-model='note667' class="eval-note" /> -->
-                    <!-- <template v-for="(code, idx) of source670s"> -->
-                    <template v-for="idx in source670s">
-                      670 Note: <textarea type=text v-model='idx.note' class="eval-note" /><br>
+                    <template v-for="(code, idx) of source670s">
+                      670 Note: <textarea type=text v-model='code.note' class="eval-note" />
+                      <button @click="removeAdded670(idx)" class="material-icons bcp-icon">delete</button><br>
                     </template>
+                    <!-- <template v-for="idx in source670s">
+                      670 Note: <textarea type=text v-model='idx.note' class="eval-note" /><br>
+                      <button @click="remove670(idx)" class="material-icons bcp-icon">delete</button>
+                    </template> -->
                   </div>
 
                 <div class="button-container">

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -567,6 +567,7 @@
       },
 
       previewMarc: async function(){
+        console.info("preview")
         this.submitting = true
         this.showMarcPreview = true
         let prefChecks = this.checkPrefLabels()
@@ -606,14 +607,25 @@
 
         // add the 670 info
         let s670s = this.source670s
-
-        for (let note of s670s){
+        let remove670 = [] // empty 670s to remove
+        for (let idx in s670s){
+          let note = s670s[idx]
           let subfields = note.note.match(/.+?(?=\$[a-z0-9]|$|\n)/g)
-          for (let sub of subfields){
-            let tag = sub.slice(1,2)
-            note[tag] = sub.slice(2)
+          if (subfields){
+            for (let sub of subfields){
+              let tag = sub.slice(1,2)
+              let val = sub.slice(2)
+              if (val != ''){
+                note[tag] = val
+              } else {
+                remove670.push(idx)
+              }
+            }
+          } else {
+            remove670.push(idx)
           }
         }
+        for (let idx of remove670){ s670s.splice(idx, 1) }
         this.marcData['source670s'] = s670s
 
         let results = utilsExport.adjustAuthRecord(this.xmlDoc, this.marcData, this.xmlTargets)

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -219,13 +219,14 @@
       showBCPButton: function(key, data){
         let show = false
 
-        if (data.variantLabels){
-          for(let variant of data.variantLabels){
-            if (!this.isLatin(variant)){
-              show = true
-              break
-            }
-          }
+        if (data.variantLabels && data.variantLabels.length > 0){
+          show = true
+          // for(let variant of data.variantLabels){
+          //   if (!this.isLatin(variant)){
+          //     show = true
+          //     break
+          //   }
+          // }
         }
         if (data.varianttitles){
           for(let variant of data.varianttitles){
@@ -486,6 +487,11 @@
             }
           }
         }
+
+        if (Object.keys(this.marcData).length == 0){
+          this.addBcpRow()
+        }
+
 
         this.activeIndex = false
         // swap out left panel for form
@@ -765,11 +771,13 @@
         let lastItem = Object.keys(this.marcData).at(-1)
         // Index for new fields will start with ##
         let newIdx = false
-        if (!lastItem.startsWith("##")){
+        if (lastItem && !lastItem.startsWith("##")){
           newIdx = "##" + (Number(lastItem) + 1)
-        } else {
+        } else if (lastItem && lastItem.startsWith("##")){
           let temp = lastItem.replace("##", "")
           newIdx = "##" + (Number(temp) + 1)
+        } else {
+          newIdx = "##" + 1
         }
 
         this.source670s.push({'note': '$a'})
@@ -2283,6 +2291,9 @@
                                   <li class="modal-context-data-li" v-else v-bind:key="'var' + key">{{ activeContext.extra[key] }}</li>
                                 </ul>
                               </template>
+                            </template>
+                            <template v-if="!Object.keys(activeContext.extra).includes('variantLabels')">
+                              <button @click="edit4XX(activeContext)">Add 4XX</button>
                             </template>
                           </AccordionItem>
                         </AccordionList>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -343,7 +343,6 @@
           let lastMod = data.extra.lastmods[0]
           let earlier = new Date(lastMod) < new Date("2026-08-07");
           this.syncNar = earlier
-          console.info("sync earlier: ", lastMod, "--", earlier)
         }
 
         // if the record is less than 10 miuntes old in FOLIO, resync
@@ -357,7 +356,6 @@
           if (!this.syncNar && minutes && minutes <= 10){
             this.syncNar = true
           }
-          console.info("sync <= 10 minutes: ", minutes <= 10, "--", minutes)
         } catch(err) {
           console.error("Error checking diff: ", err)
         }
@@ -2318,6 +2316,9 @@
                             </template>
                             <template v-if="!Object.keys(activeContext.extra).includes('variantLabels')">
                               <button @click="edit4XX(activeContext)">Add 4XX</button>
+                              <template v-if="this.syncNar">
+                                Syncing <span class="syncing"><span>&nbsp;</span> <span>&nbsp;</span> <span>&nbsp;</span> </span>
+                              </template>
                             </template>
                           </AccordionItem>
                         </AccordionList>
@@ -2957,7 +2958,7 @@ input.prefCheck[type=checkbox]:checked+label {
 
 /* https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://codepen.io/itsmanojb/pen/xQpZbR&ved=2ahUKEwjqgeuKx5uWAxVaL1kFHSntE-QQFnoECBoQAQ&usg=AOvVaw1WE0klQuyvFRvuUTtGjyou */
 .syncing {
-  position: absolute;
+  position: relative;
   top: 10px;
   margin-right: 2px;
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2927,16 +2927,19 @@ const utilsExport = {
 			note670.setAttribute('tag', '670')
 			note670.setAttribute('ind1', " ")
 			note670.setAttribute('ind2', " ")
-			for (let sub of Object.keys(item)) {
-				if (sub != 'note') {
-					let subfield = document.createElementNS('http://www.loc.gov/MARC21/slim', 'marcxml:subfield');
-					subfield.setAttribute("code", sub)
-					subfield.innerHTML = item[sub].trim()
-					note670.appendChild(subfield)
+			console.info("item: ", item)
+			if (Object.keys(item).length > 0){
+				for (let sub of Object.keys(item)) {
+					if (sub != 'note') {
+						let subfield = document.createElementNS('http://www.loc.gov/MARC21/slim', 'marcxml:subfield');
+						subfield.setAttribute("code", sub)
+						subfield.innerHTML = item[sub].trim()
+						note670.appendChild(subfield)
+					}
 				}
+				marc670List = record.querySelectorAll('[tag="667"]')
+				record.appendChild(note670)
 			}
-			marc670List = record.querySelectorAll('[tag="667"]')
-			record.appendChild(note670)
 		}
 
 		// 040 if the last $d is DLC, don't add another one

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2927,7 +2927,6 @@ const utilsExport = {
 			note670.setAttribute('tag', '670')
 			note670.setAttribute('ind1', " ")
 			note670.setAttribute('ind2', " ")
-			console.info("item: ", item)
 			if (Object.keys(item).length > 0){
 				for (let sub of Object.keys(item)) {
 					if (sub != 'note') {


### PR DESCRIPTION
Updated:
- Show the edit button when there are any variants
  - If there are no variants, the button will be under "Extra Details"
- `670` notes are not mandatory
  - There's a `delete` button next to the input
  - If the input is empty or only a `$a` 
- Show when the record is syncing with FOLIO