### PR TITLE
Expand FOLIO Sync

### DIFF
--- a/src/components/panels/nav/FolioSyncModal.vue
+++ b/src/components/panels/nav/FolioSyncModal.vue
@@ -147,7 +147,7 @@
         let marc = await utilsNetwork.fetchAuthMarc(lccn, false)
         console.info(lccn, ": ", marc)
 
-        let results = false //await this.postNacoStub(marc, lccn, true)
+        let results = await this.postNacoStub(marc, lccn, true)
 
         if (!results) return
 
@@ -172,6 +172,19 @@
         return 'folio-newer-same'
       },
     },
+
+    mounted(){
+      let lccn = window.location.search.split('=')[1]
+      if (!lccn){ return }
+      console.info("lccn: ", lccn)
+      // authLccn
+      console.info("mounted: ", lccn)
+      if (lccn.startsWith('n')){
+        this.authLccn = lccn
+      } else {
+        this.bibLccn = lccn
+      }
+    }
   }
 </script>
 

--- a/src/components/panels/nav/FolioSyncModal.vue
+++ b/src/components/panels/nav/FolioSyncModal.vue
@@ -1,9 +1,12 @@
 <script>
   import { useProfileStore } from '@/stores/profile'
+  import { usePreferenceStore } from '@/stores/preference'
   import { useConfigStore } from '@/stores/config'
   import { mapStores, mapWritableState } from 'pinia'
   import { VueFinalModal } from 'vue-final-modal'
   import VueDragResize from 'vue3-drag-resize'
+
+  import utilsNetwork from '@/lib/utils_network';
 
   export default {
     components: {
@@ -26,12 +29,15 @@
         result: null,
         bibSyncConfirm: false,
         authSyncConfirm: false,
+        pushNarConfirm: false,
       }
     },
 
     computed: {
-      ...mapStores(useProfileStore, useConfigStore),
-      ...mapWritableState(useProfileStore, ['showFolioSyncModal']),
+      ...mapStores(useProfileStore, useConfigStore, usePreferenceStore),
+
+      ...mapWritableState(useProfileStore, ['showFolioSyncModal', 'postNacoStub']),
+      ...mapWritableState(usePreferenceStore, ['featureFlags']),
 
       env() {
         return this.configStore.returnUrls.env === 'production' ? 'production' : 'staging'
@@ -85,6 +91,7 @@
         this.result = null
         this.bibSyncConfirm = false
         this.authSyncConfirm = false
+        this.pushNarConfirm = false
 
         let params = new URLSearchParams()
         if (bib) params.set('bibLccn', bib)
@@ -132,6 +139,31 @@
         let lccn = this.result.authority.lccn
         window.open(`http://c2vlpndmsojump01.loc.gov/foliar/api/fetch_and_load/name?lccn=${encodeURIComponent(lccn)}&serialization=json`, '_blank')
         this.authSyncConfirm = false
+      },
+
+      async pushNar() {
+        let lccn = this.authLccn.trim()
+        // get the MARC
+        let marc = await utilsNetwork.fetchAuthMarc(lccn, false)
+        console.info(lccn, ": ", marc)
+
+        let results = false //await this.postNacoStub(marc, lccn, true)
+
+        if (!results) return
+
+        if (!results.pubResuts.status){
+          alert("Error posting NAR")
+          console.error("NAR post error: ", results)
+          return
+        }
+
+        if (results.pubResuts.details){
+          let details = JSON.parse(atob(results.pubResuts.details))
+          if (details.status == 'success, but with errors'){
+            alert("NAR added to BFDB, but not sent to FOLIO.")
+            return
+          }
+        }
       },
 
       newerClass(newerIn) {
@@ -261,6 +293,19 @@
                 </div>
               </div>
             </div>
+
+            <!-- Push to FOLIO -->
+            <div class="folio-sync-action" v-if="this.featureFlags.includes('push-nar')">
+              <button v-if="!pushNarConfirm" @click="pushNarConfirm = true" class="folio-force-btn">Push NAR to FOLIO</button>
+              <div v-if="pushNarConfirm" class="folio-confirm">
+                <span>Are you sure you want to send the NAR ID to FOLIO?</span>
+                <div class="folio-confirm-btns">
+                  <button @click="pushNar()" class="folio-yes-btn">Yes</button>
+                  <button @click="pushNarConfirm = false" class="folio-cancel-btn">Cancel</button>
+                </div>
+              </div>
+            </div>
+
           </div>
 
         </div>

--- a/src/components/panels/nav/FolioSyncModal.vue
+++ b/src/components/panels/nav/FolioSyncModal.vue
@@ -174,8 +174,16 @@
     },
 
     mounted(){
-      let lccn = window.location.search.split('=')[1]
+      // http://localhost:5173/marva/?lccn=n81133834 #foliosync
+      // ?lccn=ntest#foliosync
+      console.info("window.location: ", window.location)
+      let search = window.location.search
+      const params = new URLSearchParams(search)
+      console.info("params: ", params)
+
+      let lccn = params.get('lccn').trim()
       if (!lccn){ return }
+
       console.info("lccn: ", lccn)
       // authLccn
       console.info("mounted: ", lccn)

--- a/src/lib/utils_network.js
+++ b/src/lib/utils_network.js
@@ -3295,6 +3295,7 @@ const utilsNetwork = {
     let url = useConfigStore().returnUrls.publishNar
     let uuid = translator.toUUID(translator.new())
 
+    return false
     const rawResponse = await fetch(url, {
       method: 'POST',
       headers: {

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -72,7 +72,7 @@ export const useConfigStore = defineStore('config', {
         copyCatUpload: 'http://localhost:9401/marva/util/copycat/upload/stag',
 
         id: 'https://preprod-8080.id.loc.gov/',
-        env : 'staging',
+        env : 'production',   //staging
         dev: false,
         devFakePosting: true,
         displayLCOnlyFeatures: true,

--- a/src/views/Load.vue
+++ b/src/views/Load.vue
@@ -478,7 +478,7 @@ export default {
     ...mapState(usePreferenceStore, ['styleDefault', 'panelDisplay']),
     ...mapState(useConfigStore, ['testData']),
     ...mapState(useProfileStore, ['startingPoints', 'profiles', 'copyCatMode']),
-    ...mapWritableState(useProfileStore, ['activeProfile', 'emptyComponents', 'activeProfilePosted', 'activeProfilePostedTimestamp', 'copyCatMode', 'showShelfListingModal', 'copyCatSearch']),
+    ...mapWritableState(useProfileStore, ['activeProfile', 'emptyComponents', 'activeProfilePosted', 'activeProfilePostedTimestamp', 'copyCatMode', 'showShelfListingModal', 'copyCatSearch', 'showFolioSyncModal']),
 
 
     // // gives read access to this.count and this.double
@@ -1505,6 +1505,11 @@ export default {
     }
     if (this.$route && this.$route.params && this.$route.params.searchId){
       this.searchMarvaLog(this.$route.params.searchId)
+    }
+
+    if (window.location.hash && window.location.hash =='#foliosync'){
+      console.info("show sync: ", window.location)
+      this.showFolioSyncModal = true
     }
   },
 


### PR DESCRIPTION
FOLIO Sync: add ability to push a NAR from Marva to FOLIO using a similar steps as NAR updates.

To the marva home URL adding `?lccn=<LCCN>#foliosync` will cause the FOLIO sync modal to be open when the page loads. If the LCCN starts with an n, it'll populate the Authority input, otherwise it'll populate the bib input.

Will not currently work because `publishNar()` will return `false`.