### PR TITLE
`expand` works even when it's already selected.

### DIFF
--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -2165,7 +2165,7 @@
                     <template v-for="(value, key) in langs">
                       <option :value="key">{{ key }}</option>
                     </template>
-                    <option value="expand">Expand</option>
+                    <option value="expand" @click="setBcp">Expand</option>
                   </select>
                 </div>
 


### PR DESCRIPTION
For cases when `expand` is the only option