### PR TITLE
Sort subfield when making adjustments, Fix handleInput()

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -378,7 +378,6 @@
           this.authLccn = authId
           marcXML = await this.fetchAuthXML(authId)
         }
-
         let parser = new DOMParser()
         this.xmlDoc = parser.parseFromString(marcXML, "text/xml")
         this.originalMarc = this.xmlDoc.cloneNode(true)
@@ -452,7 +451,6 @@
 
             for (let sub of targetNameXML.children){
               let subfield = sub.getAttribute("code")
-              console.info("subfield: ", subfield)
               let value = sub.innerHTML
               // localMarc.indicators = sub
 
@@ -480,9 +478,7 @@
               }
             }
             localMarc.idx = varIdx
-
             this.marcData[varIdx] = localMarc
-
             this.activeIndex = varIdx
             this.buildNewMarcKey()
 

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -378,6 +378,9 @@
           this.authLccn = authId
           marcXML = await this.fetchAuthXML(authId)
         }
+
+        console.info("marcXML: ", marcXML)
+
         let parser = new DOMParser()
         this.xmlDoc = parser.parseFromString(marcXML, "text/xml")
         this.originalMarc = this.xmlDoc.cloneNode(true)
@@ -451,6 +454,7 @@
 
             for (let sub of targetNameXML.children){
               let subfield = sub.getAttribute("code")
+              console.info("subfield: ", subfield)
               let value = sub.innerHTML
               // localMarc.indicators = sub
 
@@ -478,7 +482,23 @@
               }
             }
             localMarc.idx = varIdx
+
+            // --------------------------------------------------------
+            let keyOrder = Object.keys(localMarc).sort((a, b) => /^[0-9]/.test(a.replace("subfield_", "")) - /^[0-9]/.test(b.replace("subfield_", "")) || a.replace("subfield_", "").localeCompare(b.replace("subfield_", ""), undefined, { numeric: true }))
+            console.info("keyOrder: ", keyOrder)
+            let newObj = Object.fromEntries(
+                                      keyOrder.map(key => [key, key])//[key, localMarc[key]])
+                                    ); // sort by subfield
+            console.info("newObj: ", newObj)
+            // [ "tag", "indicators", "bcpSelection", "script", "subfield_7", "subfield_a", "subfield_c", "displayName", "idx" ]
+            this.marcData[varIdx] = null
+            this.marcData[varIdx] = newObj
+            console.info("this.marcData[varIdx]: ", JSON.parse(JSON.stringify(this.marcData[varIdx])))
+            // --------------------------------------------------------
+
+
             this.marcData[varIdx] = localMarc
+
             this.activeIndex = varIdx
             this.buildNewMarcKey()
 
@@ -581,6 +601,7 @@
       },
 
       previewMarc: async function(){
+        console.info("\nPREVIEW")
         this.submitting = true
         this.showMarcPreview = true
         let prefChecks = this.checkPrefLabels()
@@ -640,6 +661,8 @@
         }
         for (let idx of remove670){ s670s.splice(idx, 1) }
         this.marcData['source670s'] = s670s
+
+        console.info("\t updates: ", this.marcData)
 
         let results = utilsExport.adjustAuthRecord(this.xmlDoc, this.marcData, this.xmlTargets)
         this.updatedRecord = results[0]
@@ -726,7 +749,6 @@
           'newRow': this.marcData[this.activeIndex].newRow,
           'scripts': this.marcData[this.activeIndex].scripts ? this.marcData[this.activeIndex].scripts : [],
         }
-
 
         let key = ''
         let marcKey = this.marcData[this.activeIndex].tag + this.marcData[this.activeIndex].indicators
@@ -899,7 +921,11 @@
         this.buildNewMarcKey()
 
         window.setTimeout(async ()=>{
-          el.setSelectionRange(startPos+1, startPos+1)
+          if (event.inputType == "deleteContentBackward" ){
+            el.setSelectionRange(startPos-1, startPos-1)
+          } else {
+            el.setSelectionRange(startPos+1, startPos+1)
+          }
           this.getBcpSuggestions()
         }, 1)
       },

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -379,8 +379,6 @@
           marcXML = await this.fetchAuthXML(authId)
         }
 
-        console.info("marcXML: ", marcXML)
-
         let parser = new DOMParser()
         this.xmlDoc = parser.parseFromString(marcXML, "text/xml")
         this.originalMarc = this.xmlDoc.cloneNode(true)
@@ -482,20 +480,6 @@
               }
             }
             localMarc.idx = varIdx
-
-            // --------------------------------------------------------
-            let keyOrder = Object.keys(localMarc).sort((a, b) => /^[0-9]/.test(a.replace("subfield_", "")) - /^[0-9]/.test(b.replace("subfield_", "")) || a.replace("subfield_", "").localeCompare(b.replace("subfield_", ""), undefined, { numeric: true }))
-            console.info("keyOrder: ", keyOrder)
-            let newObj = Object.fromEntries(
-                                      keyOrder.map(key => [key, key])//[key, localMarc[key]])
-                                    ); // sort by subfield
-            console.info("newObj: ", newObj)
-            // [ "tag", "indicators", "bcpSelection", "script", "subfield_7", "subfield_a", "subfield_c", "displayName", "idx" ]
-            this.marcData[varIdx] = null
-            this.marcData[varIdx] = newObj
-            console.info("this.marcData[varIdx]: ", JSON.parse(JSON.stringify(this.marcData[varIdx])))
-            // --------------------------------------------------------
-
 
             this.marcData[varIdx] = localMarc
 
