### PR TITLE
BCP Lang Only Option, Consider entire heading

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -418,7 +418,7 @@
         let vars = this.xmlDoc.querySelectorAll('[tag="' + targetTag +'"]')
         for (let varIdx in Array.from(vars)){
           let variant = Array.from(vars[varIdx].children).map((item) => {
-            if(data.type != 'Hub' && item.getAttribute('code') == 'a'){
+            if(data.type != 'Hub' ){ //&& ['a', 'b'].includes(item.getAttribute('code'))
               return item.textContent
             } else if (data.type == 'Hub' && ['a', 't'].includes(item.getAttribute('code'))){
               return item.textContent

--- a/src/components/panels/edit/modals/NacoStubCreateModal.vue
+++ b/src/components/panels/edit/modals/NacoStubCreateModal.vue
@@ -1613,12 +1613,24 @@
           let nonLatin = this.profileStore.returnAllNonLatinLiterals()
           for (let item of nonLatin){
             let lang = item.lang
-            if (Object.keys(this.langs).includes(lang)){
+            if (lang.includes("zxx")){ continue }
+
+            if (lang.includes("-")){
+              let l = lang.split("-")[0]
+              if ( l in this.langs ){
+                this.langs[l] += 1
+              } else {
+                this.langs[l] = 2
+              }
+            }
+
+            if (lang in this.langs){
               this.langs[lang] = this.langs[lang] + 1
             } else {
               this.langs[lang] = 1
             }
           }
+
           if (Object.keys(this.langs).length > 0){
             this.selectedBcp = Object.keys(this.langs).reduce((a,b) => this.langs[a] > this.langs[b] ? a : b)
           }


### PR DESCRIPTION
NAR creation:
- Provide language only option when generating selection from bib record. So "ko-kore" tags will have the options: "ko" and "ko-kore"
- Don't provide options that have `zxx`

NAR edition:
- consider the entire heading, was only looking at `$a`