### PR TITLE
Name Details BCP Info 🗣️ 

### DIFF
--- a/src/components/panels/edit/fields/helpers/BcpIndicator.vue
+++ b/src/components/panels/edit/fields/helpers/BcpIndicator.vue
@@ -1,0 +1,75 @@
+<template>
+    <span :data-tooltip="useLabel" class="simptip-position-right" v-for="icon in useIcon">
+        <span :class="['material-icons-outlined', icon, 'bcp-icon', {'pref': isPreferred, 'notPref': !isPreferred, 'und': isUnd}]"> ({{ icon }})</span>
+    </span>
+</template>
+
+<script>
+
+
+export default {
+    name: "BcpIndicator",
+    components: {
+    },
+
+    props: {
+        data: Object,
+    },
+
+    data: function () {
+        return { }
+    },
+
+    created: function () {},
+
+    computed: {
+
+        useLabel() {
+            if (this.data.code) return this.data.code
+        },
+
+
+        useIcon() {
+            const preferred = ['translate']
+            const notPref = ['translate']
+
+            if (this.data.code){
+                if (this.data.pref) return preferred
+                else return notPref
+            }
+            return []
+        },
+
+        isPreferred(){
+            return this.data.pref
+        },
+
+        isUnd(){
+            return this.data.code.includes('und')
+        },
+    },
+
+    methods: {}
+
+};
+
+</script>
+
+<style scoped>
+.bcp-icon {
+    font-size: .9em
+}
+
+.pref {
+    color: green;
+}
+
+.notPref {
+    color: gray;
+}
+
+.und {
+    color: red;
+}
+
+</style>

