### PR TITLE
shortcode alias modal, and LookupSimple.vue mods

### DIFF
--- a/src/components/panels/edit/fields/LookupSimple.vue
+++ b/src/components/panels/edit/fields/LookupSimple.vue
@@ -145,6 +145,10 @@
 
   </template>
     <div v-if="displayAutocomplete==true" ref="selectlist" :class="{'autocomplete-container':true, 'autocomplete-container-camm-mode': returnCAMModeShowAutoComplete}">
+      <div v-if="activeShortcodeAlias" class="shortcode-alias-callout">
+        <span class="material-icons shortcode-alias-callout-icon">bolt</span>
+        Shortcode alias &mdash; [Enter] will add: <strong>{{ activeShortcodeAlias.label }}</strong>
+      </div>
       <ul>
         <li v-for="(item, idx) in displayList" :data-idx="idx" v-bind:key="idx" @click="clickAdd(item)">
             <span v-if="item==activeSelect"  :data-idx="idx" class="selected">{{item}}</span>
@@ -374,6 +378,17 @@ export default {
         }
       }
       return false
+    },
+
+    // if current val matches a shortcode get the {uri,label} and show in the list that a shortcode will be used if they do press eneter now  
+    activeShortcodeAlias(){
+      if (this.preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')){
+        return null
+      }
+      if (!this.activeValue || this.activeValue.trim() == ''){
+        return null
+      }
+      return this.preferenceStore.returnShortcodeAlias(this.uri, this.activeValue)
     },
 
 
@@ -858,6 +873,23 @@ export default {
         }
 
         this.doubleDelete = false
+
+        // check whether what the user typed matches a shortcode alias configured for this
+        // vocabulary — an alias always beats whatever happens to be highlighted in the autocomplete
+        if (!this.preferenceStore.returnValue('--b-edit-main-splitpane-edit-inline-mode')){
+          let shortcodeAlias = this.preferenceStore.returnShortcodeAlias(this.uri, event.target.value)
+          if (shortcodeAlias){
+            this.activePlaceholderText=''
+            this.activeFilter = ''
+            this.activeValue = ''
+            this.activeSelect = ''
+            this.displayAutocomplete=false
+            event.target.value = ''
+            this.profileStore.setValueSimple(this.guid,this.existingGuid,this.propertyPath,shortcodeAlias.uri,shortcodeAlias.label)
+            event.preventDefault()
+            return
+          }
+        }
 
         let metadata = utilsNetwork.lookupLibrary[this.uri].metadata.values
 
