### PR TITLE
Ignore rdaregistry for illustrativeContent

### DIFF
--- a/src/lib/utils_parse.js
+++ b/src/lib/utils_parse.js
@@ -832,6 +832,9 @@ const utilsParse = {
             // console.log(e.innerHTML)
             // console.log((new XMLSerializer()).serializeToString(e))
 
+            // ignore illustrativeContent from rdaregistry
+            if (e?.tagName == "bf:illustrativeContent" && e.getAttribute('rdf:resource')?.includes('rdaregistry')){ continue }
+
             // some special checks here first
             // differentiate between creator and contributor
             if (ptk.propertyURI == 'http://id.loc.gov/ontologies/bibframe/contribution'){


### PR DESCRIPTION
Throws a warning because the BF is an empty tag.

`<bf:illustrativeContent rdf:resource="http://rdaregistry.info/termList/IllusContent/1014" />`