--- a/src/components/panels/edit/fields/helpers/BcpIndicator.vue
+++ b/src/components/panels/edit/fields/helpers/BcpIndicator.vue
@@ -30,8 +30,9 @@ export default {
 
 
         useIcon() {
-            const preferred = ['translate']
-            const notPref = ['translate']
+            const preferred = ['🗣️']
+            const notPref = ['🗣️']
+            // 🗣️translate
 
             if (this.data.code){
                 if (this.data.pref) return preferred
@@ -57,19 +58,25 @@ export default {
 
 <style scoped>
 .bcp-icon {
-    font-size: .9em
+    font-size: 1.2em
 }
 
 .pref {
-    color: green;
+    /* color: green; */
+    color: transparent;
+    text-shadow: 0 0 0 green;
 }
 
 .notPref {
-    color: gray;
+    /* color: gray; */
+    color: transparent;
+    text-shadow: 0 0 0 gray;
 }
 
 .und {
-    color: red;
+    /* color: red; */
+    color: transparent;
+    text-shadow: 0 0 0 red;
 }
 
 </style>

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -337,33 +337,18 @@
       },
 
       checkHasBcp: function(val, data, key){
-        console.info("checkHasBcp")
-        console.info("\t val: ", val)
-        console.info("\t data: ", data)
-        console.info("\t key: ", key)
-
         let bcp = false
         let pref = false
         if (key == 'variantLabels'){
-          console.info("data: ", data)
           if (data.extra.vernacularMarcKeys){
             for (let k of data.extra.vernacularMarcKeys){
-
-              console.info("\t\t k: ", k.replace(/\$[a-z0-9]/g, ' '))
-              console.info("\t\t\t val: ", val)
-
               let parts = k.match(/.+?(?=\$[a-z0-9]|$|\n)/g)
               let subA = parts.filter(p => p.includes('$a'))[0].slice(2)
               if (subA.endsWith(',')){
                 subA = subA.slice(0, -1)
               }
-
-              console.info("\t\t\t parts: ", parts)
-              console.info("\t\t\t subA: ", subA)
-
               // if (k.includes(val)){
               if (val.includes(subA)){
-                console.info("k: ", k)
                 let hasBcp = k.includes('bcp47')
                 if (hasBcp){
                   bcp = parts.filter(i => i.includes('bcp'))[0].split('(bcp47)')[1]
@@ -663,8 +648,6 @@
         const marcXML = this.xmlDoc
         let updates = this.marcData
 
-        console.info("updates: ", updates)
-
         let numEval = 0
         let totalVars = 0
         for (let key of Object.keys(updates)){
@@ -715,8 +698,6 @@
         }
         for (let idx of remove670){ s670s.splice(idx, 1) }
         this.marcData['source670s'] = s670s
-
-        console.info("targets: ", this.xmlTargets)
         let results = utilsExport.adjustAuthRecord(this.xmlDoc, this.marcData, this.xmlTargets)
         this.updatedRecord = results[0]
         let parsedRecord = results[1]

--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -10,6 +10,7 @@
   import { VueFinalModal } from 'vue-final-modal'
 
   import AuthTypeIcon from "@/components/panels/edit/fields/helpers/AuthTypeIcon.vue";
+  import BcpIndicator from "@/components/panels/edit/fields/helpers/BcpIndicator.vue";
   import CopyCat from "@/views/CopyCat.vue"
 
   import isoLangLib from "@/lib/iso_lang.json"
@@ -24,7 +25,8 @@
       VueFinalModal,
       AuthTypeIcon,
       AccordionList,
-      AccordionItem
+      AccordionItem,
+      BcpIndicator,
     },
     props: {
       // structure of the field that owns this modal
@@ -332,6 +334,53 @@
         }
 
         window.open(this.feedbackUrl, '_blank');
+      },
+
+      checkHasBcp: function(val, data, key){
+        console.info("checkHasBcp")
+        console.info("\t val: ", val)
+        console.info("\t data: ", data)
+        console.info("\t key: ", key)
+
+        let bcp = false
+        let pref = false
+        if (key == 'variantLabels'){
+          console.info("data: ", data)
+          if (data.extra.vernacularMarcKeys){
+            for (let k of data.extra.vernacularMarcKeys){
+
+              console.info("\t\t k: ", k.replace(/\$[a-z0-9]/g, ' '))
+              console.info("\t\t\t val: ", val)
+
+              let parts = k.match(/.+?(?=\$[a-z0-9]|$|\n)/g)
+              let subA = parts.filter(p => p.includes('$a'))[0].slice(2)
+              if (subA.endsWith(',')){
+                subA = subA.slice(0, -1)
+              }
+
+              console.info("\t\t\t parts: ", parts)
+              console.info("\t\t\t subA: ", subA)
+
+              // if (k.includes(val)){
+              if (val.includes(subA)){
+                console.info("k: ", k)
+                let hasBcp = k.includes('bcp47')
+                if (hasBcp){
+                  bcp = parts.filter(i => i.includes('bcp'))[0].split('(bcp47)')[1]
+                  let tag = k.slice(0,3)
+                  if (tag == '430'){
+                    pref = Array.from(k).at(3) == "1"
+                  } else {
+                    pref = Array.from(k).at(4) == "1"
+                  }
+                  return {'code': bcp, 'pref': pref}
+                }
+              }
+            }
+          }
+        }
+
+        return {'code': false, 'pref': false}
       },
 
       // initial 4XX
@@ -2186,7 +2235,7 @@
                           </div>
                           <ul :class="['details-list', {'note-data': key == 'notes'}]">
                             <li class="modal-context-data-li" v-if="Array.isArray(activeContext.extra[key])" v-for="(v, idx) in activeContext.extra[key] " v-bind:key="'var' + idx">
-                              <span v-if="key !='sees' && key !='relateds'">{{v}}
+                              <span v-if="key !='sees' && key !='relateds'">{{v}}<BcpIndicator :data="checkHasBcp(v, activeContext, key)" />
                               </span>
                               <div v-else-if="key == 'relateds'">
                                 {{v}}<button class="material-icons see-search" @click="searchValueLocal = v">search</button>

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2385,8 +2385,6 @@ const utilsExport = {
 	},
 
 	createNacoStubXML(oneXXParts,fourXXParts,mainTitle,lccn,instanceUri, mainTitleDate, mainTitleLccn, mainTitleNote,zero46,add667,extraMarcStatements,useAdvancedMode){
-		console.info("createNacoStubXML")
-		console.info("\t extraMarcStatements: ", extraMarcStatements)
 		let marcTxt = ''
 		marcTxt = marcTxt + " 111111111122222222223333333333\n"
 		marcTxt = marcTxt + "       0123456789012345678901234567890123456789\n"
@@ -2778,7 +2776,6 @@ const utilsExport = {
 
 		if (extraMarcStatements && extraMarcStatements.length > 0){
 			for (let x of extraMarcStatements){
-				console.info("x: ", x)
 				let hasValue = false
 				if (x.fieldTag && x.fieldTag.trim() != ''){
 					let field = document.createElementNS(marcNamespace,"marcxml:datafield");


### PR DESCRIPTION
Add icons to details panel to surface BCP47 information. It relies on the `vernacularMarcKeys` from suggest2. However, this only includes one marcKey per language/script, the one that has been identified as the source for an 880 added to the record. In cases where multiple variants use the same script, only 1 will have the icon. 

<img width="872" height="62" alt="image" src="https://github.com/user-attachments/assets/63e22b54-9365-4b2e-b44c-0d66fc38eefd" />


More details: https://bibframe.org/docs/view/documentation-marva-manual/Marva%20tools/Edit%20Authority%20Language%20Info.md#bcp-status