@@ -1555,6 +1587,22 @@ export default {
 
 .autocomplete-container-camm-mode{
  display: none;
+}
+
+.shortcode-alias-callout{
+  background-color: lightgoldenrodyellow;
+  color: black;
+  border: solid 1px lightslategray;
+  border-radius: 5px;
+  padding: 0.25em 0.5em;
+  margin-bottom: 0.35em;
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+}
+.shortcode-alias-callout-icon{
+  font-size: 1.25em;
+  padding-right: 0.25em;
 }
 
 .component .lookup-fake-input{

--- a/src/components/panels/edit/fields/helpers/ActionButton.vue
+++ b/src/components/panels/edit/fields/helpers/ActionButton.vue
@@ -20,6 +20,8 @@
 
     <InstanceSelectionModal ref="instanceSelectionModal" :currentRt="currentRt" :instances="instances" v-model="displayInstanceSelectionModal" @hideInstanceSelectionModal="hideInstanceSelectionModal()" @emitSetInstance="setInstance"/>
 
+    <ShortcodeAliasModal v-if="displayShortcodeAliasModal" :structure="structure" v-model="displayShortcodeAliasModal" @hideShortcodeAliasModal="displayShortcodeAliasModal=false"/>
+
     <Teleport to="body">
       <div v-if="showRelWorkIframeModal" class="rel-work-iframe-overlay">
         <div class="rel-work-iframe-container">
@@ -100,6 +102,11 @@
 
         <template v-if="type=='lookupSimple'">
 
+          <button class="" :id="`action-button-command-${fieldGuid}-5`" @click="openShortcodeAliasModal()" :style="buttonStyle">
+            <span class="button-shortcut-label">5</span>
+            Set Shortcode Alias
+          </button>
+          <hr>
 
         </template>
         <template v-if="type=='lookupComplex' || structure.parent.includes(':Identifiers')">
@@ -229,6 +236,7 @@
 
   import AutoDewey from "@/components/panels/edit/modals/AutoDeweyModal.vue";
   import InstanceSelectionModal from "@/components/panels/edit/modals/InstanceSelectionModal.vue";
+  import ShortcodeAliasModal from "@/components/panels/edit/modals/ShortcodeAliasModal.vue";
   import { usePreferenceStore } from '@/stores/preference'
   import { useProfileStore } from '@/stores/profile'
   import { useConfigStore } from '@/stores/config'
@@ -243,6 +251,7 @@
     components: {
     AutoDewey,
     InstanceSelectionModal,
+    ShortcodeAliasModal,
   },
     props: {
       type: String,
@@ -273,6 +282,8 @@
         instances: {},
         targetInstance: null,
         currentRt: null,
+
+        displayShortcodeAliasModal: false,
 
         showRelWorkIframeModal: false,
         relWorkIframeSrc: null,
@@ -352,6 +363,11 @@
       hideInstanceSelectionModal: function(){
         this.instances = {}
         this.displayInstanceSelectionModal = false;
+      },
+
+      openShortcodeAliasModal: function(){
+        this.isMenuShown = false
+        this.displayShortcodeAliasModal = true
       },
       hideDeweyModal:function (){
         this.displayDewey = false

--- a/src/components/panels/edit/modals/ShortcodeAliasModal.vue
+++ b/src/components/panels/edit/modals/ShortcodeAliasModal.vue
@@ -1,0 +1,424 @@
+<script>
+  import { usePreferenceStore } from '@/stores/preference'
+
+  import { mapStores } from 'pinia'
+  import { VueFinalModal } from 'vue-final-modal'
+  import VueDragResize from 'vue3-drag-resize'
+
+  import utilsNetwork from '@/lib/utils_network'
+
+  export default {
+    name: "ShortcodeAliasModal",
+    components: {
+      VueFinalModal,
+      VueDragResize,
+    },
+
+    props: {
+      structure: Object,
+    },
+
+    data() {
+      return {
+        width: 0,
+        height: 0,
+        top: 100,
+        left: 0,
+
+        initalHeight: 600,
+        initalLeft: 400,
+
+        shortcode: '',
+        searchValue: '',
+
+        // which item from the list the shortcode points at {uri,label,display}
+        selectedValue: null,
+
+        lookupItems: [],
+        loading: false,
+        usesSuggest: false,
+        debounceTimeout: null,
+
+        existingAliases: {},
+
+      }
+    },
+    computed: {
+
+      ...mapStores(usePreferenceStore),
+
+      lookupUri(){
+        if (this.structure && this.structure.valueConstraint && this.structure.valueConstraint.useValuesFrom && this.structure.valueConstraint.useValuesFrom[0]){
+          return this.structure.valueConstraint.useValuesFrom[0]
+        }
+        return null
+      },
+
+      filteredItems(){
+        // suggest2 sources get narrowed down server side using the search term, so no client filtering here
+        if (this.usesSuggest){
+          return this.lookupItems
+        }
+        let filter = this.searchValue.toLowerCase().trim()
+        if (filter == ''){
+          return this.lookupItems
+        }
+        return this.lookupItems.filter((item)=>{
+          if (item.display && item.display.toLowerCase().includes(filter)){ return true }
+          if (item.label && item.label.toLowerCase().includes(filter)){ return true }
+          for (let code of item.codes){
+            if (code.toLowerCase().startsWith(filter)){ return true }
+          }
+          return false
+        })
+      },
+
+    },
+
+    methods: {
+
+        dragResize: function(newRect){
+
+          this.width = newRect.width
+          this.height = newRect.height
+          this.top = newRect.top
+          this.left = newRect.left
+
+          this.$refs.shortcodeAliasContent.style.height = newRect.height + 'px'
+
+        },
+
+        onSelectElement (event) {
+          const tagName = event.target.tagName
+
+          if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'SPAN'|| tagName === 'TD' || tagName === 'LI') {
+            event.stopPropagation()
+          }
+        },
+
+        /**
+        * Flatten whatever came back from lookupLibrary into a straightforward list to pick from
+        */
+        buildItemsFromLookup(data){
+          let items = []
+          if (data && data.metadata && data.metadata.values){
+            for (let key of Object.keys(data.metadata.values)){
+              let value = data.metadata.values[key]
+              if (!value || !value.uri){ continue }
+
+              let display = value.displayLabel
+              if (Array.isArray(display)){ display = display[0] }
+              if (display){ display = display.replace(/\s+/g,' ') }
+
+              let authLabel = value.authLabel
+              if (authLabel){ authLabel = authLabel.replace(/\s+/g,' ') }
+
+              items.push({
+                uri: value.uri,
+                display: display,
+                // match the label the field saves when you choose from the autocomplete
+                label: (authLabel) ? authLabel : display,
+                codes: (value.code) ? value.code : []
+              })
+            }
+          }
+          items.sort((a,b)=>{ return (a.display > b.display) ? 1 : -1 })
+          return items
+        },
+
+        async loadLookup(){
+          if (!this.lookupUri){ return false }
+          this.loading = true
+
+          if (this.lookupUri.includes('suggest2')){
+            this.usesSuggest = true
+            let uriParts = this.lookupUri.split("/suggest2?q=")
+            let keyword = (this.searchValue.trim() != '') ? this.searchValue.trim() : uriParts[1]
+            let results = await utilsNetwork.loadSimpleLookupKeyword(uriParts[0], keyword)
+            this.lookupItems = this.buildItemsFromLookup(results)
+          }else{
+            let data = await utilsNetwork.loadSimpleLookup(this.lookupUri)
+            this.lookupItems = this.buildItemsFromLookup(data)
+          }
+
+          this.loading = false
+        },
+
+        searchKeyUp(){
+          // everything else is already in memory — filteredItems does the narrowing client side
+          if (this.usesSuggest){
+            window.clearTimeout(this.debounceTimeout)
+            this.debounceTimeout = window.setTimeout(()=>{
+              this.loadLookup()
+            },500)
+          }
+        },
+
+        selectItem(item){
+          this.selectedValue = item
+        },
+
+        loadExistingAliases(){
+          let allAliases = this.preferenceStore.returnValue('--o-edit-main-lookup-shortcode-aliases')
+          if (allAliases && allAliases[this.lookupUri]){
+            this.existingAliases = JSON.parse(JSON.stringify(allAliases[this.lookupUri]))
+          }else{
+            this.existingAliases = {}
+          }
+        },
+
+        deleteAlias(shortcode){
+          this.preferenceStore.removeShortcodeAlias(this.lookupUri, shortcode)
+          this.loadExistingAliases()
+        },
+
+        save(){
+          let shortcode = this.shortcode.trim()
+          if (shortcode == ''){
+            alert("Type the shortcode to use.")
+            return false
+          }
+          if (!this.selectedValue){
+            alert("Select the value the shortcode should map to.")
+            return false
+          }
+
+          this.preferenceStore.saveShortcodeAlias(this.lookupUri, shortcode, this.selectedValue.uri, this.selectedValue.label)
+          this.closeModal()
+        },
+
+        closeModal(){
+          this.$emit('hideShortcodeAliasModal')
+        },
+
+        focusShortcodeInput(){
+          if (this.$refs.shortcodeInput){
+            this.$refs.shortcodeInput.focus()
+          }
+        },
+
+    },
+
+
+    mounted() {
+
+      this.loadExistingAliases()
+      this.loadLookup()
+
+      // the modal's @opened event is supposed to grab focus; this is a safety net for when it doesn't
+      window.setTimeout(()=>{
+        this.focusShortcodeInput()
+      },250)
+
+    }
+  }
+
+
+
+</script>
+
+<template>
+
+
+    <VueFinalModal
+      display-directive="show"
+      :hide-overlay="false"
+      :overlay-transition="'vfm-fade'"
+      @opened="focusShortcodeInput()"
+
+    >
+        <VueDragResize
+          :is-active="true"
+          :w="650"
+          :h="initalHeight"
+          :x="initalLeft"
+          class="debug-modal"
+          @resizing="dragResize"
+          @dragging="dragResize"
+          :sticks="['br']"
+          :stickSize="22"
+        >
+          <div id="shortcode-alias-content" ref="shortcodeAliasContent" @mousedown="onSelectElement($event)" @touchstart="onSelectElement($event)">
+
+            <div class="menu-buttons">
+              <button class="close-button" @pointerup="closeModal()">X</button>
+            </div>
+
+            <h3>Set Shortcode Alias</h3>
+            <div v-if="structure && structure.propertyLabel" class="field-label">{{ structure.propertyLabel }}</div>
+
+            <div class="shortcode-input-container">
+              <input ref="shortcodeInput" v-model="shortcode" type="text" placeholder="Shortcode (for example: inv)">
+            </div>
+
+            <div class="map-to-label">Map to:</div>
+
+            <div class="search-input-container">
+              <input v-model="searchValue" type="text" placeholder="(type to filter the list)" @keyup="searchKeyUp">
+            </div>
+
+            <div class="lookup-list">
+              <div v-if="loading" class="lookup-list-loading">Loading Data...</div>
+              <ul v-else>
+                <li v-for="item in filteredItems" :key="item.uri" @click="selectItem(item)" :class="{'selected-item': selectedValue && selectedValue.uri == item.uri}">
+                  {{ item.display }}
+                </li>
+              </ul>
+            </div>
+
+            <div class="selected-display" v-if="selectedValue">
+              "{{ shortcode.trim().toLowerCase() }}" will insert: <strong>{{ selectedValue.display }}</strong>
+            </div>
+
+            <div class="save-cancel-buttons">
+              <button @click="save()">Save</button>
+              <button @click="closeModal()">Cancel</button>
+            </div>
+
+            <template v-if="Object.keys(existingAliases).length>0">
+              <hr>
+              <h3>Existing Aliases</h3>
+              <table>
+                <thead>
+                  <th>Shortcode</th>
+                  <th>Maps To</th>
+                  <th></th>
+                </thead>
+                <tbody>
+                  <template v-for="(alias,code) in existingAliases">
+                    <tr>
+                      <td class="table-shortcode">{{ code }}</td>
+                      <td>{{ alias.label }}</td>
+                      <td class="table-delete">
+                        <button @click="deleteAlias(code)"><span class="material-icons">delete</span></button>
+                      </td>
+                    </tr>
+                  </template>
+                </tbody>
+              </table>
+            </template>
+
+          </div>
+
+
+        </VueDragResize>
+    </VueFinalModal>
+
+
+
+
+</template>
+
+<style scoped>
+
+  h3{
+    font-weight: bold;
+  }
+
+  .field-label{
+    color: gray;
+    margin-bottom: 1em;
+  }
+
+  .shortcode-input-container input, .search-input-container input{
+    font-size: 1.25em;
+    width: 95%;
+  }
+
+  .map-to-label{
+    font-weight: bold;
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+  }
+
+  .lookup-list{
+    height: 200px;
+    overflow-y: scroll;
+    border: solid 1px lightgray;
+    margin-top: 0.5em;
+    padding: 0.25em;
+  }
+  .lookup-list-loading{
+    padding: 1em;
+  }
+  .lookup-list li{
+    cursor: pointer;
+    list-style: none;
+    padding: 2px;
+  }
+  .lookup-list li:hover{
+    background-color: aliceblue;
+  }
+  .lookup-list li.selected-item{
+    border:solid 4px lightblue;
+    border-radius: 5px;
+  }
+
+  .selected-display{
+    margin-top: 1em;
+  }
+
+  .save-cancel-buttons{
+    text-align: center;
+    padding: 1em;
+  }
+  .save-cancel-buttons button{
+    font-size: 1.25em;
+    margin: 0 0.5em;
+  }
+
+  table{
+    width: 100%;
+  }
+  th{
+    text-align: left;
+    font-weight: bold;
+  }
+  tr:hover{
+    background-color: aliceblue;
+  }
+  td{
+    border-bottom: solid 1px whitesmoke;
+  }
+  .table-shortcode{
+    font-family: monospace;
+    background-color: whitesmoke;
+    font-size: 1.25em;
+    padding: 2px;
+  }
+  .table-delete{
+    text-align: center;
+  }
+
+  hr{
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+
+  #shortcode-alias-content{
+    padding: 1em;
+    overflow-y: scroll;
+  }
+  .menu-buttons{
+    margin-bottom: 2em;
+    position: relative;
+  }
+  .close-button{
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    background-color: white;
+    border-radius: 5px;
+    border: solid 1px black;
+    cursor: pointer;
+  }
+  .debug-modal{
+    background-color: white;
+    -webkit-box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
+    box-shadow: 0px 10px 13px -7px #000000, 5px 5px 15px 5px rgba(0,0,0,0.27);
+    border-radius: 1em;
+    padding:1em;
+    border: solid 1px black;
+  }
+
+</style>

--- a/src/stores/preference.js
+++ b/src/stores/preference.js
@@ -861,6 +861,20 @@ export const usePreferenceStore = defineStore('preference', {
       group: 'Lookup Field',
       range: [0.75,2]
   },
+  // shortcodes users can set up for quick entry on simple lookups — first keyed by
+  // vocabulary uri, then by the shortcode itself, e.g. {"http://id.loc.gov/vocabulary/mstatus": {"inv": {uri: "...", label: "..."}}}
+  // managed through the action button menu on those fields
+  '--o-edit-main-lookup-shortcode-aliases' : {
+      desc: 'Shortcode aliases for simple lookup fields.',
+      descShort: 'Lookup Shortcode Aliases',
+      value: {},
+      step: null,
+      type: 'object',
+      unit: null,
+      group: 'Lookup Field',
+      hide: true,
+      range: null
+  },
 
 
 
@@ -2237,6 +2251,55 @@ export const usePreferenceStore = defineStore('preference', {
     loadOrder: function(){
       let currentOrder = this.returnValue('--l-custom-order')
       return currentOrder
+    },
+
+    /**
+    * Looks up what a given shortcode expands to within a simple lookup vocabulary
+    * @param {string} lookupUri - uri of the vocabulary in play (the useValuesFrom value)
+    * @param {string} shortcode - whatever shortcode the user entered
+    * @return {object|null} - {uri,label} the alias points at, or null when none exists
+    */
+    returnShortcodeAlias: function(lookupUri, shortcode){
+      if (!lookupUri || !shortcode){ return null }
+      let aliases = this.returnValue('--o-edit-main-lookup-shortcode-aliases')
+      shortcode = shortcode.toLowerCase().trim()
+      if (aliases && aliases[lookupUri] && aliases[lookupUri][shortcode]){
+        return aliases[lookupUri][shortcode]
+      }
+      return null
+    },
+
+    /**
+    * Saves an alias tying a shortcode to a value in a simple lookup vocabulary
+    * @param {string} lookupUri - uri of the vocabulary in play (the useValuesFrom value)
+    * @param {string} shortcode - the shortcut to type into the field
+    * @param {string} uri - uri of the vocab value the shortcode resolves to
+    * @param {string} label - label of the vocab value the shortcode resolves to
+    * @return {void}
+    */
+    saveShortcodeAlias: function(lookupUri, shortcode, uri, label){
+      let aliases = this.returnValue('--o-edit-main-lookup-shortcode-aliases')
+      if (!aliases || typeof aliases != 'object' || Array.isArray(aliases)){ aliases = {} }
+      if (!aliases[lookupUri]){ aliases[lookupUri] = {} }
+      aliases[lookupUri][shortcode.toLowerCase().trim()] = {uri: uri, label: label}
+      this.setValue('--o-edit-main-lookup-shortcode-aliases', aliases)
+    },
+
+    /**
+    * Drops a shortcode alias from a simple lookup vocabulary
+    * @param {string} lookupUri - uri of the vocabulary in play (the useValuesFrom value)
+    * @param {string} shortcode - the shortcode being deleted
+    * @return {void}
+    */
+    removeShortcodeAlias: function(lookupUri, shortcode){
+      let aliases = this.returnValue('--o-edit-main-lookup-shortcode-aliases')
+      if (aliases && aliases[lookupUri] && aliases[lookupUri][shortcode]){
+        delete aliases[lookupUri][shortcode]
+        if (Object.keys(aliases[lookupUri]).length==0){
+          delete aliases[lookupUri]
+        }
+        this.setValue('--o-edit-main-lookup-shortcode-aliases', aliases)
+      }
     },
 
     deleteLayout: function(target){


### PR DESCRIPTION
A new feature that lets the user bind a literal value to a simplelookup list value allowing them to enter a short code into the field hit enter and it will select their desired mapped value. Allows to setup more expected code in simple lookup than using what is the default code values.

Documentation: https://bibframe.org/docs/view/documentation-marva-manual/Configuration/shortcodealias.md

<img width="709" height="656" alt="image" src="https://github.com/user-attachments/assets/0fed546e-b374-44ce-a227-f5bc0af4ea3b" />
