### PR TITLE
NAR Modal Updates

### DIFF
--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -2032,7 +2032,7 @@
 
 
     async mounted() {
-      this.initalHeight = window.innerHeight * .8
+      this.initalHeight = window.innerHeight * .9
       this.init()
 
     }

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -26,7 +26,7 @@
         top: 200,
         left: 0,
 
-        initalHeight: 750,
+        initalHeight: 800,
         initalLeft: 400,
 
 
@@ -2032,8 +2032,9 @@
 
 
     async mounted() {
-
+      this.initalHeight = window.innerHeight * .8
       this.init()
+      console.info("height: ", window.innerHeight)
 
 
 
@@ -2130,7 +2131,7 @@
               </div>
 
               <div style="display: flex; margin-bottom: 1em;">
-                <div style="flex: 1;">
+                <div style="flex: 1 3;">
                   <select @change="presetChange" class="preset-select">
                     <option class="preset-option" value="home">Presets</option>
                     <option class="preset-option" value="1000#">"1000 "</option>
@@ -2152,7 +2153,7 @@
 
                   </select>
                 </div>
-                <div style="flex: 1;">
+                <div style="flex: 1 3;">
                   <select @change="transliterateChange">
                     <option value="home">Transliterate</option>
                     <option value="home2" v-if="transliterateOptions().length == 0">You have no Scriptshifter languages set. Use Preferences->Scriptshifter</option>
@@ -2161,8 +2162,8 @@
                     </template>
                   </select>
                 </div>
-
-                <div>
+              </div>
+              <div>
                   Set BCP
                   <select @change="setBcp" v-model="selectedBcp">
                     <template v-for="(value, key) in langs">
@@ -2171,10 +2172,6 @@
                     <option value="expand">Expand</option>
                   </select>
                 </div>
-
-
-              </div>
-
 
 
 

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -2034,10 +2034,6 @@
     async mounted() {
       this.initalHeight = window.innerHeight * .8
       this.init()
-      console.info("height: ", window.innerHeight)
-
-
-
 
     }
 

--- a/src/views/CopyCat.vue
+++ b/src/views/CopyCat.vue
@@ -794,6 +794,8 @@ export default {
 
       let strXmlBasic = (new XMLSerializer()).serializeToString(xml.documentElement)
 
+      console.info("strXmlBasic: ", strXmlBasic)
+
       this.posting = true
       this.postResults = {}
 
@@ -830,6 +832,8 @@ export default {
       }
       this.existingLCCN = false
       this.existingISBN = false
+
+      console.info("url: ", this.urlToLoad)
 
       try {
         this.loadUrl(profile)


### PR DESCRIPTION
- The modal will start out 80% of the window height
- The `transliteration` dropdown can be really wide, might be do to the value in the dropdowns, it could cause the `BCP` selection to be off the screen