### PR TITLE
Stricter match for removing

### DIFF
--- a/src/components/panels/edit/modals/ComplexLookupModal.vue
+++ b/src/components/panels/edit/modals/ComplexLookupModal.vue
@@ -742,7 +742,7 @@
         }
         this.validating = false
         this.validationErrors = false
-        if (this.validationResult.validation.some(item => item.level == 'ERROR')){
+        if (this.validationResult.validation && this.validationResult.validation.some(item => item.level == 'ERROR')){
           this.validationErrors = true
           this.validationResult.validation = this.validationResult.validation.filter(item => item.level == 'ERROR')
         }

--- a/src/lib/utils_export.js
+++ b/src/lib/utils_export.js
@@ -2872,7 +2872,7 @@ const utilsExport = {
 		// remove
 		let target667s = []
 		for (let sixSixSeven of marc667List) {
-			if (/>non-latin script reference[s ]{1}/gi.test(sixSixSeven.innerHTML)) {
+			if (/>non-latin script reference[s]? not evaluated/gi.test(sixSixSeven.innerHTML)) {
 				target667s.push(sixSixSeven)
 			} else if (sixSixSeven.innerHTML.includes('Non-Latin script variants with (bcp47) in subfield 7')) {
 				target667s.push(sixSixSeven)


### PR DESCRIPTION
Was removing notes that should have remained. Should only match on `non-latin script references not evaluated`

`Non-Latin script references reviewed in NACO CJK` was being removed.