@@ -601,7 +585,6 @@
       },
 
       previewMarc: async function(){
-        console.info("\nPREVIEW")
         this.submitting = true
         this.showMarcPreview = true
         let prefChecks = this.checkPrefLabels()
@@ -661,8 +644,6 @@
         }
         for (let idx of remove670){ s670s.splice(idx, 1) }
         this.marcData['source670s'] = s670s
-
-        console.info("\t updates: ", this.marcData)
 
         let results = utilsExport.adjustAuthRecord(this.xmlDoc, this.marcData, this.xmlTargets)
         this.updatedRecord = results[0]

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -590,6 +590,8 @@
         const marcXML = this.xmlDoc
         let updates = this.marcData
 
+        console.info("updates: ", updates)
+
         let numEval = 0
         let totalVars = 0
         for (let key of Object.keys(updates)){
@@ -641,6 +643,7 @@
         for (let idx of remove670){ s670s.splice(idx, 1) }
         this.marcData['source670s'] = s670s
 
+        console.info("targets: ", this.xmlTargets)
         let results = utilsExport.adjustAuthRecord(this.xmlDoc, this.marcData, this.xmlTargets)
         this.updatedRecord = results[0]
         let parsedRecord = results[1]

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2956,7 +2956,6 @@ const utilsExport = {
 		let langEval = []
 		let langUneval = []
 		for (let target of targets) {
-
 			let targetNameXML = record.querySelectorAll('[tag="' + target[0] + '"]')[target[1]]
 			let index = [].indexOf.call(record.children, targetNameXML)
 

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2956,8 +2956,14 @@ const utilsExport = {
 		let langEval = []
 		let langUneval = []
 		for (let target of targets) {
+
 			let targetNameXML = record.querySelectorAll('[tag="' + target[0] + '"]')[target[1]]
 			let index = [].indexOf.call(record.children, targetNameXML)
+
+			// sort the subfields in alpha - numeric
+			let sorted = Array.from(targetNameXML.children).sort((a,b) => /^[0-9]/.test(a.getAttribute('code')) - /^[0-9]/.test(b.getAttribute('code')) || a.getAttribute('code').localeCompare(b.getAttribute('code'), undefined, { numeric: true }))
+			targetNameXML.innerHTML = '';
+			sorted.forEach(child => targetNameXML.appendChild(child))
 
 			if (!targetNameXML) {
 				targetNameXML = { 'children': [] }

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2960,9 +2960,13 @@ const utilsExport = {
 			let index = [].indexOf.call(record.children, targetNameXML)
 
 			// sort the subfields in alpha - numeric
-			let sorted = Array.from(targetNameXML.children).sort((a,b) => /^[0-9]/.test(a.getAttribute('code')) - /^[0-9]/.test(b.getAttribute('code')) || a.getAttribute('code').localeCompare(b.getAttribute('code'), undefined, { numeric: true }))
-			targetNameXML.innerHTML = '';
-			sorted.forEach(child => targetNameXML.appendChild(child))
+			try {
+				let sorted = Array.from(targetNameXML.children).sort((a,b) => /^[0-9]/.test(a.getAttribute('code')) - /^[0-9]/.test(b.getAttribute('code')) || a.getAttribute('code').localeCompare(b.getAttribute('code'), undefined, { numeric: true }))
+				targetNameXML.innerHTML = '';
+				sorted.forEach(child => targetNameXML.appendChild(child))
+			} catch(err){
+				console.error("Couldn't sort children of ", targetNameXML)
+			}
 
 			if (!targetNameXML) {
 				targetNameXML = { 'children': [] }
@@ -2972,6 +2976,7 @@ const utilsExport = {
 					index = [].indexOf.call(record.children, targetNameXML)
 				}
 			}
+
 
 			// Get the existing subfields
 			let existingCodes = {}

--- a/src/stores/__tests__/profiles.test.js
+++ b/src/stores/__tests__/profiles.test.js
@@ -151,14 +151,14 @@ describe('methods', () => {
       let marcXML = twainXml
       let parser = new DOMParser()
       marcXML = parser.parseFromString(marcXML, "text/xml")
-      const updates = {"13": {"tag":"400","indicators":"11","bcpSelection":[0],"marcKey":"40011$aטבןַ, מרק,(bcp47)he","displayName":"$aטבןַ, מרק,","delete":false,"subfield_a":"טבןַ, מרק,","subfield_7":["(bcp47)he"]},"refEval":false, "source670s":[]}
-      const target = [["400",13,"טבןַ, מרק,"]]
+      const updates = {"20": {"tag":"400","indicators":"11","bcpSelection":[0],"marcKey":"undefined","displayName":"$a트웨인, 마크","delete":false,"subfield_a":"트웨인, 마크","subfield_7":["(bcp47)ko"]},"refEval":false, "source670s":[]}
+      const target = [["400", 20,"트웨인, 마크"]]
       let update = await utilsExport.adjustAuthRecord(marcXML, updates, target)[0]
       update = new XMLSerializer().serializeToString(update)
       update = update.replace(/[\n\r\s\s]+/g, ' ')
 
       expect(update).toContain('<marcxml:datafield tag="400" ind1="1" ind2="1">')
-      expect(update).toContain('<marcxml:subfield code="a">טבןַ, מרק,</marcxml:subfield> <marcxml:subfield code="7">(bcp47)he</marcxml:subfield>')
+      expect(update).toContain('<marcxml:subfield code="a">트웨인, 마크</marcxml:subfield><marcxml:subfield code="7">(bcp47)ko</marcxml:subfield>')
     });
 
     it('Update NAR DELETE 4XX', async () => {


### PR DESCRIPTION
Marva honored the order of subfields from the source, but if those are wrong or in an undesirable order it would be maintained. Now for 4XX fields, and maybe 670s, the subfields will be forced into alpha order, then numbers.

`handleInput()` would jump forward when deleting characters instead of going back